### PR TITLE
Add AWS_ENDPOINT_URL for non-default S3 endpoint in AIcrowd Helpers.

### DIFF
--- a/flatland/evaluators/aicrowd_helpers.py
+++ b/flatland/evaluators/aicrowd_helpers.py
@@ -1,9 +1,9 @@
 import glob
 import os
+import pathlib
 import random
 import subprocess
 import uuid
-import pathlib
 
 ###############################################################
 # Expected Env Variables
@@ -20,9 +20,11 @@ import pathlib
 ###############################################################
 AWS_ACCESS_KEY_ID = os.getenv("AWS_ACCESS_KEY_ID", False)
 AWS_SECRET_ACCESS_KEY = os.getenv("AWS_SECRET_ACCESS_KEY", False)
+AWS_ENDPOINT_URL = os.getenv("AWS_ENDPOINT_URL", None)
 S3_UPLOAD_PATH_TEMPLATE = os.getenv("S3_UPLOAD_PATH_TEMPLATE", "misc/flatland-rl-Media/{}.mp4")
 S3_BUCKET = os.getenv("S3_BUCKET", "aicrowd-production")
 S3_BUCKET_ACL = "public-read" if S3_BUCKET == "aicrowd-production" else ""
+
 
 def get_boto_client():
     if not AWS_ACCESS_KEY_ID or not AWS_SECRET_ACCESS_KEY:
@@ -37,6 +39,8 @@ def get_boto_client():
 
     return boto3.client(
         's3',
+        # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html
+        endpoint_url=AWS_ENDPOINT_URL,
         aws_access_key_id=AWS_ACCESS_KEY_ID,
         aws_secret_access_key=AWS_SECRET_ACCESS_KEY
     )
@@ -51,7 +55,7 @@ def is_aws_configured():
 
 def is_grading():
     return os.getenv("CROWDAI_IS_GRADING", False) or \
-           os.getenv("AICROWD_IS_GRADING", False)
+        os.getenv("AICROWD_IS_GRADING", False)
 
 
 def get_submission_id():
@@ -117,6 +121,7 @@ def upload_folder_to_s3(folderpath):
                     Key=file_target_key,
                     Body=open(localpath, 'rb')
                 )
+
 
 def make_subprocess_call(command, shell=False):
     result = subprocess.run(


### PR DESCRIPTION
## Changes

Add `AWS_ENDPOINT_URL` env var to override default S3 endpoint URL in `aicrowd_helpers.py`.

## Related issues



## Checklist

- [ ] Tests are included for relevant behavior changes.
- [ ] Documentation is added in the `docs` folder for relevant behavior changes. If you made important user-facing
  changes, describe them under the `[Unreleased]` tag in `CHANGELOG.md`.
- [ ] New package dependencies are declared in the `pyproject.toml` file.
  Requirement files have been updated by running `tox -e requirements`.
- [ ] Code works with all supported Python versions (3.10, 3.11 and 3.12). Checks run with all three version and are
  required to run successfully.
- [x] Code is formatted according to PEP 8 (an IDE like PyCharm can do this for you).
- [x] Technical guidelines listed in `CONTRIBUTING.md` are followed.
