### PR TITLE
Allow action to push release tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,6 +29,8 @@ jobs:
     publish:
         runs-on: ubuntu-22.04
         needs: [ test ]
+        permissions:
+            contents: write
         steps:
             -   name: Checkout
                 uses: actions/checkout@v3


### PR DESCRIPTION
@aiAdrian I think this should fix the issue you encountered. Let's see the next time a release is published :).