### PR TITLE
feat: ignore paths leading out of the grid in `get_k_shortest_paths`.

### DIFF
--- a/flatland/envs/rail_env_shortest_paths.py
+++ b/flatland/envs/rail_env_shortest_paths.py
@@ -24,6 +24,9 @@ def get_k_shortest_paths(env: "RailEnv",
     following pseudo-code https://en.wikipedia.org/wiki/K_shortest_path_routing
     In contrast to the pseudo-code in wikipedia, we do not a allow for loopy paths.
 
+    A `cutoff` can be defined optionally to limit search.
+    If the grid is not closed under transitions, then paths going out of the grid are ignored.
+
     Parameters
     ----------
     env :             RailEnv
@@ -117,7 +120,17 @@ def get_k_shortest_paths(env: "RailEnv",
 
                     # – let Pv be a new path with cost C + w(u, v) formed by concatenating edge (u, v) to path Pu
                     pv = pu + (v,)
+
+                    # ignore if cutoff reached
                     if cutoff is not None and len(pv) > cutoff:
+                        if debug:
+                            print(f"        ignoring v={v} as out cutoff {cutoff} reached.")
+                        continue
+                    # ignore if out of bounds
+                    r, c = v.position
+                    if r >= height or r < 0 or c >= width or c < 0:
+                        if debug:
+                            print(f"        ignoring v={v} as out out bounds ({height, width}).")
                         continue
                     #     – insert Pv into B
                     heap.add(pv)


### PR DESCRIPTION
## Changes

* feat: ignore paths leading out of the grid in `get_k_shortest_paths`.

## Related issues

Link to every issue from the issue tracker (if any) you addressed in this PR.

## Checklist

- [ ] Tests are included for relevant behavior changes.
- [ ] Documentation is added in the [flatland-book](https://github.com/flatland-association/flatland-book) repo for relevant behavior changes.
- [ ] If you made important user-facing changes, describe them under the `[Unreleased]` tag in `CHANGELOG.md`.
- [ ] New package dependencies are declared in the `pyproject.toml` file.
  Requirement files have been updated by running `tox -e requirements`.
- [ ] Code works with all supported Python versions (3.10, 3.11, 3.12 and 3.13). Checks run with all supported version and are
  required to run successfully.
- [ ] Code is formatted according to PEP 8 (an IDE like PyCharm can do this for you).
- [ ] Technical guidelines listed in `CONTRIBUTING.md` are followed.
