### PR TITLE
fix: from attr import attr, attrs, attrib, Factory ImportError: cannot import name 'attrs' from 'attr'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     'Programming Language :: Python :: 3.12',
 ]
 dependencies = [
-    "attr",
+    "attrs",
     "boto3",
     "click",
     "crowdai_api",
@@ -42,6 +42,8 @@ dependencies = [
     "recordtype",
     "redis",
     "seaborn",
+    # https://docs.python.org/3/whatsnew/3.12.html: Python 3.12 has removed pkg_resources from the standard library (moved to setuptools):
+    "setuptools",
     "svgutils",
     "timeout_decorator",
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -24,11 +24,10 @@ async-lru==2.0.4
     # via jupyterlab
 async-timeout==5.0.1
     # via redis
-attr==0.3.2
-    # via flatland-rl (pyproject.toml)
 attrs==25.1.0
     # via
     #   flake8-eradicate
+    #   flatland-rl (pyproject.toml)
     #   jsonschema
     #   referencing
 babel==2.17.0

--- a/requirements-ml.txt
+++ b/requirements-ml.txt
@@ -24,11 +24,10 @@ async-timeout==5.0.1
     # via
     #   aiohttp
     #   redis
-attr==0.3.2
-    # via flatland-rl (pyproject.toml)
 attrs==25.1.0
     # via
     #   aiohttp
+    #   flatland-rl (pyproject.toml)
     #   jsonschema
     #   referencing
 boto3==1.36.20

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ asttokens==3.0.0
     # via stack-data
 async-timeout==5.0.1
     # via redis
-attr==0.3.2
+attrs==25.1.0
     # via flatland-rl (pyproject.toml)
 boto3==1.36.20
     # via flatland-rl (pyproject.toml)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-env_list = py{310,311,312},notebooks,py{310,311,312}-ml
+env_list = py{310,311,312},notebooks,py{310,311,312}-ml,py{310,311,312}-verify-install
 
 [gh-actions]
 python =
@@ -123,3 +123,10 @@ deps =
     -r requirements-dev.txt
 commands =
     python -m build
+
+[testenv:py{310,311,312}-verify-install]
+# install flatland-rl without additional dependencies
+skip_install = false
+commands =
+    python --version
+    python -c 'from flatland.evaluators.service import FlatlandRemoteEvaluationService'


### PR DESCRIPTION
## Changes

* Add test reproducing the error
* Fix error `from attr import attr, attrs, attrib, Factory ImportError: cannot import name 'attrs' from 'attr'`

## Related issues

Link to every issue from the issue tracker (if any) you addressed in this PR.

## Checklist

- [ ] Tests are included for relevant behavior changes.
- [ ] Documentation is added in the [flatland-book](https://github.com/flatland-association/flatland-book) repo for relevant behavior changes.
- [ ] If you made important user-facing changes, describe them under the `[Unreleased]` tag in `CHANGELOG.md`.
- [ ] New package dependencies are declared in the `pyproject.toml` file.
  Requirement files have been updated by running `tox -e requirements`.
- [ ] Code works with all supported Python versions (3.10, 3.11 and 3.12). Checks run with all three version and are
  required to run successfully.
- [ ] Code is formatted according to PEP 8 (an IDE like PyCharm can do this for you).
- [ ] Technical guidelines listed in `CONTRIBUTING.md` are followed.
