### PR TITLE
Fix is_cell_entry of SpeedCounter.__setstate__

### DIFF
--- a/flatland/envs/step_utils/speed_counter.py
+++ b/flatland/envs/step_utils/speed_counter.py
@@ -99,7 +99,7 @@ class SpeedCounter:
         else:
             self._distance = load_dict['distance']
         if "is_cell_entry" in load_dict:
-            self._is_cell_entry = load_dict['distance']
+            self._is_cell_entry = load_dict['is_cell_entry']
         if "max_speed" in load_dict:
             self._max_speed = load_dict["max_speed"]
         else:


### PR DESCRIPTION
## Changes

fix speed counter. Set state was restoring `distance` into the `is_cell_entry`

## Related issues

.

## Checklist

- [ ] Tests are included for relevant behavior changes.
- [ ] Documentation is added in the [flatland-book](https://github.com/flatland-association/flatland-book) repo for relevant behavior changes.
- [ ] If you made important user-facing changes, describe them under the `[Unreleased]` tag in `CHANGELOG.md`.
- [ ] New package dependencies are declared in the `pyproject.toml` file.
  Requirement files have been updated by running `tox -e requirements`.
- [ ] Code works with all supported Python versions (3.10, 3.11 and 3.12). Checks run with all three version and are
  required to run successfully.
- [ ] Code is formatted according to PEP 8 (an IDE like PyCharm can do this for you).
- [ ] Technical guidelines listed in `CONTRIBUTING.md` are followed.
