### PR TITLE
update pyglet to latest

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -483,7 +483,7 @@ pycparser==2.21
     # via cffi
 pyflakes==3.1.0
     # via flake8
-pyglet==1.3.2
+pyglet
     # via
     #   flatland-rl (pyproject.toml)
     #   gym

--- a/requirements.txt
+++ b/requirements.txt
@@ -206,7 +206,7 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.2
     # via stack-data
-pyglet==1.3.2
+pyglet
     # via
     #   flatland-rl (pyproject.toml)
     #   gym


### PR DESCRIPTION
## Changes

pyglet version 1.3.2 doesn't no longer supported with python 3.8< under windows.

## Related issues

Link to every issue from the issue tracker (if any) you addressed in this PR.

## Checklist

- [x] Tests are included for relevant behavior changes.
- [x] Documentation is added in the `docs` folder for relevant behavior changes. If you made important user-facing
  changes, describe them under the `[Unreleased]` tag in `CHANGELOG.md`.
- [x] New package dependencies are declared in the `pyproject.toml` file.
  Requirement files have been updated by running `tox -e requirements`.
- [x] Code works with all supported Python versions (3.8, 3.9 and 3.10). Checks run with all three version and are
  required to run successfully.
- [ ] Code is formatted according to PEP 8 (an IDE like PyCharm can do this for you).
- [x] Technical guidelines listed in `CONTRIBUTING.md` are followed.
