### PR TITLE
Drop pkg_resources as it is deprecated and removed in Python 3.12.

### DIFF
--- a/benchmarks/flatland_performance_profiling.ipynb
+++ b/benchmarks/flatland_performance_profiling.ipynb
@@ -15,7 +15,6 @@
     "import os\n",
     "\n",
     "import importlib_resources\n",
-    "import pkg_resources\n",
     "from importlib_resources import path\n",
     "from pstats import Stats\n",
     "import pandas as pd\n",

--- a/benchmarks/profile_all_examples.py
+++ b/benchmarks/profile_all_examples.py
@@ -44,6 +44,7 @@ def profile_all_examples():
                   and str(entry).endswith(".py")
                   and '__init__' not in str(entry)
                   and 'DELETE' not in str(entry)
+                  and 'flatland_performance_profiling' not in str(entry)
                   ]:
         profile('examples', entry.name)
 

--- a/benchmarks/profile_all_examples.py
+++ b/benchmarks/profile_all_examples.py
@@ -6,7 +6,6 @@ import traceback
 from io import StringIO
 
 import importlib_resources
-import pkg_resources
 from importlib_resources import path
 
 from benchmarks.benchmark_utils import swap_attr
@@ -40,13 +39,13 @@ def profile(resource, entry):
 
 
 def profile_all_examples():
-    for entry in [entry for entry in importlib_resources.contents('examples') if
-                  not pkg_resources.resource_isdir('examples', entry)
-                  and entry.endswith(".py")
-                  and '__init__' not in entry
-                  and 'DELETE' not in entry
+    for entry in [entry for entry in importlib_resources.files('examples').iterdir() if
+                  not importlib_resources.files('examples').joinpath(str(entry)).is_dir()
+                  and str(entry).endswith(".py")
+                  and '__init__' not in str(entry)
+                  and 'DELETE' not in str(entry)
                   ]:
-        profile('examples', entry)
+        profile('examples', entry.name)
 
 
 if __name__ == '__main__':

--- a/benchmarks/run_all_examples.py
+++ b/benchmarks/run_all_examples.py
@@ -4,7 +4,6 @@ import traceback
 from io import StringIO
 
 import importlib_resources
-import pkg_resources
 from importlib_resources import path
 
 from benchmarks.benchmark_utils import swap_attr
@@ -13,13 +12,13 @@ from benchmarks.benchmark_utils import swap_attr
 def run_all_examples():
     print("run_all_examples.py")
     error_log_examples = {}
-    for entry in [entry for entry in importlib_resources.contents('examples') if
-                  not pkg_resources.resource_isdir('examples', entry)
-                  and entry.endswith(".py")
-                  and '__init__' not in entry
-                  and 'DELETE' not in entry
+    for entry in [entry for entry in importlib_resources.files('examples').iterdir() if
+                  not importlib_resources.files('examples').joinpath(str(entry)).is_dir()
+                  and str(entry).endswith(".py")
+                  and '__init__' not in str(entry)
+                  and 'DELETE' not in str(entry)
                   ]:
-        with path('examples', entry) as file_in:
+        with path('examples', entry.name) as file_in:
             print("")
             print("")
 

--- a/benchmarks/run_all_examples.py
+++ b/benchmarks/run_all_examples.py
@@ -17,6 +17,7 @@ def run_all_examples():
                   and str(entry).endswith(".py")
                   and '__init__' not in str(entry)
                   and 'DELETE' not in str(entry)
+                  and 'flatland_performance_profiling' not in str(entry)
                   ]:
         with path('examples', entry.name) as file_in:
             print("")
@@ -46,6 +47,7 @@ def run_all_examples():
         print("*****************************************************************")
         print(error_log_examples)
         print("*****************************************************************")
+        raise Exception("Some examples failed.")
     else:
         print("*****************************************************************")
         print("All examples executed - no error.")

--- a/examples/custom_railmap_example.py
+++ b/examples/custom_railmap_example.py
@@ -8,15 +8,15 @@ import numpy as np
 
 from flatland.core.env_observation_builder import DummyObservationBuilder
 from flatland.core.grid.rail_env_grid import RailEnvTransitions
-from flatland.core.transition_map import GridTransitionMap
 from flatland.envs.line_generators import sparse_line_generator
 from flatland.envs.rail_env import RailEnv
 from flatland.envs.rail_generators import rail_from_grid_transition_map
+from flatland.envs.rail_grid_transition_map import RailGridTransitionMap
 from flatland.utils.misc import str2bool
 from flatland.utils.rendertools import RenderTool
 
 
-def custom_rail_map() -> Tuple[GridTransitionMap, np.array]:
+def custom_rail_map() -> Tuple[RailGridTransitionMap, np.array]:
     # We instantiate a very simple rail network on a 7x10 grid:
     #  0 1 2 3 4 5 6 7 8 9  10
     # 0        /-------------\
@@ -54,8 +54,8 @@ def custom_rail_map() -> Tuple[GridTransitionMap, np.array]:
         [[empty] * 6 + [simple_switch_north_right] + [horizontal_straight] * 2 + [right_turn_from_north]] +
         [[empty] * 6 + [vertical_straight] + [empty] * 3] +
         [[empty] * 6 + [dead_end_from_north] + [empty] * 3], dtype=np.uint16)
-    rail = GridTransitionMap(width=rail_map.shape[1],
-                             height=rail_map.shape[0], transitions=transitions)
+    rail = RailGridTransitionMap(width=rail_map.shape[1],
+                                 height=rail_map.shape[0], transitions=transitions)
     rail.grid = rail_map
     city_positions = [(0, 3), (6, 6)]
     train_stations = [

--- a/flatland/utils/graphics_pgl.py
+++ b/flatland/utils/graphics_pgl.py
@@ -1,13 +1,13 @@
-
-import pyglet as pgl
 import time
 
+import pyglet as pgl
 from PIL import Image
-# from numpy import array
-# from pkg_resources import resource_string as resource_bytes
 
 # from flatland.utils.graphics_layer import GraphicsLayer
 from flatland.utils.graphics_pil import PILSVG
+
+
+# from numpy import array
 
 
 class PGLGL(PILSVG):
@@ -22,34 +22,31 @@ class PGLGL(PILSVG):
         print("open_window - pyglet")
         assert self.window_open is False, "Window is already open!"
         self.window = pgl.window.Window(resizable=True, vsync=False, width=1200, height=800)
-        #self.__class__.window.title("Flatland")
-        #self.__class__.window.configure(background='grey')
+        # self.__class__.window.title("Flatland")
+        # self.__class__.window.configure(background='grey')
         self.window_open = True
-
 
         @self.window.event
         def on_draw():
-            #print("pyglet draw event")
+            # print("pyglet draw event")
             self.window.clear()
             self.show(from_event=True)
-            #print("pyglet draw event done")
-            
+            # print("pyglet draw event done")
 
         @self.window.event
         def on_resize(width, height):
-            #print(f"The window was resized to {width}, {height}")
+            # print(f"The window was resized to {width}, {height}")
             self.show(from_event=True)
             self.window.dispatch_event("on_draw")
-            #print("pyglet resize event done")
+            # print("pyglet resize event done")
 
         @self.window.event
         def on_close():
             self.close_requested = True
 
-
     def close_window(self):
         self.window.close()
-        self.closed=True
+        self.closed = True
 
     def show(self, block=False, from_event=False):
         if not self.window_open:
@@ -59,8 +56,8 @@ class PGLGL(PILSVG):
             if not self.closed:
                 self.close_window()
             return
-            
-        #tStart = time.time()
+
+        # tStart = time.time()
         self._processEvents()
 
         pil_img = self.alpha_composite_layers()
@@ -69,41 +66,39 @@ class PGLGL(PILSVG):
         # convert our PIL image to pyglet:
         bytes_image = pil_img_resized.tobytes()
         pgl_image = pgl.image.ImageData(pil_img_resized.width, pil_img_resized.height,
-            #self.window.width, self.window.height, 
-            'RGBA',
-            bytes_image, pitch=-pil_img_resized.width * 4)
+                                        # self.window.width, self.window.height,
+                                        'RGBA',
+                                        bytes_image, pitch=-pil_img_resized.width * 4)
 
-        pgl_image.blit(0,0)
-        #tEnd = time.time()
-        #print("show time: ", tEnd - tStart)
+        pgl_image.blit(0, 0)
+        # tEnd = time.time()
+        # print("show time: ", tEnd - tStart)
 
     def _processEvents(self):
         """ This is the replacement for a custom event loop for Pyglet.
             The lines below are typical of Pyglet examples.
             Manually resizing the window is still very clunky.
         """
-        #print("process events...", end="")
+        # print("process events...", end="")
         pgl.clock.tick()
-        #for window in pgl.app.windows:
+        # for window in pgl.app.windows:
         if not self.closed:
             self.window.switch_to()
             self.window.dispatch_events()
             self.window.flip()
-        #print(" events done")
-        
-        
+        # print(" events done")
 
     def idle(self, seconds=0.00001):
         tStart = time.time()
         tEnd = tStart + seconds
         while (time.time() < tEnd):
             self._processEvents()
-            #self.show()
+            # self.show()
             time.sleep(min(seconds, 0.1))
 
 
 def test_pyglet():
-    oGL = PGLGL(400,300)
+    oGL = PGLGL(400, 300)
     time.sleep(2)
 
 
@@ -112,7 +107,6 @@ def test_event_loop():
         Resizing is fairly smooth (ie runs at least 10-20x a second)
     """
 
-
     window = pgl.window.Window(resizable=True)
     pil_img = Image.open("notebooks/simple_example_3.png")
 
@@ -120,10 +114,10 @@ def test_event_loop():
         pil_img_resized = pil_img.resize((window.width, window.height), resample=Image.NEAREST)
         bytes_image = pil_img_resized.tobytes()
         pgl_image = pgl.image.ImageData(pil_img_resized.width, pil_img_resized.height,
-            #self.window.width, self.window.height, 
-            'RGBA',
-            bytes_image, pitch=-pil_img_resized.width * 4)
-        pgl_image.blit(0,0)
+                                        # self.window.width, self.window.height,
+                                        'RGBA',
+                                        bytes_image, pitch=-pil_img_resized.width * 4)
+        pgl_image.blit(0, 0)
 
     @window.event
     def on_draw():
@@ -131,22 +125,21 @@ def test_event_loop():
         window.clear()
         show()
         print("pyglet draw event done")
-            
 
         @window.event
         def on_resize(width, height):
             print(f"The window was resized to {width}, {height}")
-            #show()
+            # show()
             print("pyglet resize event done")
 
         @window.event
         def on_close():
-            #self.close_requested = True
+            # self.close_requested = True
             print("close")
-    
+
     pgl.app.run()
 
 
-if __name__=="__main__":
-    #test_pyglet()
+if __name__ == "__main__":
+    # test_pyglet()
     test_event_loop()

--- a/flatland/utils/graphics_pil.py
+++ b/flatland/utils/graphics_pil.py
@@ -1,16 +1,16 @@
 import io
-import os
 import time
-#import tkinter as tk
 
+import importlib_resources
 import numpy as np
 from PIL import Image, ImageDraw, ImageFont
 from numpy import array
-from pkg_resources import resource_string as resource_bytes
-
-from flatland.utils.graphics_layer import GraphicsLayer
 
 from flatland.core.grid.rail_env_grid import RailEnvTransitions  # noqa: E402
+from flatland.utils.graphics_layer import GraphicsLayer
+
+
+# import tkinter as tk
 
 
 class PILGL(GraphicsLayer):
@@ -184,7 +184,7 @@ class PILGL(GraphicsLayer):
         self.create_layer(iLayer=PILGL.PREDICTION_PATH_LAYER, clear=True)
 
     def show(self, block=False):
-        #print("show() - ", self.__class__)
+        # print("show() - ", self.__class__)
         pass
 
     def pause(self, seconds=0.00001):
@@ -257,6 +257,7 @@ class PILSVG(PILGL):
     but for backward compatibility, and to not introduce any breaking changes at this point
     we are sticking to the legacy name of PILSVG (when in practice we are not using SVG anymore)
     """
+
     def __init__(self, width, height, jupyter=False, screen_width=800, screen_height=600):
         oSuper = super()
         oSuper.__init__(width, height, jupyter, screen_width, screen_height)
@@ -283,7 +284,7 @@ class PILSVG(PILGL):
         self.agents_prev = []
 
     def pil_from_png_file(self, package, resource):
-        bytestring = resource_bytes(package, resource)
+        bytestring = importlib_resources.files(package).joinpath(resource).read_bytes()
         with io.BytesIO(bytestring) as fIn:
             pil_img = Image.open(fIn)
             pil_img.load()

--- a/notebooks/run_all_notebooks.py
+++ b/notebooks/run_all_notebooks.py
@@ -3,9 +3,8 @@ import sys
 from subprocess import Popen, PIPE
 
 import importlib_resources
-import pkg_resources
-from importlib_resources import path
 import importlib_resources as ir
+from importlib_resources import path
 from ipython_genutils.py3compat import string_types, bytes_to_str
 
 
@@ -40,22 +39,21 @@ def run_python(parameters, ignore_return_code=False, stdin=None):
 
 
 def main():
-
     # If the file notebooks-list exists, use it as a definitive list of notebooks to run
     # This in effect ignores any local notebooks you might be working on, so you can run tox
     # without them causing the notebooks task / testenv to fail.
     if importlib_resources.is_resource("notebooks", "notebook-list"):
         print("Using the notebooks-list file to designate which notebooks to run")
         lsNB = [
-            sLine for sLine in ir.read_text("notebooks", "notebook-list").split("\n") 
+            sLine for sLine in ir.read_text("notebooks", "notebook-list").split("\n")
             if len(sLine) > 3 and not sLine.startswith("#")
-            ]
+        ]
     else:
         lsNB = [
-            entry for entry in importlib_resources.contents('notebooks') if
-                not pkg_resources.resource_isdir('notebooks', entry)
-                and entry.endswith(".ipynb")
-                ]
+            entry for entry in importlib_resources.files('notebooks').iterdir() if
+            not importlib_resources.files('notebooks').joinpath(str(entry)).is_dir()
+            and str(entry).endswith(".ipynb")
+        ]
 
     print("Running notebooks:", " ".join(lsNB))
 
@@ -65,12 +63,13 @@ def main():
         print("*****************************************************************")
 
         with path('notebooks', entry) as file_in:
-            out, err = run_python(" -m jupyter nbconvert --ExecutePreprocessor.timeout=120 " + 
-                "--execute --to notebook --inplace " + str(file_in))
+            out, err = run_python(" -m jupyter nbconvert --ExecutePreprocessor.timeout=120 " +
+                                  "--execute --to notebook --inplace " + str(file_in))
             sys.stderr.write(err)
             sys.stderr.flush()
             sys.stdout.write(out)
             sys.stdout.flush()
+
 
 if __name__ == "__main__":
     main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,8 +45,6 @@ dependencies = [
     "recordtype",
     "redis",
     "seaborn",
-    # https://docs.python.org/3/whatsnew/3.12.html: Python 3.12 has removed pkg_resources from the standard library (moved to setuptools):
-    "setuptools",
     "tqdm",
     "svgutils",
     "timeout_decorator",


### PR DESCRIPTION
## Changes

Drop pkg_resources as it is deprecated and removed in Python 3.12.

## Related issues

Closes #128 .

## Checklist

- [ ] Tests are included for relevant behavior changes.
- [ ] Documentation is added in the [flatland-book](https://github.com/flatland-association/flatland-book) repo for relevant behavior changes.
- [ ] If you made important user-facing changes, describe them under the `[Unreleased]` tag in `CHANGELOG.md`.
- [ ] New package dependencies are declared in the `pyproject.toml` file.
  Requirement files have been updated by running `tox -e requirements`.
- [ ] Code works with all supported Python versions (3.10, 3.11 and 3.12). Checks run with all three version and are
  required to run successfully.
- [ ] Code is formatted according to PEP 8 (an IDE like PyCharm can do this for you).
- [ ] Technical guidelines listed in `CONTRIBUTING.md` are followed.
