### PR TITLE
fix(env-generator): avoid division by zero.

### DIFF
--- a/flatland/env_generation/env_generator.py
+++ b/flatland/env_generation/env_generator.py
@@ -1,3 +1,4 @@
+import sys
 from typing import Tuple, Dict, Optional
 
 from flatland.core.effects_generator import EffectsGenerator
@@ -86,6 +87,10 @@ def env_generator(n_agents=7,
         speed_ratios = {1.0: 0.25, 0.5: 0.25, 0.33: 0.25, 0.25: 0.25}
     if obs_builder_object is None:
         obs_builder_object = TreeObsForRailEnv(max_depth=3, predictor=ShortestPathPredictorForRailEnv(max_depth=50))
+
+    # avoid division by zero.
+    if malfunction_interval is None or malfunction_interval == 0:
+        malfunction_interval = sys.maxsize
 
     env = RailEnv(
         width=x_dim,


### PR DESCRIPTION
## Changes

* Avoid division by zero when `malfunction_interval=0`.

## Related issues
`0` coming from metadata.csv, see https://github.com/flatland-association/flatland-benchmarks-f3-starterkit/pull/11/checks

## Checklist

- [ ] Tests are included for relevant behavior changes.
- [ ] Documentation is added in the [flatland-book](https://github.com/flatland-association/flatland-book) repo for relevant behavior changes.
- [ ] If you made important user-facing changes, describe them under the `[Unreleased]` tag in `CHANGELOG.md`.
- [ ] New package dependencies are declared in the `pyproject.toml` file.
  Requirement files have been updated by running `tox -e requirements`.
- [ ] Code works with all supported Python versions (3.10, 3.11, 3.12 and 3.13). Checks run with all supported version and are
  required to run successfully.
- [ ] Code is formatted according to PEP 8 (an IDE like PyCharm can do this for you).
- [ ] Technical guidelines listed in `CONTRIBUTING.md` are followed.
