### PR TITLE
add codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*   @flatland-association/core


### PR DESCRIPTION
This restricts approving PRs (that change any file) to members of the core team. On top, it automatically notifies them when a new PR is opened.