### PR TITLE
Remove obsolete parameters in rewards function. Add math references.

### DIFF
--- a/flatland/envs/rail_env.py
+++ b/flatland/envs/rail_env.py
@@ -371,34 +371,6 @@ class RailEnv(Environment):
                 if agent.old_position is not None:
                     self.agent_positions[agent.old_position] = -1
 
-    def _handle_end_reward(self, agent: EnvAgent) -> int:
-        '''
-        Handles end-of-episode reward for a particular agent.
-
-        Parameters
-        ----------
-        agent : EnvAgent
-        '''
-        reward = None
-        # agent done? (arrival_time is not None)
-        if agent.state == TrainState.DONE:
-            # if agent arrived earlier or on time = 0
-            # if agent arrived later = -ve reward based on how late
-            reward = min(agent.latest_arrival - agent.arrival_time, 0)
-
-        # Agents not done (arrival_time is None)
-        else:
-            # CANCELLED check (never departed)
-            if (agent.state.is_off_map_state()):
-                reward = -1 * self.cancellation_factor * \
-                         (agent.get_travel_time_on_shortest_path(self.distance_map) + self.cancellation_time_buffer)
-
-            # Departed but never reached
-            if (agent.state.is_on_map_state()):
-                reward = agent.get_current_delay(self._elapsed_steps, self.distance_map)
-
-        return reward
-
     def preprocess_action(self, action, agent):
         """
         Preprocess the provided action

--- a/flatland/envs/rewards.py
+++ b/flatland/envs/rewards.py
@@ -8,35 +8,50 @@ from flatland.envs.step_utils.states import TrainState
 
 class Rewards:
     """
-    Reward Function:
+    Reward Function.
 
-    It costs each agent a step_penalty for every time-step taken in the environment. Independent of the movement
-    of the agent.
+    This scoring function is designed to capture key operational metrics such as punctuality, efficiency in responding to disruptions, and safety.
 
-    Parameters
-    ----------
-    epsilon : float
-        avoid rounding errors, defaults to 0.01
-    cancellation_factor : float
-        Cancellation factor $\phi$. defaults to  1.
-    cancellation_time_buffer : float
-        Cancellation time buffer $\pi$. Defaults to 0.
-    intermediate_not_served_penalty : float
-       Intermediate stop not served penalty $\mu$. Defaults to -1.
-    intermediate_late_arrival_penalty_factor : float
-        Intermediate late arrival penalty factor $\alpha$. Defaults to 0.2.
-    intermediate_early_departure_penalty_factor : float
-        Intermeidate early departure penalty factor $\delta$. Defaults to 0.5.
+    Punctuality and schedule adherence are rewarded based on the difference between actual and target arrival and departure times at each stop respectively,
+    as well as penalties for intermediate stops not served or even journeys not started.
+
+    Safety measures are implemented as penalties for collisions which are directly proportional to the train’s speed at impact, ensuring that high-speed operations are managed with extra caution.
     """
-    epsilon = 0.01
-    cancellation_factor = 1
-    cancellation_time_buffer = 0
-    intermediate_not_served_penalty = -1
-    intermediate_late_arrival_penalty_factor = 0.2
-    intermediate_early_departure_penalty_factor = 0.5
-    crash_penalty_factor = 0.0  # \alpha penalty for stopping train in conflict
 
-    def __init__(self):
+    def __init__(self,
+                 epsilon: float = 0.01,
+                 cancellation_factor: float = 1,
+                 cancellation_time_buffer: float = 0,
+                 intermediate_not_served_penalty: float = -1,
+                 intermediate_late_arrival_penalty_factor: float = 0.2,
+                 intermediate_early_departure_penalty_factor: float = 0.5,
+                 crash_penalty_factor: float = 0.0
+                 ):
+        """
+        Parameters
+        ----------
+        epsilon : float
+            avoid rounding errors, defaults to 0.01.
+        cancellation_factor : float
+            Cancellation factor $\phi$. defaults to  1.
+        cancellation_time_buffer : float
+            Cancellation time buffer $\pi$. Defaults to 0.
+        intermediate_not_served_penalty : float
+           Intermediate stop not served penalty $\mu$. Defaults to -1.
+        intermediate_late_arrival_penalty_factor : float
+            Intermediate late arrival penalty factor $\alpha$. Defaults to 0.2.
+        intermediate_early_departure_penalty_factor : float
+            Intermediate early departure penalty factor $\delta$. Defaults to 0.5.
+        crash_penalty_factor : float
+            Crash penalty factor $\kappa$. Defaults to 0.0.
+        """
+        self.crash_penalty_factor = crash_penalty_factor
+        self.intermediate_early_departure_penalty_factor = intermediate_early_departure_penalty_factor
+        self.intermediate_late_arrival_penalty_factor = intermediate_late_arrival_penalty_factor
+        self.intermediate_not_served_penalty = intermediate_not_served_penalty
+        self.cancellation_time_buffer = cancellation_time_buffer
+        self.cancellation_factor = cancellation_factor
+        self.epsilon = epsilon
         # https://stackoverflow.com/questions/16439301/cant-pickle-defaultdict
         self.arrivals = defaultdict(defaultdict)
         self.departures = defaultdict(defaultdict)

--- a/flatland/envs/rewards.py
+++ b/flatland/envs/rewards.py
@@ -22,7 +22,7 @@ class Rewards:
                  epsilon: float = 0.01,
                  cancellation_factor: float = 1,
                  cancellation_time_buffer: float = 0,
-                 intermediate_not_served_penalty: float = -1,
+                 intermediate_not_served_penalty: float = 1,
                  intermediate_late_arrival_penalty_factor: float = 0.2,
                  intermediate_early_departure_penalty_factor: float = 0.5,
                  crash_penalty_factor: float = 0.0

--- a/tests/test_flatland_rail_agent_status.py
+++ b/tests/test_flatland_rail_agent_status.py
@@ -33,9 +33,6 @@ def test_initial_status():
                 state=TrainState.READY_TO_DEPART,
 
                 action=RailEnvActions.DO_NOTHING,
-
-                reward=env.rewards.step_penalty * 0.5,
-
             ),
             Replay(  # 1
                 position=None,  # not entered grid yet before step
@@ -43,8 +40,6 @@ def test_initial_status():
                 state=TrainState.READY_TO_DEPART,
 
                 action=RailEnvActions.MOVE_LEFT,
-
-                reward=env.rewards.step_penalty * 0.5,  # auto-correction left to forward without penalty!
             ),
             Replay(  # 2
                 position=(3, 9),
@@ -53,8 +48,6 @@ def test_initial_status():
                 state=TrainState.MOVING,
 
                 action=RailEnvActions.MOVE_LEFT,
-
-                reward=env.start_penalty + env.rewards.step_penalty * 0.5,  # running at speed 0.5
             ),
             Replay(  # 3
                 position=(3, 9),
@@ -63,8 +56,6 @@ def test_initial_status():
                 state=TrainState.MOVING,
 
                 action=RailEnvActions.MOVE_FORWARD,
-
-                reward=env.rewards.step_penalty * 0.5,  # running at speed 0.5
             ),
             Replay(  # 4
                 position=(3, 8),
@@ -73,42 +64,35 @@ def test_initial_status():
                 state=TrainState.MOVING,
 
                 action=RailEnvActions.MOVE_FORWARD,
-                reward=env.rewards.step_penalty * 0.5,  # running at speed 0.5
             ),
             Replay(
                 position=(3, 8),
                 direction=Grid4TransitionsEnum.WEST,
                 state=TrainState.MOVING,
                 action=None,
-                reward=env.rewards.step_penalty * 0.5,  # running at speed 0.5
-
             ),
             Replay(
                 position=(3, 7),
                 direction=Grid4TransitionsEnum.WEST,
                 action=RailEnvActions.MOVE_FORWARD,
-                reward=env.rewards.step_penalty * 0.5,  # running at speed 0.5
                 state=TrainState.MOVING
             ),
             Replay(
                 position=(3, 7),
                 direction=Grid4TransitionsEnum.WEST,
                 action=None,
-                reward=env.rewards.step_penalty * 0.5,  # wrong action is corrected to forward without penalty!
                 state=TrainState.MOVING
             ),
             Replay(
                 position=(3, 6),
                 direction=Grid4TransitionsEnum.WEST,
                 action=RailEnvActions.MOVE_RIGHT,
-                reward=env.rewards.step_penalty * 0.5,  #
                 state=TrainState.MOVING
             ),
             Replay(
                 position=(3, 6),
                 direction=Grid4TransitionsEnum.WEST,
                 action=None,
-                reward=env.rewards.global_reward,  #
                 state=TrainState.MOVING
             ),
             # Replay(
@@ -162,7 +146,6 @@ def test_status_done_remove():
                 direction=Grid4TransitionsEnum.EAST,
                 state=TrainState.READY_TO_DEPART,
                 action=RailEnvActions.DO_NOTHING,
-                reward=env.rewards.step_penalty * 0.5,
 
             ),
             Replay(  # 1
@@ -170,63 +153,54 @@ def test_status_done_remove():
                 direction=Grid4TransitionsEnum.EAST,
                 state=TrainState.READY_TO_DEPART,
                 action=RailEnvActions.MOVE_LEFT,
-                reward=env.rewards.step_penalty * 0.5,  # auto-correction left to forward without penalty!
             ),
             Replay(  # 2
                 position=(3, 9),
                 direction=Grid4TransitionsEnum.EAST,
                 state=TrainState.MOVING,
                 action=RailEnvActions.MOVE_FORWARD,
-                reward=env.rewards.start_penalty + env.rewards.step_penalty * 0.5,  # running at speed 0.5
             ),
             Replay(  # 3
                 position=(3, 9),
                 direction=Grid4TransitionsEnum.EAST,
                 state=TrainState.MOVING,
                 action=None,
-                reward=env.rewards.step_penalty * 0.5,  # running at speed 0.5
             ),
             Replay(  # 4
                 position=(3, 8),
                 direction=Grid4TransitionsEnum.WEST,
                 state=TrainState.MOVING,
                 action=RailEnvActions.MOVE_FORWARD,
-                reward=env.rewards.step_penalty * 0.5,  # running at speed 0.5
             ),
             Replay(  # 5
                 position=(3, 8),
                 direction=Grid4TransitionsEnum.WEST,
                 state=TrainState.MOVING,
                 action=None,
-                reward=env.rewards.step_penalty * 0.5,  # running at speed 0.5
 
             ),
             Replay(  # 6
                 position=(3, 7),
                 direction=Grid4TransitionsEnum.WEST,
                 action=RailEnvActions.MOVE_RIGHT,
-                reward=env.rewards.step_penalty * 0.5,  # running at speed 0.5
                 state=TrainState.MOVING
             ),
             Replay(  # 7
                 position=(3, 7),
                 direction=Grid4TransitionsEnum.WEST,
                 action=None,
-                reward=env.rewards.step_penalty * 0.5,  # wrong action is corrected to forward without penalty!
                 state=TrainState.MOVING
             ),
             Replay(  # 8
                 position=(3, 6),
                 direction=Grid4TransitionsEnum.WEST,
                 action=RailEnvActions.MOVE_FORWARD,
-                reward=env.rewards.step_penalty * 0.5,  # done
                 state=TrainState.MOVING
             ),
             Replay(
                 position=(3, 6),
                 direction=Grid4TransitionsEnum.WEST,
                 action=None,
-                reward=env.rewards.global_reward,  # already done
                 state=TrainState.MOVING
             ),
             # Replay(

--- a/tests/test_multi_speed.py
+++ b/tests/test_multi_speed.py
@@ -237,8 +237,6 @@ def test_multispeed_actions_no_malfunction_blocking():
                     speed=1. / 3.,
 
                     action=RailEnvActions.MOVE_FORWARD,
-
-                    reward=env.rewards.start_penalty + env.rewards.step_penalty * 1.0 / 3.0  # starting and running at speed 1/3
                 ),
                 Replay(  # 1
                     position=(3, 8),
@@ -246,8 +244,6 @@ def test_multispeed_actions_no_malfunction_blocking():
                     state=TrainState.MOVING,
 
                     action=None,
-
-                    reward=env.rewards.step_penalty * 1.0 / 3.0  # running at speed 1/3
                 ),
                 Replay(  # 2
                     position=(3, 8),
@@ -255,8 +251,6 @@ def test_multispeed_actions_no_malfunction_blocking():
                     state=TrainState.MOVING,
 
                     action=None,
-
-                    reward=env.rewards.step_penalty * 1.0 / 3.0  # running at speed 1/3
                 ),
 
                 Replay(
@@ -265,8 +259,6 @@ def test_multispeed_actions_no_malfunction_blocking():
                     state=TrainState.MOVING,
 
                     action=RailEnvActions.MOVE_FORWARD,
-
-                    reward=env.rewards.step_penalty * 1.0 / 3.0  # running at speed 1/3
                 ),
                 Replay(
                     position=(3, 7),
@@ -274,8 +266,6 @@ def test_multispeed_actions_no_malfunction_blocking():
                     state=TrainState.MOVING,
 
                     action=None,
-
-                    reward=env.rewards.step_penalty * 1.0 / 3.0  # running at speed 1/3
                 ),
                 Replay(
                     position=(3, 7),
@@ -283,8 +273,6 @@ def test_multispeed_actions_no_malfunction_blocking():
                     state=TrainState.MOVING,
 
                     action=None,
-
-                    reward=env.rewards.step_penalty * 1.0 / 3.0  # running at speed 1/3
                 ),
 
                 Replay(
@@ -292,7 +280,6 @@ def test_multispeed_actions_no_malfunction_blocking():
                     direction=Grid4TransitionsEnum.WEST,
                     state=TrainState.MOVING,
                     action=RailEnvActions.MOVE_FORWARD,
-                    reward=env.rewards.step_penalty * 1.0 / 3.0  # running at speed 1/3
                 ),
                 Replay(
                     position=(3, 6),
@@ -300,8 +287,6 @@ def test_multispeed_actions_no_malfunction_blocking():
                     state=TrainState.MOVING,
 
                     action=None,
-
-                    reward=env.rewards.step_penalty * 1.0 / 3.0  # running at speed 1/3
                 ),
                 Replay(
                     position=(3, 6),
@@ -309,8 +294,6 @@ def test_multispeed_actions_no_malfunction_blocking():
                     state=TrainState.MOVING,
 
                     action=None,
-
-                    reward=env.rewards.step_penalty * 1.0 / 3.0  # running at speed 1/3
                 ),
 
                 Replay(
@@ -318,8 +301,6 @@ def test_multispeed_actions_no_malfunction_blocking():
                     direction=Grid4TransitionsEnum.WEST,
 
                     action=RailEnvActions.MOVE_FORWARD,
-
-                    reward=env.rewards.step_penalty * 1.0 / 3.0  # running at speed 1/3
                 ),
                 Replay(
                     position=(3, 5),
@@ -327,8 +308,6 @@ def test_multispeed_actions_no_malfunction_blocking():
                     state=TrainState.MOVING,
 
                     action=None,
-
-                    reward=env.rewards.step_penalty * 1.0 / 3.0  # running at speed 1/3
                 ),
                 Replay(
                     position=(3, 5),
@@ -336,8 +315,6 @@ def test_multispeed_actions_no_malfunction_blocking():
                     state=TrainState.MOVING,
 
                     action=None,
-
-                    reward=env.rewards.step_penalty * 1.0 / 3.0  # running at speed 1/3
                 )
             ],
             target=(3, 0),  # west dead-end
@@ -353,8 +330,6 @@ def test_multispeed_actions_no_malfunction_blocking():
                     state=TrainState.MOVING,
 
                     action=RailEnvActions.MOVE_FORWARD,
-
-                    reward=env.rewards.start_penalty + env.rewards.step_penalty * 0.5  # starting and running at speed 0.5
                 ),
                 Replay(  # 1
                     position=(3, 9),
@@ -362,8 +337,6 @@ def test_multispeed_actions_no_malfunction_blocking():
                     state=TrainState.MOVING,
 
                     action=None,
-
-                    reward=env.rewards.step_penalty * 0.5 + CRASH_PENALTY * 0.5  # was running at speed 0.5 but force-stopped now
                 ),
                 # blocked although fraction >= 1.0
                 Replay(  # 2
@@ -372,8 +345,6 @@ def test_multispeed_actions_no_malfunction_blocking():
                     state=TrainState.STOPPED,
 
                     action=RailEnvActions.MOVE_FORWARD,  # SM: STOPPED -> MOVING needs move action
-
-                    reward=env.rewards.step_penalty * 0.5  # running at speed 0.5
                 ),
                 Replay(  # 3
                     position=(3, 8),
@@ -381,8 +352,6 @@ def test_multispeed_actions_no_malfunction_blocking():
                     state=TrainState.MOVING,
 
                     action=RailEnvActions.MOVE_FORWARD,
-
-                    reward=env.rewards.step_penalty * 0.5  # running at speed 0.5
                 ),
                 Replay(  # 4
                     position=(3, 8),
@@ -390,8 +359,6 @@ def test_multispeed_actions_no_malfunction_blocking():
                     state=TrainState.MOVING,
 
                     action=RailEnvActions.MOVE_FORWARD,
-
-                    reward=env.rewards.step_penalty * 0.5 + CRASH_PENALTY * 0.5  # was running at speed 0.5 but force-stopped now
                 ),
                 # blocked although fraction >= 1.0
                 Replay(  # 5
@@ -400,8 +367,6 @@ def test_multispeed_actions_no_malfunction_blocking():
                     state=TrainState.STOPPED,
 
                     action=RailEnvActions.MOVE_FORWARD,  # SM: STOPPED -> MOVING needs move action
-
-                    reward=env.rewards.step_penalty * 0.5  # running at speed 0.5
                 ),
 
                 Replay(  # 6
@@ -410,8 +375,6 @@ def test_multispeed_actions_no_malfunction_blocking():
                     state=TrainState.MOVING,
 
                     action=RailEnvActions.MOVE_FORWARD,
-
-                    reward=env.rewards.step_penalty * 0.5  # running at speed 0.5
                 ),
                 Replay(  # 7
                     position=(3, 7),
@@ -419,8 +382,6 @@ def test_multispeed_actions_no_malfunction_blocking():
                     state=TrainState.MOVING,
 
                     action=RailEnvActions.STOP_MOVING,
-
-                    reward=env.rewards.step_penalty * 0.5  # was running at speed 0.5 but stopped by action -> no crash penalty
                 ),
                 # blocked although fraction >= 1.0
                 Replay(  # 8
@@ -429,8 +390,6 @@ def test_multispeed_actions_no_malfunction_blocking():
                     state=TrainState.STOPPED,
 
                     action=RailEnvActions.MOVE_FORWARD,  # SM: STOPPED -> MOVING needs move action
-
-                    reward=env.rewards.step_penalty * 0.5  # running at speed 0.5
                 ),
 
                 Replay(  # 9
@@ -439,7 +398,6 @@ def test_multispeed_actions_no_malfunction_blocking():
                     state=TrainState.MOVING,
 
                     action=None,
-                    reward=env.rewards.step_penalty * 0.5  # running at speed 0.5
                 ),
                 Replay(  # 10
                     position=(3, 6),
@@ -449,16 +407,12 @@ def test_multispeed_actions_no_malfunction_blocking():
                     speed=0.5,
 
                     action=RailEnvActions.MOVE_LEFT,
-
-                    reward=env.rewards.step_penalty * 0.5  # running at speed 0.5
                 ),
                 Replay(  # 11
                     position=(4, 6),
                     direction=Grid4TransitionsEnum.SOUTH,
 
                     action=RailEnvActions.MOVE_FORWARD,
-
-                    reward=env.rewards.step_penalty * 0.5  # running at speed 0.5
                 ),
             ],
             target=(3, 0),  # west dead-end
@@ -468,7 +422,7 @@ def test_multispeed_actions_no_malfunction_blocking():
         )
 
     ]
-    run_replay_config(env, test_configs, skip_reward_check=False, skip_action_required_check=True)
+    run_replay_config(env, test_configs, skip_reward_check=True, skip_action_required_check=True)
 
 
 def test_multispeed_actions_malfunction_no_blocking():

--- a/tests/test_multi_speed.py
+++ b/tests/test_multi_speed.py
@@ -224,7 +224,7 @@ def test_multispeed_actions_no_malfunction_blocking():
                   rewards=Rewards()
                   )
     env.reset()
-    CRASH_PENALTY = -5
+    CRASH_PENALTY = 5
     env.rewards.crash_penalty_factor = CRASH_PENALTY
 
     test_configs = [

--- a/tests/test_rewards.py
+++ b/tests/test_rewards.py
@@ -39,7 +39,7 @@ def test_rewards_early_arrival():
 
 def test_rewards_intermediate_not_served_penalty():
     rewards = Rewards()
-    rewards.intermediate_not_served_penalty = -33
+    rewards.intermediate_not_served_penalty = 33
     agent = EnvAgent(initial_position=(0, 0),
                      initial_direction=5,
                      target=(3, 3),


### PR DESCRIPTION
## Changes

* Remove obsolete parameters in rewards function
* Update documentation in line with [math formulation](https://github.com/flatland-association/flatland-book/pull/17).
* Remove stale end-of-episode reward handling as moved to rewards.py.

## Related issues

Link to every issue from the issue tracker (if any) you addressed in this PR.

## Checklist

- [ ] Tests are included for relevant behavior changes.
- [x] Documentation is added in the [flatland-book](https://github.com/flatland-association/flatland-book) repo for relevant behavior changes.
- [ ] If you made important user-facing changes, describe them under the `[Unreleased]` tag in `CHANGELOG.md`.
- [ ] New package dependencies are declared in the `pyproject.toml` file.
  Requirement files have been updated by running `tox -e requirements`.
- [ ] Code works with all supported Python versions (3.10, 3.11 and 3.12). Checks run with all three version and are
  required to run successfully.
- [ ] Code is formatted according to PEP 8 (an IDE like PyCharm can do this for you).
- [ ] Technical guidelines listed in `CONTRIBUTING.md` are followed.
