### PR TITLE
ci: bump supercharge/redis-github-action@1.7.0 to 1.8.1.

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -187,7 +187,7 @@ jobs:
                 with:
                     python-version: ${{ matrix.python-version }}
             -   name: Start Redis
-                uses: supercharge/redis-github-action@1.7.0
+                uses: supercharge/redis-github-action@1.8.1
                 with:
                     redis-version: 7.4.2
                     redis-port: 6379


### PR DESCRIPTION
## Changes

* [fix](https://github.com/flatland-association/flatland-rl/actions/runs/21956709277)
```
Starting single-node Redis instance: --name redis --publish 6379:6379 --detach redis:7.4.2
docker: Error response from daemon: client version 1.40 is too old. Minimum supported API version is 1.44, please upgrade your client to a newer version.
See 'docker run --help'.
```

See https://github.blog/changelog/2026-01-30-docker-and-docker-compose-version-upgrades-on-hosted-runners/
> On February 9th, 2026, Docker and Docker Compose will be updated on all Windows and Ubuntu runner images except ubuntu-slim. This update allows you to take advantage of the latest features in these tools.
[New Versions](https://github.blog/changelog/2026-01-30-docker-and-docker-compose-version-upgrades-on-hosted-runners/#new-versions)
>
>    Docker Engine: v29.1
>    Docker Compose: v2.40 (or higher if new v2 minor versions release before our change)
>
> You may need to update your workflows if you rely on Docker functionality [slated for removal in v29](https://docs.docker.com/engine/deprecated/).

## Related issues

Link to every issue from the issue tracker (if any) you addressed in this PR.

## Checklist

- [ ] Tests are included for relevant behavior changes.
- [ ] Documentation is added in the [flatland-book](https://github.com/flatland-association/flatland-book) repo for relevant behavior changes.
- [ ] If you made important user-facing changes, describe them under the `[Unreleased]` tag in `CHANGELOG.md`.
- [ ] New package dependencies are declared in the `pyproject.toml` file.
  Requirement files have been updated by running `tox -e requirements`.
- [ ] Code works with all supported Python versions (3.10, 3.11, 3.12 and 3.13). Checks run with all supported version and are
  required to run successfully.
- [ ] Code is formatted according to PEP 8 (an IDE like PyCharm can do this for you).
- [ ] Technical guidelines listed in `CONTRIBUTING.md` are followed.
