### PR TITLE
Update gym to a later version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "crowdai_api",
     "dataclasses",
     "graphviz",
-    "gym==0.14.0",
+    "gym<0.23.0",
     "importlib_resources<2.0.0",
     "ipycanvas",
     "ipyevents",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -22,7 +22,7 @@ argon2-cffi-bindings==21.2.0
     # via argon2-cffi
 arrow==1.3.0
     # via isoduration
-asttokens==2.4.0
+asttokens==2.4.1
     # via stack-data
 async-lru==2.0.4
     # via jupyterlab
@@ -35,7 +35,7 @@ attrs==23.1.0
     #   flake8-eradicate
     #   jsonschema
     #   referencing
-babel==2.13.0
+babel==2.13.1
     # via
     #   jupyterlab-server
     #   sphinx
@@ -47,15 +47,15 @@ benchmarker==4.0.1
     # via flatland-rl (pyproject.toml)
 bleach==6.1.0
     # via nbconvert
-boto3==1.28.68
+boto3==1.28.73
     # via flatland-rl (pyproject.toml)
-botocore==1.31.68
+botocore==1.31.73
     # via
     #   boto3
     #   s3transfer
 build==1.0.3
     # via pip-tools
-cachetools==5.3.1
+cachetools==5.3.2
     # via tox
 certifi==2023.7.22
     # via
@@ -73,7 +73,7 @@ click==8.1.7
     #   pip-tools
     #   ray
     #   wandb
-cloudpickle==1.2.2
+cloudpickle==3.0.0
     # via
     #   gym
     #   gymnasium
@@ -124,7 +124,7 @@ farama-notifications==0.0.4
     # via gymnasium
 fastjsonschema==2.18.1
     # via nbformat
-filelock==3.12.4
+filelock==3.13.0
     # via
     #   ray
     #   torch
@@ -146,16 +146,16 @@ frozenlist==1.4.0
     #   ray
 fsspec==2023.10.0
     # via torch
-future==0.18.3
-    # via pyglet
 gitdb==4.0.11
     # via gitpython
 gitpython==3.1.40
     # via wandb
 graphviz==0.20.1
     # via flatland-rl (pyproject.toml)
-gym==0.14.0
+gym==0.22.0
     # via flatland-rl (pyproject.toml)
+gym-notices==0.0.8
+    # via gym
 gymnasium==0.29.1
     # via
     #   pettingzoo
@@ -171,6 +171,7 @@ imagesize==1.4.1
 importlib-metadata==6.8.0
     # via
     #   build
+    #   gym
     #   gymnasium
     #   jupyter-client
     #   jupyter-lsp
@@ -194,7 +195,7 @@ ipycytoscape==1.3.3
     # via flatland-rl (pyproject.toml)
 ipyevents==2.0.2
     # via flatland-rl (pyproject.toml)
-ipykernel==6.25.2
+ipykernel==6.26.0
     # via
     #   jupyter
     #   jupyter-console
@@ -250,7 +251,7 @@ jsonschema-specifications==2023.7.1
     # via jsonschema
 jupyter==1.0.0
     # via flatland-rl (pyproject.toml)
-jupyter-client==8.4.0
+jupyter-client==8.5.0
     # via
     #   ipykernel
     #   jupyter-console
@@ -288,7 +289,7 @@ jupyter-lsp==2.2.0
     # via jupyterlab
 jupyter-nbextensions-configurator==0.6.3
     # via jupyter-contrib-nbextensions
-jupyter-server==2.8.0
+jupyter-server==2.9.1
     # via
     #   jupyter-lsp
     #   jupyterlab
@@ -395,7 +396,6 @@ numpy==1.24.4
     #   pandas
     #   pettingzoo
     #   ray
-    #   scipy
     #   seaborn
     #   stable-baselines3
     #   supersuit
@@ -483,10 +483,8 @@ pycparser==2.21
     # via cffi
 pyflakes==3.1.0
     # via flake8
-pyglet==1.3.2
-    # via
-    #   flatland-rl (pyproject.toml)
-    #   gym
+pyglet==2.0.9
+    # via flatland-rl (pyproject.toml)
 pygments==2.16.1
     # via
     #   ipython
@@ -502,7 +500,7 @@ pyproject-api==1.6.1
     # via tox
 pyproject-hooks==1.0.0
     # via build
-pytest==7.4.2
+pytest==7.4.3
     # via flatland-rl (pyproject.toml)
 python-dateutil==2.8.2
     # via
@@ -535,7 +533,7 @@ pyzmq==25.1.1
     #   qtconsole
 qtconsole==5.4.4
     # via jupyter
-qtpy==2.4.0
+qtpy==2.4.1
     # via qtconsole
 ray==2.7.1
     # via flatland-rl (pyproject.toml)
@@ -584,8 +582,6 @@ rpds-py==0.10.6
     #   referencing
 s3transfer==0.7.0
     # via boto3
-scipy==1.10.1
-    # via gym
 seaborn==0.13.0
     # via flatland-rl (pyproject.toml)
 send2trash==1.8.2
@@ -599,7 +595,6 @@ six==1.16.0
     #   asttokens
     #   bleach
     #   docker-pycreds
-    #   gym
     #   python-dateutil
     #   recordtype
     #   rfc3339-validator
@@ -682,7 +677,7 @@ tornado==6.3.3
     #   terminado
 tox==4.11.3
     # via flatland-rl (pyproject.toml)
-traitlets==5.11.2
+traitlets==5.12.0
     # via
     #   comm
     #   ipykernel
@@ -724,7 +719,7 @@ urllib3==1.26.18
     #   requests
     #   sentry-sdk
     #   twine
-virtualenv==20.24.5
+virtualenv==20.24.6
     # via tox
 wandb==0.15.12
     # via flatland-rl (pyproject.toml)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ appdirs==1.4.4
     # via wandb
 appnope==0.1.3
     # via ipython
-asttokens==2.4.0
+asttokens==2.4.1
     # via stack-data
 async-timeout==4.0.3
     # via redis
@@ -22,9 +22,9 @@ attrs==23.1.0
     #   referencing
 backcall==0.2.0
     # via ipython
-boto3==1.28.68
+boto3==1.28.73
     # via flatland-rl (pyproject.toml)
-botocore==1.31.68
+botocore==1.31.73
     # via
     #   boto3
     #   s3transfer
@@ -39,7 +39,7 @@ click==8.1.7
     #   flatland-rl (pyproject.toml)
     #   ray
     #   wandb
-cloudpickle==1.2.2
+cloudpickle==3.0.0
     # via
     #   gym
     #   gymnasium
@@ -62,7 +62,7 @@ executing==2.0.0
     # via stack-data
 farama-notifications==0.0.4
     # via gymnasium
-filelock==3.12.4
+filelock==3.13.0
     # via
     #   ray
     #   torch
@@ -74,16 +74,16 @@ frozenlist==1.4.0
     #   ray
 fsspec==2023.10.0
     # via torch
-future==0.18.3
-    # via pyglet
 gitdb==4.0.11
     # via gitpython
 gitpython==3.1.40
     # via wandb
 graphviz==0.20.1
     # via flatland-rl (pyproject.toml)
-gym==0.14.0
+gym==0.22.0
     # via flatland-rl (pyproject.toml)
+gym-notices==0.0.8
+    # via gym
 gymnasium==0.29.1
     # via
     #   pettingzoo
@@ -92,7 +92,9 @@ gymnasium==0.29.1
 idna==3.4
     # via requests
 importlib-metadata==6.8.0
-    # via gymnasium
+    # via
+    #   gym
+    #   gymnasium
 importlib-resources==1.5.0
     # via
     #   flatland-rl (pyproject.toml)
@@ -163,7 +165,6 @@ numpy==1.24.4
     #   pandas
     #   pettingzoo
     #   ray
-    #   scipy
     #   seaborn
     #   stable-baselines3
     #   supersuit
@@ -206,10 +207,8 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.2
     # via stack-data
-pyglet==1.3.2
-    # via
-    #   flatland-rl (pyproject.toml)
-    #   gym
+pyglet==2.0.9
+    # via flatland-rl (pyproject.toml)
 pygments==2.16.1
     # via ipython
 pyparsing==3.1.1
@@ -255,8 +254,6 @@ rpds-py==0.10.6
     #   referencing
 s3transfer==0.7.0
     # via boto3
-scipy==1.10.1
-    # via gym
 seaborn==0.13.0
     # via flatland-rl (pyproject.toml)
 sentry-sdk==1.32.0
@@ -267,7 +264,6 @@ six==1.16.0
     # via
     #   asttokens
     #   docker-pycreds
-    #   gym
     #   python-dateutil
     #   recordtype
 smmap==5.0.1
@@ -288,7 +284,7 @@ tinyscaler==1.2.7
     # via supersuit
 torch==2.1.0
     # via stable-baselines3
-traitlets==5.11.2
+traitlets==5.12.0
     # via
     #   comm
     #   ipython


### PR DESCRIPTION
Trying to address https://github.com/flatland-association/flatland-rl/issues/53

I tried various version of `gym` and 0.22.0 is the latest I could get something running. But 2 tests are failing: `tests/test_flatland_envs_sparse_rail_generator.py` and `tests/test_flatland_malfunction.py`. @aiAdrian could you maybe have a look?