### PR TITLE
fix: correct waypoint tracking in DefaultRewards

### DIFF
--- a/flatland/envs/rewards.py
+++ b/flatland/envs/rewards.py
@@ -149,9 +149,12 @@ class DefaultRewards(Rewards[float]):
             old_wp = Waypoint(agent.old_position, agent.old_direction)
             if wp not in self.arrivals[agent.handle]:
                 self.arrivals[agent.handle][wp] = elapsed_steps
-                # Only record departure from old position if we actually moved
-                if old_wp != wp:
+                # Only record departure from old position when we arrive from on-map position
+                if old_wp.position is not None:
                     self.departures[agent.handle][old_wp] = elapsed_steps
+        elif agent.old_position is not None:
+            old_wp = Waypoint(agent.old_position, agent.old_direction)
+            self.departures[agent.handle][old_wp] = elapsed_steps
 
         if agent.state_machine.previous_state == TrainState.MOVING and agent.state == TrainState.STOPPED and not agent_transition_data.state_transition_signal.stop_action_given:
             reward += -1 * agent_transition_data.speed * self.crash_penalty_factor


### PR DESCRIPTION
Fix type mismatch where `agent.position` (tuple) was compared against `Waypoint` object keys, causing arrivals to be recorded every step instead of once per waypoint.






## Changes
- Create `Waypoint` object before comparison
- Only record arrival for new waypoints
- Only record departure when agent actually moves
- Add 3 tests verifying the fix

## Related issues

Fixes #327

## Checklist

- [x] Tests are included for relevant behavior changes.
- [ ] Documentation is added in the [flatland-book](https://github.com/flatland-association/flatland-book) repo for relevant behavior changes.
- [ ] If you made important user-facing changes, describe them under the `[Unreleased]` tag in `CHANGELOG.md`.
- [ ] New package dependencies are declared in the `pyproject.toml` file.
  Requirement files have been updated by running `tox -e requirements`.
- [ ] Code works with all supported Python versions (3.10, 3.11, 3.12 and 3.13). Checks run with all supported version and are
  required to run successfully.
- [x] Code is formatted according to PEP 8 (an IDE like PyCharm can do this for you).
- [x] Technical guidelines listed in `CONTRIBUTING.md` are followed.
