### PR TITLE
Fix path type conversion trajectory API cli.

### DIFF
--- a/flatland/evaluators/trajectory_evaluator.py
+++ b/flatland/evaluators/trajectory_evaluator.py
@@ -111,7 +111,7 @@ class TrajectoryEvaluator:
 
 @click.command()
 @click.option('--data-dir',
-              type=click.Path(exists=True),
+              type=click.Path(exists=True, path_type=Path),
               help="Path to folder containing Flatland episode",
               required=True
               )

--- a/flatland/trajectories/trajectories.py
+++ b/flatland/trajectories/trajectories.py
@@ -345,7 +345,7 @@ class Trajectory:
 
 @click.command()
 @click.option('--data-dir',
-              type=click.Path(exists=True),
+              type=click.Path(exists=True, path_type=Path),
               help="Path to folder containing Flatland episode",
               required=True
               )

--- a/tests/trajectories/test_trajectories.py
+++ b/tests/trajectories/test_trajectories.py
@@ -85,7 +85,8 @@ def test_cli_from_submission():
     with tempfile.TemporaryDirectory() as tmpdirname:
         data_dir = Path(tmpdirname)
         with pytest.raises(SystemExit) as e_info:
-            generate_trajectory_from_policy(["--data-dir", data_dir, "--policy-pkg", "tests.trajectories.test_trajectories", "--policy-cls", "RandomPolicy"])
+            generate_trajectory_from_policy(
+                ["--data-dir", str(data_dir), "--policy-pkg", "tests.trajectories.test_trajectories", "--policy-cls", "RandomPolicy"])
         assert e_info.value.code == 0
 
         ep_id = re.sub(r"_step.*", "", str(next((data_dir / SERIALISED_STATE_SUBDIR).glob("*step*.pkl")).name))
@@ -105,7 +106,7 @@ def test_cli_from_submission():
         assert "episode_id	env_time	agent_id	position" in (data_dir / TRAINS_POSITIONS_FNAME).read_text()
 
         with pytest.raises(SystemExit) as e_info:
-            evaluate_trajectory(["--data-dir", data_dir, "--ep-id", ep_id])
+            evaluate_trajectory(["--data-dir", str(data_dir), "--ep-id", ep_id])
         assert e_info.value.code == 0
 
 


### PR DESCRIPTION
## Changes

Fix path type conversion trajectory API cli and supporting tests.

## Related issues

Link to every issue from the issue tracker (if any) you addressed in this PR.

## Checklist

- [ ] Tests are included for relevant behavior changes.
- [ ] Documentation is added in the [flatland-book](https://github.com/flatland-association/flatland-book) repo for relevant behavior changes.
- [ ] If you made important user-facing changes, describe them under the `[Unreleased]` tag in `CHANGELOG.md`.
- [ ] New package dependencies are declared in the `pyproject.toml` file.
  Requirement files have been updated by running `tox -e requirements`.
- [ ] Code works with all supported Python versions (3.10, 3.11, 3.12 and 3.13). Checks run with all supported version and are
  required to run successfully.
- [ ] Code is formatted according to PEP 8 (an IDE like PyCharm can do this for you).
- [ ] Technical guidelines listed in `CONTRIBUTING.md` are followed.
