### PR TITLE
feat: add cutoff option to k shortest paths.

### DIFF
--- a/flatland/envs/rail_env_shortest_paths.py
+++ b/flatland/envs/rail_env_shortest_paths.py
@@ -17,6 +17,7 @@ def get_k_shortest_paths(env: "RailEnv",
                          k: int = 1, debug=False,
                          target_direction: int = None,
                          rail: GridTransitionMap = None,
+                         cutoff: int = None,
                          ) -> List[Tuple[Waypoint]]:
     """
     Computes the k shortest paths using modified Dijkstra
@@ -33,14 +34,15 @@ def get_k_shortest_paths(env: "RailEnv",
         max number of shortest paths
     debug:            bool
         print debug statements
-
+    target_direction: Optional[Tuple[int,int]]
+    cutoff :          Optional[int]
+        do not consider paths longer than cutoff
     Returns
     -------
     List[Tuple[WalkingElement]]
         We use tuples since we need the path elements to be hashable.
         We use a list of paths in order to keep the order of length.
     """
-
     if env is not None:
         rail = env.rail
     else:
@@ -115,6 +117,8 @@ def get_k_shortest_paths(env: "RailEnv",
 
                     # – let Pv be a new path with cost C + w(u, v) formed by concatenating edge (u, v) to path Pu
                     pv = pu + (v,)
+                    if cutoff is not None and len(pv) > cutoff:
+                        continue
                     #     – insert Pv into B
                     heap.add(pv)
 


### PR DESCRIPTION
## Changes

* add `cutoff` option to `get_k_shortest_paths` to limit search scope.

## Related issues

Link to every issue from the issue tracker (if any) you addressed in this PR.

## Checklist

- [ ] Tests are included for relevant behavior changes.
- [ ] Documentation is added in the [flatland-book](https://github.com/flatland-association/flatland-book) repo for relevant behavior changes.
- [ ] If you made important user-facing changes, describe them under the `[Unreleased]` tag in `CHANGELOG.md`.
- [ ] New package dependencies are declared in the `pyproject.toml` file.
  Requirement files have been updated by running `tox -e requirements`.
- [ ] Code works with all supported Python versions (3.10, 3.11, 3.12 and 3.13). Checks run with all supported version and are
  required to run successfully.
- [ ] Code is formatted according to PEP 8 (an IDE like PyCharm can do this for you).
- [ ] Technical guidelines listed in `CONTRIBUTING.md` are followed.
