### PR TITLE
refactor: revert version pinning flatland-baselines.

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -245,9 +245,8 @@ jobs:
                     unzip FLATLAND_BENCHMARK_EPISODES_FOLDER -d episodes
                 working-directory: ${{ github.workspace }}
             -   name: Clone flatland-baselines
-                # TODO temporary workaround till https://github.com/flatland-association/flatland-baselines/pull/13
                 run: |
-                    git clone https://github.com/flatland-association/flatland-baselines.git@244-policy-act-no-handle
+                    git clone https://github.com/flatland-association/flatland-baselines.git
             -   name: Install tox
                 run: |
                     python -m pip install --upgrade pip


### PR DESCRIPTION

## Changes

Revert temporary workaround for circular dependency with flatland-baselines.

## Related issues

#244 #255 


## Checklist

- [ ] Tests are included for relevant behavior changes.
- [ ] Documentation is added in the [flatland-book](https://github.com/flatland-association/flatland-book) repo for relevant behavior changes.
- [ ] If you made important user-facing changes, describe them under the `[Unreleased]` tag in `CHANGELOG.md`.
- [ ] New package dependencies are declared in the `pyproject.toml` file.
  Requirement files have been updated by running `tox -e requirements`.
- [ ] Code works with all supported Python versions (3.10, 3.11, 3.12 and 3.13). Checks run with all supported version and are
  required to run successfully.
- [ ] Code is formatted according to PEP 8 (an IDE like PyCharm can do this for you).
- [ ] Technical guidelines listed in `CONTRIBUTING.md` are followed.
