### PR TITLE
Fix passing observation builder to RailEnv in FlatlandRemoteClient.

### DIFF
--- a/flatland/envs/persistence.py
+++ b/flatland/envs/persistence.py
@@ -1,5 +1,5 @@
 import pickle
-from typing import Tuple, Dict
+from typing import Tuple, Dict, Optional
 
 import msgpack
 import msgpack_numpy
@@ -11,7 +11,7 @@ from flatland.envs.rail_grid_transition_map import RailGridTransitionMap
 from flatland.envs import rail_env
 from flatland.envs.step_utils import env_utils
 from flatland.utils.seeding import random_state_to_hashablestate
-from flatland.core.env_observation_builder import DummyObservationBuilder
+from flatland.core.env_observation_builder import DummyObservationBuilder, ObservationBuilder
 from flatland.envs.agent_utils import EnvAgent, load_env_agent
 
 # cannot import objects / classes directly because of circular import
@@ -101,7 +101,7 @@ class RailEnvPersister(object):
         cls.set_full_state(env, env_dict)
 
     @classmethod
-    def load_new(cls, filename, load_from_package=None) -> Tuple["RailEnv", Dict]:
+    def load_new(cls, filename, load_from_package=None, obs_builder_object: Optional[ObservationBuilder[rail_env.RailEnv]] = None) -> Tuple["RailEnv", Dict]:
 
         env_dict = cls.load_env_dict(filename, load_from_package=load_from_package)
 
@@ -109,6 +109,8 @@ class RailEnvPersister(object):
         height = len(llGrid)
         width = len(llGrid[0])
 
+        if obs_builder_object is None:
+            obs_builder_object = DummyObservationBuilder()
         # TODO: inefficient - each one of these generators loads the complete env file.
         env = rail_env.RailEnv(
             width=width, height=height,
@@ -120,7 +122,7 @@ class RailEnvPersister(object):
             # malfunction_generator_and_process_data=mal_gen.malfunction_from_file(filename,
             #    load_from_package=load_from_package),
             malfunction_generator=mal_gen.FileMalfunctionGen(env_dict),
-            obs_builder_object=DummyObservationBuilder(),
+            obs_builder_object=obs_builder_object,
             record_steps=True)
 
         env.rail = RailGridTransitionMap(1, 1)  # dummy

--- a/flatland/envs/persistence.py
+++ b/flatland/envs/persistence.py
@@ -101,7 +101,7 @@ class RailEnvPersister(object):
         cls.set_full_state(env, env_dict)
 
     @classmethod
-    def load_new(cls, filename, load_from_package=None, obs_builder_object: Optional[ObservationBuilder[rail_env.RailEnv]] = None) -> Tuple["RailEnv", Dict]:
+    def load_new(cls, filename, load_from_package=None, obs_builder_object: Optional[ObservationBuilder["RailEnv"]] = None) -> Tuple["RailEnv", Dict]:
 
         env_dict = cls.load_env_dict(filename, load_from_package=load_from_package)
 

--- a/flatland/evaluators/client.py
+++ b/flatland/evaluators/client.py
@@ -266,7 +266,7 @@ class FlatlandRemoteClient(object):
         if self.verbose:
             print("Current env path : ", test_env_file_path)
         self.current_env_path = test_env_file_path
-        self.env, _ = RailEnvPersister.load_new(test_env_file_path)
+        self.env, _ = RailEnvPersister.load_new(test_env_file_path, obs_builder_object=obs_builder_object)
 
         time_start = time.time()
         # Use the local observation

--- a/flatland/trajectories/trajectories.py
+++ b/flatland/trajectories/trajectories.py
@@ -318,7 +318,7 @@ class Trajectory:
             for handle, action in action_dict.items():
                 trajectory.action_collect(actions, env_time=env_time, agent_id=handle, action=action)
 
-            _, _, dones, _ = env.step(action_dict)
+            observations, _, dones, _ = env.step(action_dict)
 
             for agent_id in range(n_agents):
                 agent = env.agents[agent_id]


### PR DESCRIPTION
## Changes

Fix passing observation builder to RailEnv in FlatlandRemoteClient.

## Related issues

Bug introduced in https://github.com/flatland-association/flatland-rl/pull/136/files

## Checklist

- [ ] Tests are included for relevant behavior changes.
- [ ] Documentation is added in the [flatland-book](https://github.com/flatland-association/flatland-book) repo for relevant behavior changes.
- [ ] If you made important user-facing changes, describe them under the `[Unreleased]` tag in `CHANGELOG.md`.
- [ ] New package dependencies are declared in the `pyproject.toml` file.
  Requirement files have been updated by running `tox -e requirements`.
- [ ] Code works with all supported Python versions (3.10, 3.11 and 3.12). Checks run with all three version and are
  required to run successfully.
- [ ] Code is formatted according to PEP 8 (an IDE like PyCharm can do this for you).
- [ ] Technical guidelines listed in `CONTRIBUTING.md` are followed.
