### PR TITLE
fix: Add tox benchmark environment again.

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -8,7 +8,7 @@ on:
     pull_request:
 
 concurrency:
-    group: ${{ github.head_ref }}
+    group: ${{ github.head_ref || github.ref }}
     cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -2,6 +2,9 @@ name: Checks
 
 on:
     workflow_dispatch:
+        inputs:
+            run_benchmarks:
+                type: boolean
     pull_request:
 
 concurrency:
@@ -144,3 +147,24 @@ jobs:
                     path: .tox/profiling/log
                     if-no-files-found: error
 
+    benchmarks:
+        if: ${{ github.event.inputs.run_benchmarks }}
+        runs-on: ubuntu-22.04
+        steps:
+            -   uses: actions/checkout@v4
+            -   name: Set up Python
+                uses: actions/setup-python@v5
+                with:
+                    python-version: "3.10"
+            -   name: Download episodes
+                run: |
+                    wget "https://github.com/flatland-association/flatland-scenarios/raw/refs/heads/main/trajectories/FLATLAND_BENCHMARK_EPISODES_FOLDER_v2.zip" -O FLATLAND_BENCHMARK_EPISODES_FOLDER.zip
+                    mkdir -p episodes
+                    unzip FLATLAND_BENCHMARK_EPISODES_FOLDER -d episodes
+                working-directory: ${{ github.workspace }}
+            -   name: Install tox
+                run: |
+                    python -m pip install --upgrade pip
+                    pip install tox tox-gh-actions
+            -   name: Run benchmarks
+                run: tox run -e benchmarks

--- a/benchmarks/benchmark_episodes.py
+++ b/benchmarks/benchmark_episodes.py
@@ -126,9 +126,6 @@ from flatland.trajectories.trajectories import Trajectory
     ("malfunction_deadlock_avoidance_heuristics/Test_03/Level_4", "Test_03_Level_4"),
     ("malfunction_deadlock_avoidance_heuristics/Test_03/Level_5", "Test_03_Level_5"),
     ("malfunction_deadlock_avoidance_heuristics/Test_03/Level_6", "Test_03_Level_6"),
-    ("malfunction_deadlock_avoidance_heuristics/Test_03/Level_7", "Test_03_Level_7"),
-    ("malfunction_deadlock_avoidance_heuristics/Test_03/Level_8", "Test_03_Level_8"),
-    ("malfunction_deadlock_avoidance_heuristics/Test_03/Level_9", "Test_03_Level_9"),
 ])
 def test_episode(data_sub_dir: str, ep_id: str):
     _dir = os.getenv("BENCHMARK_EPISODES_FOLDER")

--- a/benchmarks/benchmark_episodes.py
+++ b/benchmarks/benchmark_episodes.py
@@ -129,16 +129,6 @@ from flatland.trajectories.trajectories import Trajectory
     ("malfunction_deadlock_avoidance_heuristics/Test_03/Level_7", "Test_03_Level_7"),
     ("malfunction_deadlock_avoidance_heuristics/Test_03/Level_8", "Test_03_Level_8"),
     ("malfunction_deadlock_avoidance_heuristics/Test_03/Level_9", "Test_03_Level_9"),
-    ("malfunction_deadlock_avoidance_heuristics/Test_04/Level_0", "Test_04_Level_0"),
-    ("malfunction_deadlock_avoidance_heuristics/Test_04/Level_1", "Test_04_Level_1"),
-    ("malfunction_deadlock_avoidance_heuristics/Test_04/Level_2", "Test_04_Level_2"),
-    ("malfunction_deadlock_avoidance_heuristics/Test_04/Level_3", "Test_04_Level_3"),
-    ("malfunction_deadlock_avoidance_heuristics/Test_04/Level_4", "Test_04_Level_4"),
-    ("malfunction_deadlock_avoidance_heuristics/Test_04/Level_5", "Test_04_Level_5"),
-    ("malfunction_deadlock_avoidance_heuristics/Test_04/Level_6", "Test_04_Level_6"),
-    ("malfunction_deadlock_avoidance_heuristics/Test_04/Level_7", "Test_04_Level_7"),
-    ("malfunction_deadlock_avoidance_heuristics/Test_04/Level_8", "Test_04_Level_8"),
-    ("malfunction_deadlock_avoidance_heuristics/Test_04/Level_9", "Test_04_Level_9"),
 ])
 def test_episode(data_sub_dir: str, ep_id: str):
     _dir = os.getenv("BENCHMARK_EPISODES_FOLDER")

--- a/benchmarks/benchmark_episodes.py
+++ b/benchmarks/benchmark_episodes.py
@@ -125,7 +125,6 @@ from flatland.trajectories.trajectories import Trajectory
     ("malfunction_deadlock_avoidance_heuristics/Test_03/Level_3", "Test_03_Level_3"),
     ("malfunction_deadlock_avoidance_heuristics/Test_03/Level_4", "Test_03_Level_4"),
     ("malfunction_deadlock_avoidance_heuristics/Test_03/Level_5", "Test_03_Level_5"),
-    ("malfunction_deadlock_avoidance_heuristics/Test_03/Level_6", "Test_03_Level_6"),
 ])
 def test_episode(data_sub_dir: str, ep_id: str):
     _dir = os.getenv("BENCHMARK_EPISODES_FOLDER")

--- a/tox.ini
+++ b/tox.ini
@@ -132,3 +132,13 @@ commands =
     flatland-evaluator --help
     flatland-trajectory-evaluate --help
     flatland-trajectory-generate-from-policy --help
+
+[testenv:benchmarks]
+platform = linux|linux2|darwin
+deps =
+    -r requirements-dev.txt
+set_env =
+    BENCHMARK_EPISODES_FOLDER = {tox_root}/episodes
+commands =
+    python --version
+    pyest -s benchmarks/benchmarks_episodes.py

--- a/tox.ini
+++ b/tox.ini
@@ -141,4 +141,4 @@ set_env =
     BENCHMARK_EPISODES_FOLDER = {tox_root}/episodes
 commands =
     python --version
-    pyest -s benchmarks/benchmarks_episodes.py
+    pytest -s benchmarks/benchmarks_episodes.py

--- a/tox.ini
+++ b/tox.ini
@@ -141,4 +141,4 @@ set_env =
     BENCHMARK_EPISODES_FOLDER = {tox_root}/episodes
 commands =
     python --version
-    pytest -s benchmarks/benchmarks_episodes.py
+    pytest -s benchmarks/benchmark_episodes.py


### PR DESCRIPTION
## Changes

* fix benchmarks on main workflow by adding tox benchmark environment again. 
* allow benchmarks in checks workflow during prs already.

## Related issues

Link to every issue from the issue tracker (if any) you addressed in this PR.

## Checklist

- [ ] Tests are included for relevant behavior changes.
- [ ] Documentation is added in the [flatland-book](https://github.com/flatland-association/flatland-book) repo for relevant behavior changes.
- [ ] If you made important user-facing changes, describe them under the `[Unreleased]` tag in `CHANGELOG.md`.
- [ ] New package dependencies are declared in the `pyproject.toml` file.
  Requirement files have been updated by running `tox -e requirements`.
- [ ] Code works with all supported Python versions (3.10, 3.11 and 3.12). Checks run with all three version and are
  required to run successfully.
- [ ] Code is formatted according to PEP 8 (an IDE like PyCharm can do this for you).
- [ ] Technical guidelines listed in `CONTRIBUTING.md` are followed.
