### PR TITLE
refactor(rewards): use generic configuration.

### DIFF
--- a/flatland/envs/rail_trainrun_data_structures.py
+++ b/flatland/envs/rail_trainrun_data_structures.py
@@ -16,7 +16,8 @@ class Waypoint:
     position = field(type=Tuple[int, int])
     direction = field(type=int, converter=lambda d: d if d is None else int(d))
 
-
+    def _to_tuple(self):
+        return self.position, self.direction
 
 
 # A train run is represented by the waypoints traversed and the times of traversal

--- a/flatland/envs/rail_trainrun_data_structures.py
+++ b/flatland/envs/rail_trainrun_data_structures.py
@@ -16,7 +16,7 @@ class Waypoint:
     position = field(type=Tuple[int, int])
     direction = field(type=int, converter=lambda d: d if d is None else int(d))
 
-    def _to_tuple(self):
+    def _to_tuple(self) -> Tuple[Tuple[int, int], int]:
         return self.position, self.direction
 
 

--- a/flatland/envs/rewards.py
+++ b/flatland/envs/rewards.py
@@ -7,7 +7,6 @@ from fastenum import fastenum
 from flatland.core.env_observation_builder import AgentHandle
 from flatland.envs.agent_utils import EnvAgent
 from flatland.envs.grid.distance_map import DistanceMap
-from flatland.envs.rail_trainrun_data_structures import Waypoint
 from flatland.envs.step_utils.env_utils import AgentTransitionData
 from flatland.envs.step_utils.states import TrainState
 
@@ -101,7 +100,10 @@ class DefaultPenalties(fastenum.Enum):
     INTERMEDIATE_EARLY_DEPARTURE = "INTERMEDIATE_EARLY_DEPARTURE"
 
 
-class BaseDefaultRewards(Rewards[Dict[str, float]]):
+ConfigurationType = TypeVar('ConfigurationType')
+
+
+class BaseDefaultRewards(Rewards[Dict[str, float]], Generic[ConfigurationType]):
     r"""
     Reward Function.
 
@@ -156,28 +158,26 @@ class BaseDefaultRewards(Rewards[Dict[str, float]]):
         assert self.cancellation_factor >= 0
         assert self.target_not_reached_minimum_penalty >= 0
         # https://stackoverflow.com/questions/16439301/cant-pickle-defaultdict
-        self.arrivals: Dict[AgentHandle, Dict[Waypoint, List[int]]] = defaultdict(defaultdict_list)
-        self.departures: Dict[AgentHandle, Dict[Waypoint, List[int]]] = defaultdict(defaultdict_list)
-        self.states: Dict[AgentHandle, Dict[Waypoint, Set[TrainState]]] = defaultdict(defaultdict_set)
+        self.arrivals: Dict[AgentHandle, Dict[ConfigurationType, List[int]]] = defaultdict(defaultdict_list)
+        self.departures: Dict[AgentHandle, Dict[ConfigurationType, List[int]]] = defaultdict(defaultdict_list)
+        self.states: Dict[AgentHandle, Dict[ConfigurationType, Set[TrainState]]] = defaultdict(defaultdict_set)
 
     def step_reward(self, agent: EnvAgent, agent_transition_data: AgentTransitionData, distance_map: DistanceMap, elapsed_steps: int) -> Dict[str, float]:
         d = self.empty()
         if agent.current_configuration is not None:
-            wp = Waypoint(agent.position, agent.direction)
-            self.states[agent.handle][wp].add(agent.state)
+
+            self.states[agent.handle][agent.current_configuration].add(agent.state)
 
             # Only record arrival if this is a new waypoint (not dwelling at same position)
             if agent.old_configuration != agent.current_configuration:
-                assert wp is not None
+                assert agent.current_configuration is not None
                 assert elapsed_steps is not None
-                self.arrivals[agent.handle][wp].append(elapsed_steps)
+                self.arrivals[agent.handle][agent.current_configuration].append(elapsed_steps)
                 # Only record departure from old position when we arrive from on-map position
                 if agent.old_configuration is not None:
-                    old_wp = Waypoint(agent.old_position, agent.old_direction)
-                    self.departures[agent.handle][old_wp].append(elapsed_steps)
+                    self.departures[agent.handle][agent.old_configuration].append(elapsed_steps)
         elif agent.old_configuration is not None:
-            old_wp = Waypoint(agent.old_position, agent.old_direction)
-            self.departures[agent.handle][old_wp].append(elapsed_steps)
+            self.departures[agent.handle][agent.old_configuration].append(elapsed_steps)
 
         if agent.state_machine.previous_state == TrainState.MOVING and agent.state == TrainState.STOPPED:
             # agent_transition_data.speed has speed after action is applied at start of step(), not set to 0 upon motion check.
@@ -226,9 +226,9 @@ class BaseDefaultRewards(Rewards[Dict[str, float]]):
                                                                    agent.get_current_delay(elapsed_steps, distance_map))
         for intermediate_alternatives, la, ed in zip(agent.waypoints[1:-1], agent.waypoints_latest_arrival[1:-1],
                                                      agent.waypoints_earliest_departure[1:-1]):
-            agent_arrivals: Set[Waypoint] = set(self.arrivals[agent.handle])
-            intermediate_alternatives: Set[Waypoint] = set(intermediate_alternatives)
-            wps_intersection: Set[Waypoint] = intermediate_alternatives.intersection(agent_arrivals)
+            agent_arrivals: Set[ConfigurationType] = set(self.arrivals[agent.handle])
+            intermediate_alternatives: Set[ConfigurationType] = set(intermediate_alternatives)
+            wps_intersection: Set[ConfigurationType] = intermediate_alternatives.intersection(agent_arrivals)
             if len(wps_intersection) == 0 or TrainState.STOPPED not in self.states[agent.handle][list(wps_intersection)[0]]:
                 # stop not served or served but not stopped
                 d[DefaultPenalties.INTERMEDIATE_NOT_SERVED.value] += -1 * self.intermediate_not_served_penalty
@@ -470,11 +470,11 @@ class PunctualityRewards(Rewards[Tuple[int, int]]):
     def step_reward(self, agent: EnvAgent, agent_transition_data: AgentTransitionData, distance_map: DistanceMap, elapsed_steps: int) -> Tuple[int, int]:
         # N.B. assuming target is only travelled once:
         if agent.current_configuration is None and agent.state_machine.state == TrainState.DONE and agent.old_configuration is not None and agent.old_configuration in agent.targets:
-            self.arrivals[agent.handle][Waypoint(*agent.old_configuration)].append(elapsed_steps)
+            self.arrivals[agent.handle][agent.old_configuration].append(elapsed_steps)
 
         if agent.current_configuration is not None and agent.current_configuration not in self.arrivals[agent.handle]:
-            self.arrivals[agent.handle][Waypoint(*agent.current_configuration)].append(elapsed_steps)
-            self.departures[agent.handle][Waypoint(*agent.old_configuration)].append(elapsed_steps)
+            self.arrivals[agent.handle][agent.current_configuration].append(elapsed_steps)
+            self.departures[agent.handle][agent.old_configuration].append(elapsed_steps)
 
         return 0, 0
 

--- a/flatland/envs/rewards.py
+++ b/flatland/envs/rewards.py
@@ -5,6 +5,7 @@ import numpy as np
 from fastenum import fastenum
 
 from flatland.core.env_observation_builder import AgentHandle
+from flatland.core.grid.grid4 import Grid4TransitionsEnum
 from flatland.envs.agent_utils import EnvAgent
 from flatland.envs.grid.distance_map import DistanceMap
 from flatland.envs.rail_trainrun_data_structures import Waypoint
@@ -530,7 +531,7 @@ class PunctualityRewards(Rewards[Tuple[int, int]]):
 
         target_wps = agent_waypoints[-1]
         # TODO wrong place to explode to set of target configurations - get rid of ((r,c), None) everyhwer
-        target_wps = {(target_wp[0], i) for target_wp in target_wps for i in range(4)}
+        target_wps = {(target_wp[0], d) for target_wp in target_wps for d in Grid4TransitionsEnum}
         # N.B. assuming target is only travelled once:
         if any(target_wp in self.arrivals[agent.handle] for target_wp in target_wps) and any(
             self.arrivals[agent.handle][target_wp][0] <= agent.waypoints_latest_arrival[-1] for target_wp in target_wps if

--- a/flatland/envs/rewards.py
+++ b/flatland/envs/rewards.py
@@ -7,6 +7,7 @@ from fastenum import fastenum
 from flatland.core.env_observation_builder import AgentHandle
 from flatland.envs.agent_utils import EnvAgent
 from flatland.envs.grid.distance_map import DistanceMap
+from flatland.envs.rail_trainrun_data_structures import Waypoint
 from flatland.envs.step_utils.env_utils import AgentTransitionData
 from flatland.envs.step_utils.states import TrainState
 
@@ -79,6 +80,16 @@ class Rewards(Generic[RewardType]):
 
         """
         return None
+
+    # TODO we should drop these methods once EnvAgent.waypoints is also of ConfigurationType instead of Waypoint.
+    @staticmethod
+    def _sanitize_waypoints(agent_waypoints: List[List[Waypoint]]) -> List[List[Tuple[Tuple[int, int], int]]]:
+        agent_waypoints = [[(Rewards._sanitize_waypoint(wp)) for wp in wps] for wps in agent_waypoints]
+        return agent_waypoints
+
+    @staticmethod
+    def _sanitize_waypoint(wp: Waypoint) -> Tuple[Tuple[int, int], int]:
+        return wp._to_tuple() if isinstance(wp, Waypoint) else wp
 
 
 def defaultdict_set():
@@ -224,7 +235,8 @@ class BaseDefaultRewards(Rewards[Dict[str, float]], Generic[ConfigurationType]):
             if agent.state.is_on_map_state():
                 d[DefaultPenalties.TARGET_NOT_REACHED.value] = min(-1 * self.target_not_reached_minimum_penalty,
                                                                    agent.get_current_delay(elapsed_steps, distance_map))
-        for intermediate_alternatives, la, ed in zip(agent.waypoints[1:-1], agent.waypoints_latest_arrival[1:-1],
+        agent_waypoints = self._sanitize_waypoints(agent.waypoints)
+        for intermediate_alternatives, la, ed in zip(agent_waypoints[1:-1], agent.waypoints_latest_arrival[1:-1],
                                                      agent.waypoints_earliest_departure[1:-1]):
             agent_arrivals: Set[ConfigurationType] = set(self.arrivals[agent.handle])
             intermediate_alternatives: Set[ConfigurationType] = set(intermediate_alternatives)
@@ -468,11 +480,18 @@ class PunctualityRewards(Rewards[Tuple[int, int]]):
         self.departures = defaultdict(defaultdict_list)
 
     def step_reward(self, agent: EnvAgent, agent_transition_data: AgentTransitionData, distance_map: DistanceMap, elapsed_steps: int) -> Tuple[int, int]:
-        # N.B. assuming target is only travelled once:
-        if agent.current_configuration is None and agent.state_machine.state == TrainState.DONE and agent.old_configuration is not None and agent.old_configuration in agent.targets:
-            self.arrivals[agent.handle][agent.old_configuration].append(elapsed_steps)
+        agent_targets = agent.targets
+        # TODO wrong place to explode to set of target configurations - get rid of ((r,c), None) everyhwer
+        if len(agent_targets) == 1 and agent_targets[0][1] is None:
+            agent_targets = [(agent_targets[0][0], i) for i in range(4)]
+        # N.B. assuming target is only travelled once
+        # TODO revise design -  target configurations have no arrival - should we change that?
+        if agent.current_configuration is None and agent.state_machine.state == TrainState.DONE and agent.old_configuration is not None and not any(
+            target_configuration in self.arrivals[agent.handle] for target_configuration in agent_targets):
+            # TODO bad design smell - we haven't kept track of which one was reach, we take any of them here
+            self.arrivals[agent.handle][next(target_configuration for target_configuration in agent_targets)].append(elapsed_steps)
 
-        if agent.current_configuration is not None and agent.current_configuration not in self.arrivals[agent.handle]:
+        if agent.current_configuration is not None and agent.current_configuration not in self.arrivals[agent.handle][agent.current_configuration]:
             self.arrivals[agent.handle][agent.current_configuration].append(elapsed_steps)
             self.departures[agent.handle][agent.old_configuration].append(elapsed_steps)
 
@@ -480,8 +499,11 @@ class PunctualityRewards(Rewards[Tuple[int, int]]):
 
     def end_of_episode_reward(self, agent: EnvAgent, distance_map: DistanceMap, elapsed_steps: int) -> Tuple[int, int]:
         n_stops_on_time = 0
+        agent_waypoints = self._sanitize_waypoints(agent.waypoints)
         # by design, initial waypoint is unique
-        initial_wp = agent.waypoints[0][0]
+        assert len(agent_waypoints[0]) == 1
+
+        initial_wp = agent_waypoints[0][0]
         if initial_wp in self.departures[agent.handle]:
             stop_on_time = False
             for departure in self.departures[agent.handle][initial_wp]:
@@ -491,7 +513,7 @@ class PunctualityRewards(Rewards[Tuple[int, int]]):
             if stop_on_time:
                 n_stops_on_time += 1
         for i, (wps, la, ed) in enumerate(zip(
-            agent.waypoints[1:-1],
+            agent_waypoints[1:-1],
             agent.waypoints_latest_arrival[1:-1],
             agent.waypoints_earliest_departure[1:-1]
         )):
@@ -508,10 +530,14 @@ class PunctualityRewards(Rewards[Tuple[int, int]]):
             if stop_on_time:
                 n_stops_on_time += 1
                 break
-        # by design, target is only one cell
-        target_wp = agent.waypoints[-1][0]
+
+        target_wps = agent_waypoints[-1]
+        # TODO wrong place to explode to set of target configurations - get rid of ((r,c), None) everyhwer
+        target_wps = {(target_wp[0], i) for target_wp in target_wps for i in range(4)}
         # N.B. assuming target is only travelled once:
-        if target_wp in self.arrivals[agent.handle] and self.arrivals[agent.handle][target_wp][0] <= agent.waypoints_latest_arrival[-1]:
+        if any(target_wp in self.arrivals[agent.handle] for target_wp in target_wps) and any(
+            self.arrivals[agent.handle][target_wp][0] <= agent.waypoints_latest_arrival[-1] for target_wp in target_wps if
+            len(self.arrivals[agent.handle][target_wp]) > 0):
             n_stops_on_time += 1
         n_stops = len(agent.waypoints)
         return n_stops_on_time, n_stops

--- a/flatland/envs/rewards.py
+++ b/flatland/envs/rewards.py
@@ -468,12 +468,13 @@ class PunctualityRewards(Rewards[Tuple[int, int]]):
         self.departures = defaultdict(defaultdict_list)
 
     def step_reward(self, agent: EnvAgent, agent_transition_data: AgentTransitionData, distance_map: DistanceMap, elapsed_steps: int) -> Tuple[int, int]:
-        if agent.position is None and agent.state_machine.state == TrainState.DONE and agent.target not in self.arrivals[agent.handle]:
-            self.arrivals[agent.handle][agent.target].append(elapsed_steps)
+        # N.B. assuming target is only travelled once:
+        if agent.current_configuration is None and agent.state_machine.state == TrainState.DONE and agent.old_configuration is not None and agent.old_configuration in agent.targets:
+            self.arrivals[agent.handle][Waypoint(*agent.old_configuration)].append(elapsed_steps)
 
-        if agent.position is not None and agent.position not in self.arrivals[agent.handle]:
-            self.arrivals[agent.handle][agent.position].append(elapsed_steps)
-            self.departures[agent.handle][agent.old_position].append(elapsed_steps)
+        if agent.current_configuration is not None and agent.current_configuration not in self.arrivals[agent.handle]:
+            self.arrivals[agent.handle][Waypoint(*agent.current_configuration)].append(elapsed_steps)
+            self.departures[agent.handle][Waypoint(*agent.old_configuration)].append(elapsed_steps)
 
         return 0, 0
 
@@ -481,9 +482,9 @@ class PunctualityRewards(Rewards[Tuple[int, int]]):
         n_stops_on_time = 0
         # by design, initial waypoint is unique
         initial_wp = agent.waypoints[0][0]
-        if initial_wp.position in self.departures[agent.handle]:
+        if initial_wp in self.departures[agent.handle]:
             stop_on_time = False
-            for departure in self.departures[agent.handle][initial_wp.position]:
+            for departure in self.departures[agent.handle][initial_wp]:
                 if departure >= agent.waypoints_earliest_departure[0]:
                     stop_on_time = True
                     break
@@ -497,10 +498,10 @@ class PunctualityRewards(Rewards[Tuple[int, int]]):
             stop_on_time = False
             # has any alternative with any arrival/departure been served on time?
             for wp in wps:
-                if wp.position not in self.arrivals[agent.handle] or wp.position not in self.departures[agent.handle]:
+                if wp not in self.arrivals[agent.handle] or wp not in self.departures[agent.handle]:
                     # intermediate stop not served
                     continue
-                for arrival, departure in zip(self.arrivals[agent.handle][wp.position], self.departures[agent.handle][wp.position]):
+                for arrival, departure in zip(self.arrivals[agent.handle][wp], self.departures[agent.handle][wp]):
                     if arrival <= agent.waypoints_latest_arrival[i + 1] and departure >= agent.waypoints_earliest_departure[i + 1]:
                         stop_on_time = True
                         break
@@ -509,7 +510,8 @@ class PunctualityRewards(Rewards[Tuple[int, int]]):
                 break
         # by design, target is only one cell
         target_wp = agent.waypoints[-1][0]
-        if target_wp.position in self.arrivals[agent.handle] and self.arrivals[agent.handle][target_wp.position][0] <= agent.waypoints_latest_arrival[-1]:
+        # N.B. assuming target is only travelled once:
+        if target_wp in self.arrivals[agent.handle] and self.arrivals[agent.handle][target_wp][0] <= agent.waypoints_latest_arrival[-1]:
             n_stops_on_time += 1
         n_stops = len(agent.waypoints)
         return n_stops_on_time, n_stops

--- a/flatland/envs/rewards.py
+++ b/flatland/envs/rewards.py
@@ -12,6 +12,7 @@ from flatland.envs.step_utils.env_utils import AgentTransitionData
 from flatland.envs.step_utils.states import TrainState
 
 RewardType = TypeVar('RewardType')
+ConfigurationType = TypeVar('ConfigurationType')
 
 
 class Rewards(Generic[RewardType]):
@@ -83,12 +84,12 @@ class Rewards(Generic[RewardType]):
 
     # TODO we should drop these methods once EnvAgent.waypoints is also of ConfigurationType instead of Waypoint.
     @staticmethod
-    def _sanitize_waypoints(agent_waypoints: List[List[Waypoint]]) -> List[List[Tuple[Tuple[int, int], int]]]:
+    def _sanitize_waypoints(agent_waypoints: List[List[Waypoint]]) -> List[List[ConfigurationType]]:
         agent_waypoints = [[(Rewards._sanitize_waypoint(wp)) for wp in wps] for wps in agent_waypoints]
         return agent_waypoints
 
     @staticmethod
-    def _sanitize_waypoint(wp: Waypoint) -> Tuple[Tuple[int, int], int]:
+    def _sanitize_waypoint(wp: Waypoint) -> ConfigurationType:
         return wp._to_tuple() if isinstance(wp, Waypoint) else wp
 
 
@@ -109,9 +110,6 @@ class DefaultPenalties(fastenum.Enum):
     INTERMEDIATE_NOT_SERVED = "INTERMEDIATE_NOT_SERVED"
     INTERMEDIATE_LATE_ARRIVAL = "INTERMEDIATE_LATE_ARRIVAL"
     INTERMEDIATE_EARLY_DEPARTURE = "INTERMEDIATE_EARLY_DEPARTURE"
-
-
-ConfigurationType = TypeVar('ConfigurationType')
 
 
 class BaseDefaultRewards(Rewards[Dict[str, float]], Generic[ConfigurationType]):
@@ -480,10 +478,9 @@ class PunctualityRewards(Rewards[Tuple[int, int]]):
         self.departures = defaultdict(defaultdict_list)
 
     def step_reward(self, agent: EnvAgent, agent_transition_data: AgentTransitionData, distance_map: DistanceMap, elapsed_steps: int) -> Tuple[int, int]:
+        # N.B. agent.targets is always a set of already-exploded (position, direction) configurations
+        # (see EnvAgent.targets), never a placeholder with a None direction - so no further exploding needed here.
         agent_targets = agent.targets
-        # TODO wrong place to explode to set of target configurations - get rid of ((r,c), None) everyhwer
-        if len(agent_targets) == 1 and agent_targets[0][1] is None:
-            agent_targets = [(agent_targets[0][0], i) for i in range(4)]
         # N.B. assuming target is only travelled once
         # TODO revise design -  target configurations have no arrival - should we change that?
         if agent.current_configuration is None and agent.state_machine.state == TrainState.DONE and agent.old_configuration is not None and not any(
@@ -491,7 +488,7 @@ class PunctualityRewards(Rewards[Tuple[int, int]]):
             # TODO bad design smell - we haven't kept track of which one was reach, we take any of them here
             self.arrivals[agent.handle][next(target_configuration for target_configuration in agent_targets)].append(elapsed_steps)
 
-        if agent.current_configuration is not None and agent.current_configuration not in self.arrivals[agent.handle][agent.current_configuration]:
+        if agent.current_configuration is not None and agent.current_configuration not in self.arrivals[agent.handle]:
             self.arrivals[agent.handle][agent.current_configuration].append(elapsed_steps)
             self.departures[agent.handle][agent.old_configuration].append(elapsed_steps)
 

--- a/flatland/envs/rewards.py
+++ b/flatland/envs/rewards.py
@@ -490,8 +490,11 @@ class PunctualityRewards(Rewards[Tuple[int, int]]):
         # (see EnvAgent.targets), never a placeholder with a None direction - so no further exploding needed here.
         agent_targets = agent.targets
         # N.B. assuming target is only travelled once
+        # N.B. DONE is only ever reached via TrainStateMachine.update_if_reached(), which requires the agent to
+        # have actually been at a target configuration - so old_configuration being None here (e.g. a zero-distance
+        # journey reaching DONE on the very first on-map step) does not mean the target wasn't really reached.
         # TODO revise design -  target configurations have no arrival - should we change that?
-        if agent.current_configuration is None and agent.state_machine.state == TrainState.DONE and agent.old_configuration is not None and not any(
+        if agent.current_configuration is None and agent.state_machine.state == TrainState.DONE and not any(
             target_configuration in self.arrivals[agent.handle] for target_configuration in agent_targets):
             # TODO bad design smell - we haven't kept track of which one was reach, we take any of them here
             self.arrivals[agent.handle][next(target_configuration for target_configuration in agent_targets)].append(elapsed_steps)

--- a/flatland/envs/rewards.py
+++ b/flatland/envs/rewards.py
@@ -93,6 +93,14 @@ class Rewards(Generic[RewardType]):
     def _sanitize_waypoint(wp: Waypoint) -> ConfigurationType:
         return wp._to_tuple() if isinstance(wp, Waypoint) else wp
 
+    @staticmethod
+    def _intermediate_waypoints(agent_waypoints: List[List[ConfigurationType]], agent: EnvAgent):
+        """
+        Zips an agent's intermediate waypoint alternatives (i.e. excluding the initial and target stops)
+        with their corresponding earliest-departure/latest-arrival time windows.
+        """
+        return zip(agent_waypoints[1:-1], agent.waypoints_latest_arrival[1:-1], agent.waypoints_earliest_departure[1:-1])
+
 
 def defaultdict_set():
     return defaultdict(lambda: set())
@@ -235,8 +243,7 @@ class BaseDefaultRewards(Rewards[Dict[str, float]], Generic[ConfigurationType]):
                 d[DefaultPenalties.TARGET_NOT_REACHED.value] = min(-1 * self.target_not_reached_minimum_penalty,
                                                                    agent.get_current_delay(elapsed_steps, distance_map))
         agent_waypoints = self._sanitize_waypoints(agent.waypoints)
-        for intermediate_alternatives, la, ed in zip(agent_waypoints[1:-1], agent.waypoints_latest_arrival[1:-1],
-                                                     agent.waypoints_earliest_departure[1:-1]):
+        for intermediate_alternatives, la, ed in self._intermediate_waypoints(agent_waypoints, agent):
             agent_arrivals: Set[ConfigurationType] = set(self.arrivals[agent.handle])
             intermediate_alternatives: Set[ConfigurationType] = set(intermediate_alternatives)
             wps_intersection: Set[ConfigurationType] = intermediate_alternatives.intersection(agent_arrivals)
@@ -510,11 +517,7 @@ class PunctualityRewards(Rewards[Tuple[int, int]]):
                     break
             if stop_on_time:
                 n_stops_on_time += 1
-        for i, (wps, la, ed) in enumerate(zip(
-            agent_waypoints[1:-1],
-            agent.waypoints_latest_arrival[1:-1],
-            agent.waypoints_earliest_departure[1:-1]
-        )):
+        for wps, la, ed in self._intermediate_waypoints(agent_waypoints, agent):
             stop_on_time = False
             # has any alternative with any arrival/departure been served on time?
             for wp in wps:
@@ -522,7 +525,7 @@ class PunctualityRewards(Rewards[Tuple[int, int]]):
                     # intermediate stop not served
                     continue
                 for arrival, departure in zip(self.arrivals[agent.handle][wp], self.departures[agent.handle][wp]):
-                    if arrival <= agent.waypoints_latest_arrival[i + 1] and departure >= agent.waypoints_earliest_departure[i + 1]:
+                    if arrival <= la and departure >= ed:
                         stop_on_time = True
                         break
             if stop_on_time:

--- a/tests/test_rewards.py
+++ b/tests/test_rewards.py
@@ -120,7 +120,7 @@ def test_rewards_intermediate_served_and_stopped_multiple_times_no_earliest_late
 
     agent.state = TrainState.DONE
     # if agent is done, intermediate not served is handled in step reward and not in end_of_episode_reward
-    assert rewards.step_reward(agent, None, distance_map, elapsed_steps=25) == -rewards.empty()
+    assert rewards.step_reward(agent, None, distance_map, elapsed_steps=25) == rewards.empty()
 
     rewards = BasicMultiObjectiveRewards(intermediate_not_served_penalty=intermediate_not_served_penalty)
     agent.current_configuration = ((2, 2), 2)

--- a/tests/test_rewards.py
+++ b/tests/test_rewards.py
@@ -558,6 +558,37 @@ def test_punctuality_rewards_target():
     assert rewards.cumulate(*collect) == (1, 3)
 
 
+@pytest.mark.parametrize("rewards,assert_result", [
+    (PunctualityRewards(), lambda rewards, result: rewards.arrivals[0][((3, 3), 3)] == [0]),
+    (DefaultRewards(), lambda rewards, result: (sum(result.values()) if isinstance(result, dict) else result) == 0),
+    (BaseDefaultRewards(), lambda rewards, result: (sum(result.values()) if isinstance(result, dict) else result) == 0),
+])
+def test_zero_distance_target_arrival_recorded(rewards, assert_result):
+    """Regression test: an agent whose initial configuration coincides with a target reaches DONE on
+    its very first on-map step, so old_configuration/current_configuration are both None by the time
+    step_reward() runs (the agent was never on the map before, and has already been removed from it).
+    TrainState.DONE is only reachable via TrainStateMachine.update_if_reached(), which requires the
+    agent to actually be at a target configuration - so this arrival must still be recorded/rewarded,
+    independent of any internal arrival bookkeeping keyed off old_configuration/current_configuration."""
+    agent = EnvAgent(
+        handle=0,
+        initial_configuration=((3, 3), 3),
+        targets={((3, 3), 3)},
+        current_configuration=None,
+        old_configuration=None,
+        state_machine=TrainStateMachine(initial_state=TrainState.DONE),
+        earliest_departure=0,
+        latest_arrival=10,
+        arrival_time=5
+    )
+    distance_map = DistanceMap(agents=[agent], env_height=20, env_width=20)
+    distance_map.reset(agents=[agent], rail=RailGridTransitionMap(20, 20, transitions=RailEnvTransitions()))
+
+    result = rewards.step_reward(agent=agent, agent_transition_data=None, distance_map=distance_map, elapsed_steps=0)
+
+    assert assert_result(rewards, result)
+
+
 def test_punctuality_rewards_single_direction_target_does_not_crash():
     """Regression test: agent.targets can be filtered down to a single (position, direction)
     configuration (e.g. a dead-end target reachable from only one direction) - step_reward must

--- a/tests/test_rewards.py
+++ b/tests/test_rewards.py
@@ -558,6 +558,61 @@ def test_punctuality_rewards_target():
     assert rewards.cumulate(*collect) == (1, 3)
 
 
+def test_punctuality_rewards_single_direction_target_does_not_crash():
+    """Regression test: agent.targets can be filtered down to a single (position, direction)
+    configuration (e.g. a dead-end target reachable from only one direction) - step_reward must
+    not crash indexing this as if it were a subscriptable sequence."""
+    rewards = PunctualityRewards()
+    agent = EnvAgent(
+        handle=0,
+        initial_configuration=((0, 0), 0),
+        targets={((3, 3), 3)},
+        current_configuration=((3, 3), 3),
+        old_configuration=((2, 2), 2),
+        state_machine=TrainStateMachine(initial_state=TrainState.DONE),
+        earliest_departure=3,
+        latest_arrival=10,
+        arrival_time=10
+    )
+    distance_map = DistanceMap(agents=[agent], env_height=20, env_width=20)
+    distance_map.reset(agents=[agent], rail=RailGridTransitionMap(20, 20, transitions=RailEnvTransitions()))
+    agent.current_configuration = None
+
+    rewards.step_reward(agent=agent, agent_transition_data=None, distance_map=distance_map, elapsed_steps=10)
+
+    assert rewards.arrivals[0][((3, 3), 3)] == [10]
+
+
+def test_punctuality_rewards_arrival_recorded_once_per_configuration():
+    """Regression test: dwelling at the same configuration for several steps must not append
+    duplicate arrival/departure entries."""
+    rewards = PunctualityRewards()
+    agent = EnvAgent(
+        handle=0,
+        initial_configuration=((0, 0), 0),
+        targets={((3, 3), d) for d in Grid4TransitionsEnum},
+        current_configuration=(None, 3),
+        state_machine=TrainStateMachine(initial_state=TrainState.MOVING),
+        earliest_departure=3,
+        latest_arrival=10,
+        arrival_time=10
+    )
+    distance_map = DistanceMap(agents=[agent], env_height=20, env_width=20)
+    distance_map.reset(agents=[agent], rail=RailGridTransitionMap(20, 20, transitions=RailEnvTransitions()))
+
+    agent.old_configuration = ((0, 0), 0)
+    agent.current_configuration = ((2, 2), 2)
+    rewards.step_reward(agent=agent, agent_transition_data=None, distance_map=distance_map, elapsed_steps=5)
+
+    # agent dwells at the same configuration for further steps
+    agent.old_configuration = ((2, 2), 2)
+    rewards.step_reward(agent=agent, agent_transition_data=None, distance_map=distance_map, elapsed_steps=6)
+    rewards.step_reward(agent=agent, agent_transition_data=None, distance_map=distance_map, elapsed_steps=7)
+
+    assert rewards.arrivals[0][((2, 2), 2)] == [5]
+    assert rewards.departures[0][((0, 0), 0)] == [5]
+
+
 def test_arrival_recorded_once_per_waypoint():
     """Test that arrivals are only recorded once per waypoint, not every step (Bug #327)."""
     rewards = DefaultRewards()

--- a/tests/test_rewards.py
+++ b/tests/test_rewards.py
@@ -445,7 +445,7 @@ def test_punctuality_rewards_initial():
         state_machine=TrainStateMachine(initial_state=TrainState.MOVING),
         earliest_departure=3,
         latest_arrival=10,
-        waypoints=[[Waypoint((0, 0), 0)], [Waypoint((2, 2), 2)], [Waypoint((3, 3), None)]],
+        waypoints=[[Waypoint((0, 0), 0)], [Waypoint((2, 2), 2)], [Waypoint((3, 3), 3)]],
         waypoints_earliest_departure=[3, 5, None],
         waypoints_latest_arrival=[None, 2, 10],
         arrival_time=10
@@ -456,18 +456,18 @@ def test_punctuality_rewards_initial():
 
     distance_map = DistanceMap(agents=[agent], env_height=20, env_width=20)
     distance_map.reset(agents=[agent], rail=RailGridTransitionMap(20, 20, transitions=RailEnvTransitions()))
-    agent.old_position = (0, 0)
-    agent.position = (2, 2)
+    agent.old_configuration = ((0, 0), 0)
+    agent.current_configuration = ((2, 2), 2)
 
     collect.append(rewards.step_reward(agent=agent, agent_transition_data=None, distance_map=distance_map, elapsed_steps=5))
     collect.append(rewards.end_of_episode_reward(agent=agent, distance_map=distance_map, elapsed_steps=6))
 
-    assert (0, 0) not in rewards.arrivals[0]
-    assert rewards.departures[0][(0, 0)] == [5]
-    assert rewards.arrivals[0][(2, 2)] == [5]
-    assert (2, 2) not in rewards.departures[0]
-    assert (3, 3) not in rewards.arrivals[0]
-    assert (3, 3) not in rewards.departures[0]
+    assert (Waypoint(0, 0), 0) not in rewards.arrivals[0]
+    assert rewards.departures[0][Waypoint((0, 0), 0)] == [5]
+    assert rewards.arrivals[0][Waypoint((2, 2), 2)] == [5]
+    assert (Waypoint(2, 2), 2) not in rewards.departures[0]
+    assert (Waypoint(3, 3), 3) not in rewards.arrivals[0]
+    assert (Waypoint(3, 3), 3) not in rewards.departures[0]
 
     # on time only at initial
     assert rewards.cumulate(*collect) == (1, 3)
@@ -484,7 +484,7 @@ def test_punctuality_rewards_intermediate():
         state_machine=TrainStateMachine(initial_state=TrainState.MOVING),
         earliest_departure=3,
         latest_arrival=10,
-        waypoints=[[Waypoint((0, 0), 0)], [Waypoint((2, 2), 2)], [Waypoint((3, 3), None)]],
+        waypoints=[[Waypoint((0, 0), 0)], [Waypoint((2, 2), 2)], [Waypoint((3, 3), 3)]],
         waypoints_earliest_departure=[3, 5, None],
         waypoints_latest_arrival=[None, 2, 10],
         arrival_time=10
@@ -495,22 +495,22 @@ def test_punctuality_rewards_intermediate():
 
     distance_map = DistanceMap(agents=[agent], env_height=20, env_width=20)
     distance_map.reset(agents=[agent], rail=RailGridTransitionMap(20, 20, transitions=RailEnvTransitions()))
-    agent.old_position = (0, 0)
-    agent.position = (2, 2)
+    agent.old_configuration = ((0, 0), 0)
+    agent.current_configuration = ((2, 2), 2)
     collect.append(rewards.step_reward(agent=agent, agent_transition_data=None, distance_map=distance_map, elapsed_steps=2))
-    agent.old_position = (2, 2)
-    agent.position = (4, 4)
+    agent.old_configuration = ((2, 2), 2)
+    agent.current_configuration = ((4, 4), 4)
     collect.append(rewards.step_reward(agent=agent, agent_transition_data=None, distance_map=distance_map, elapsed_steps=5))
     collect.append(rewards.end_of_episode_reward(agent=agent, distance_map=distance_map, elapsed_steps=6))
 
-    assert (0, 0) not in rewards.arrivals[0]
-    assert rewards.departures[0][(0, 0)] == [2]
-    assert rewards.arrivals[0][(2, 2)] == [2]
-    assert rewards.departures[0][(2, 2)] == [5]
-    assert rewards.arrivals[0][(4, 4)] == [5]
-    assert (4, 4) not in rewards.departures[0]
-    assert (3, 3) not in rewards.arrivals[0]
-    assert (3, 3) not in rewards.departures[0]
+    assert Waypoint((0, 0), 0) not in rewards.arrivals[0]
+    assert rewards.departures[0][Waypoint((0, 0), 0)] == [2]
+    assert rewards.arrivals[0][Waypoint((2, 2), 2)] == [2]
+    assert rewards.departures[0][Waypoint((2, 2), 2)] == [5]
+    assert rewards.arrivals[0][Waypoint((4, 4), 4)] == [5]
+    assert Waypoint((4, 4), 4) not in rewards.departures[0]
+    assert Waypoint((3, 3), 3) not in rewards.arrivals[0]
+    assert Waypoint((3, 3), 3) not in rewards.departures[0]
 
     # on time only at intermediate
     assert rewards.cumulate(*collect) == (1, 3)
@@ -526,7 +526,7 @@ def test_punctuality_rewards_target():
         state_machine=TrainStateMachine(initial_state=TrainState.MOVING),
         earliest_departure=3,
         latest_arrival=10,
-        waypoints=[[Waypoint((0, 0), 0)], [Waypoint((2, 2), 2)], [Waypoint((3, 3), None)]],
+        waypoints=[[Waypoint((0, 0), 0)], [Waypoint((2, 2), 2)], [Waypoint((3, 3), 3)]],
         waypoints_earliest_departure=[3, 5, None],
         waypoints_latest_arrival=[None, 2, 10],
         arrival_time=10
@@ -537,25 +537,25 @@ def test_punctuality_rewards_target():
 
     distance_map = DistanceMap(agents=[agent], env_height=20, env_width=20)
     distance_map.reset(agents=[agent], rail=RailGridTransitionMap(20, 20, transitions=RailEnvTransitions()))
-    agent.old_position = (0, 0)
-    agent.position = (2, 2)
+    agent.old_configuration = ((0, 0), 0)
+    agent.current_configuration = ((2, 2), 2)
     collect.append(rewards.step_reward(agent=agent, agent_transition_data=None, distance_map=distance_map, elapsed_steps=2))
-    agent.old_position = (2, 2)
-    agent.position = (4, 4)
+    agent.old_configuration = ((2, 2), 2)
+    agent.current_configuration = ((4, 4), 4)
     collect.append(rewards.step_reward(agent=agent, agent_transition_data=None, distance_map=distance_map, elapsed_steps=4))
-    agent.old_position = (4, 4)
-    agent.position = (3, 3)
+    agent.old_configuration = ((4, 4), 4)
+    agent.current_configuration = ((3, 3), 3)
     collect.append(rewards.step_reward(agent=agent, agent_transition_data=None, distance_map=distance_map, elapsed_steps=10))
     collect.append(rewards.end_of_episode_reward(agent=agent, distance_map=distance_map, elapsed_steps=6))
 
-    assert (0, 0) not in rewards.arrivals[0]
-    assert rewards.departures[0][(0, 0)] == [2]
-    assert rewards.arrivals[0][(2, 2)] == [2]
-    assert rewards.departures[0][(2, 2)] == [4]
-    assert rewards.arrivals[0][(4, 4)] == [4]
-    assert rewards.departures[0][(4, 4)] == [10]
-    assert rewards.arrivals[0][(3, 3)] == [10]
-    assert (3, 3) not in rewards.departures[0]
+    assert Waypoint((0, 0), 0) not in rewards.arrivals[0]
+    assert rewards.departures[0][Waypoint((0, 0), 0)] == [2]
+    assert rewards.arrivals[0][Waypoint((2, 2), 2)] == [2]
+    assert rewards.departures[0][Waypoint((2, 2), 2)] == [4]
+    assert rewards.arrivals[0][Waypoint((4, 4), 4)] == [4]
+    assert rewards.departures[0][Waypoint((4, 4), 4)] == [10]
+    assert rewards.arrivals[0][Waypoint((3, 3), 3)] == [10]
+    assert Waypoint((3, 3), 3) not in rewards.departures[0]
 
     # on time only at target
     assert rewards.cumulate(*collect) == (1, 3)

--- a/tests/test_rewards.py
+++ b/tests/test_rewards.py
@@ -78,6 +78,8 @@ def test_rewards_intermediate_served_and_stopped_penalty():
     agent.state = TrainState.STOPPED
     assert rewards.step_reward(agent, None, distance_map, 5) == rewards.empty()
     agent.state = TrainState.DONE
+    # if agent is done, intermediate not served is handled in step reward and not in end_of_episode_reward
+    # N.B. implementation does not verify the target was reached, only train state
     assert rewards.step_reward(agent, None, distance_map, elapsed_steps=25) == rewards.empty()
 
     rewards = BasicMultiObjectiveRewards(intermediate_not_served_penalty=intermediate_not_served_penalty)
@@ -85,6 +87,8 @@ def test_rewards_intermediate_served_and_stopped_penalty():
     agent.state = TrainState.STOPPED
     assert rewards.step_reward(agent, None, distance_map, 5) == rewards.empty()
     agent.state = TrainState.DONE
+    # if agent is done, intermediate not served is handled in step reward and not in end_of_episode_reward
+    # N.B. implementation does not verify the target was reached, only train state
     assert rewards.step_reward(agent, None, distance_map, elapsed_steps=25) == rewards.empty()
 
 
@@ -115,13 +119,15 @@ def test_rewards_intermediate_served_and_stopped_multiple_times_no_earliest_late
     assert rewards.step_reward(agent, None, distance_map, 15) == rewards.empty()
 
     agent.state = TrainState.DONE
-    assert rewards.step_reward(agent, None, distance_map, elapsed_steps=25) == rewards.empty()
+    # if agent is done, intermediate not served is handled in step reward and not in end_of_episode_reward
+    assert rewards.step_reward(agent, None, distance_map, elapsed_steps=25) == -rewards.empty()
 
     rewards = BasicMultiObjectiveRewards(intermediate_not_served_penalty=intermediate_not_served_penalty)
     agent.current_configuration = ((2, 2), 2)
     agent.state = TrainState.STOPPED
     assert rewards.step_reward(agent, None, distance_map, 5) == rewards.empty()
     agent.state = TrainState.DONE
+    # if agent is done, intermediate not served is handled in step reward and not in end_of_episode_reward
     assert rewards.step_reward(agent, None, distance_map, elapsed_steps=25) == rewards.empty()
 
 
@@ -261,16 +267,12 @@ def test_rewards_intermediate_intermediate_early_departure_penalty():
                      arrival_time=10)
     distance_map = DistanceMap(agents=[agent], env_height=20, env_width=20)
     distance_map.reset(agents=[agent], rail=RailGridTransitionMap(20, 20, transitions=RailEnvTransitions()))
-    agent.old_position = (0, 0)
-    agent.old_direction = 0
-    agent.position = (2, 2)
-    agent.direction = 2
+    agent.old_configuration = ((0, 0), 0)
+    agent.current_configuration = ((2, 2), 2)
     agent.state = TrainState.STOPPED
     assert rewards.step_reward(agent=agent, agent_transition_data=None, distance_map=distance_map, elapsed_steps=5) == 0
-    agent.old_position = (2, 2)
-    agent.old_direction = 2
-    agent.position = (3, 3)
-    agent.direction = 3
+    agent.old_configuration = ((2, 2), 2)
+    agent.current_configuration = ((3, 3), 3)
     agent.state = TrainState.DONE
     assert rewards.step_reward(agent=agent, agent_transition_data=None, distance_map=distance_map, elapsed_steps=5) == -66
     assert rewards.end_of_episode_reward(agent, distance_map=distance_map, elapsed_steps=25) == 0
@@ -291,16 +293,12 @@ def test_rewards_intermediate_intermediate_late_arrival_penalty():
                      arrival_time=10)
     distance_map = DistanceMap(agents=[agent], env_height=20, env_width=20)
     distance_map.reset(agents=[agent], rail=RailGridTransitionMap(20, 20, transitions=RailEnvTransitions()))
-    agent.old_position = (0, 0)
-    agent.old_direction = 0
-    agent.position = (2, 2)
-    agent.direction = 2
+    agent.old_configuration = ((0, 0), 0)
+    agent.current_configuration = ((2, 2), 2)
     agent.state = TrainState.STOPPED
     rewards.step_reward(agent=agent, agent_transition_data=None, distance_map=distance_map, elapsed_steps=5)
-    agent.old_position = (2, 2)
-    agent.old_direction = 2
-    agent.position = (3, 3)
-    agent.direction = 3
+    agent.old_configuration = ((2, 2), 2)
+    agent.current_configuration = ((3, 3), 3)
     rewards.step_reward(agent=agent, agent_transition_data=None, distance_map=distance_map, elapsed_steps=5)
     agent.state = TrainState.DONE
     assert rewards.step_reward(agent, None, distance_map=distance_map, elapsed_steps=25) == -99
@@ -322,10 +320,8 @@ def test_rewards_departed_but_never_arrived():
                      arrival_time=10)
     distance_map = DistanceMap(agents=[agent], env_height=20, env_width=20)
     distance_map.reset(agents=[agent], rail=RailGridTransitionMap(20, 20, transitions=RailEnvTransitions()))
-    agent.old_position = (0, 0)
-    agent.old_direction = 0
-    agent.position = (2, 2)
-    agent.direction = 2
+    agent.old_configuration = ((0, 0), 0)
+    agent.current_configuration = ((2, 2), 2)
     agent.state = TrainState.STOPPED
     rewards.step_reward(agent=agent, agent_transition_data=AgentTransitionData(0.5, None, None, None, StateTransitionSignals()),
                         distance_map=distance_map,
@@ -460,14 +456,15 @@ def test_punctuality_rewards_initial():
     agent.current_configuration = ((2, 2), 2)
 
     collect.append(rewards.step_reward(agent=agent, agent_transition_data=None, distance_map=distance_map, elapsed_steps=5))
+
     collect.append(rewards.end_of_episode_reward(agent=agent, distance_map=distance_map, elapsed_steps=6))
 
-    assert (Waypoint(0, 0), 0) not in rewards.arrivals[0]
-    assert rewards.departures[0][Waypoint((0, 0), 0)] == [5]
-    assert rewards.arrivals[0][Waypoint((2, 2), 2)] == [5]
-    assert (Waypoint(2, 2), 2) not in rewards.departures[0]
-    assert (Waypoint(3, 3), 3) not in rewards.arrivals[0]
-    assert (Waypoint(3, 3), 3) not in rewards.departures[0]
+    assert ((0, 0), 0) not in rewards.arrivals[0]
+    assert rewards.departures[0][((0, 0), 0)] == [5]
+    assert rewards.arrivals[0][((2, 2), 2)] == [5]
+    assert ((2, 2), 2) not in rewards.departures[0]
+    assert ((3, 3), 3) not in rewards.arrivals[0]
+    assert ((3, 3), 3) not in rewards.departures[0]
 
     # on time only at initial
     assert rewards.cumulate(*collect) == (1, 3)
@@ -503,14 +500,14 @@ def test_punctuality_rewards_intermediate():
     collect.append(rewards.step_reward(agent=agent, agent_transition_data=None, distance_map=distance_map, elapsed_steps=5))
     collect.append(rewards.end_of_episode_reward(agent=agent, distance_map=distance_map, elapsed_steps=6))
 
-    assert Waypoint((0, 0), 0) not in rewards.arrivals[0]
-    assert rewards.departures[0][Waypoint((0, 0), 0)] == [2]
-    assert rewards.arrivals[0][Waypoint((2, 2), 2)] == [2]
-    assert rewards.departures[0][Waypoint((2, 2), 2)] == [5]
-    assert rewards.arrivals[0][Waypoint((4, 4), 4)] == [5]
-    assert Waypoint((4, 4), 4) not in rewards.departures[0]
-    assert Waypoint((3, 3), 3) not in rewards.arrivals[0]
-    assert Waypoint((3, 3), 3) not in rewards.departures[0]
+    assert ((0, 0), 0) not in rewards.arrivals[0]
+    assert rewards.departures[0][((0, 0), 0)] == [2]
+    assert rewards.arrivals[0][((2, 2), 2)] == [2]
+    assert rewards.departures[0][((2, 2), 2)] == [5]
+    assert rewards.arrivals[0][((4, 4), 4)] == [5]
+    assert ((4, 4), 4) not in rewards.departures[0]
+    assert ((3, 3), 3) not in rewards.arrivals[0]
+    assert ((3, 3), 3) not in rewards.departures[0]
 
     # on time only at intermediate
     assert rewards.cumulate(*collect) == (1, 3)
@@ -548,14 +545,14 @@ def test_punctuality_rewards_target():
     collect.append(rewards.step_reward(agent=agent, agent_transition_data=None, distance_map=distance_map, elapsed_steps=10))
     collect.append(rewards.end_of_episode_reward(agent=agent, distance_map=distance_map, elapsed_steps=6))
 
-    assert Waypoint((0, 0), 0) not in rewards.arrivals[0]
-    assert rewards.departures[0][Waypoint((0, 0), 0)] == [2]
-    assert rewards.arrivals[0][Waypoint((2, 2), 2)] == [2]
-    assert rewards.departures[0][Waypoint((2, 2), 2)] == [4]
-    assert rewards.arrivals[0][Waypoint((4, 4), 4)] == [4]
-    assert rewards.departures[0][Waypoint((4, 4), 4)] == [10]
-    assert rewards.arrivals[0][Waypoint((3, 3), 3)] == [10]
-    assert Waypoint((3, 3), 3) not in rewards.departures[0]
+    assert ((0, 0), 0) not in rewards.arrivals[0]
+    assert rewards.departures[0][((0, 0), 0)] == [2]
+    assert rewards.arrivals[0][((2, 2), 2)] == [2]
+    assert rewards.departures[0][((2, 2), 2)] == [4]
+    assert rewards.arrivals[0][((4, 4), 4)] == [4]
+    assert rewards.departures[0][((4, 4), 4)] == [10]
+    assert rewards.arrivals[0][((3, 3), 3)] == [10]
+    assert ((3, 3), 3) not in rewards.departures[0]
 
     # on time only at target
     assert rewards.cumulate(*collect) == (1, 3)
@@ -585,7 +582,7 @@ def test_arrival_recorded_once_per_waypoint():
 
     # First step at this waypoint - should record arrival
     rewards.step_reward(agent, transition_data, distance_map, elapsed_steps=10)
-    wp = Waypoint((5, 5), 0)
+    wp = ((5, 5), 0)
     assert rewards._proxy.arrivals[agent.handle][wp] == [10]
 
     # Agent dwells at same position for several steps
@@ -618,7 +615,7 @@ def test_departure_only_when_moving():
 
     # agent off map
     rewards.step_reward(agent, transition_data, distance_map, elapsed_steps=1)
-    off_wp = Waypoint(None, 0)
+    off_wp = (None, 0)
     assert off_wp not in rewards._proxy.arrivals[agent.handle]
     assert off_wp not in rewards._proxy.departures[agent.handle]
 
@@ -629,7 +626,7 @@ def test_departure_only_when_moving():
     # First step - arrival recorded, but no departure (agent hasn't left yet)
     rewards.step_reward(agent, transition_data, distance_map, elapsed_steps=2)
 
-    wp = Waypoint((5, 5), 0)
+    wp = ((5, 5), 0)
     assert off_wp not in rewards._proxy.arrivals[agent.handle]
     assert off_wp not in rewards._proxy.departures[agent.handle]
     assert wp in rewards._proxy.arrivals[agent.handle], "Should record arrival when agent enters map"
@@ -645,7 +642,7 @@ def test_departure_only_when_moving():
     assert off_wp not in rewards._proxy.departures[agent.handle]
     assert wp in rewards._proxy.departures[agent.handle], "Departure should be recorded when agent moves"
     assert rewards._proxy.departures[agent.handle][wp] == [3]
-    wp = Waypoint((5, 6), 0)
+    wp = ((5, 6), 0)
     assert wp in rewards._proxy.arrivals[agent.handle], "Arrival should be recorded when agent moves"
     assert rewards._proxy.arrivals[agent.handle][wp] == [3]
 
@@ -685,7 +682,7 @@ def test_waypoint_comparison_uses_waypoint_objects():
     rewards.step_reward(agent, transition_data, distance_map, elapsed_steps=5)
 
     # Check that arrivals dict uses Waypoint as key, not tuple
-    wp = Waypoint((7, 8), 1)
+    wp = ((7, 8), 1)
     assert wp in rewards._proxy.arrivals[agent.handle], "Should use Waypoint object as key"
     assert (7, 8) not in rewards._proxy.arrivals[agent.handle], "Should not have tuple as key"
 

--- a/tests/test_rewards.py
+++ b/tests/test_rewards.py
@@ -154,11 +154,11 @@ def test_rewards_intermediate_served_and_stopped_multiple_times_but_late_arrival
 
     # depart
     agent.old_configuration = ((2, 2), 2)
-    agent.current_configuration = ((4, 4), 4)
+    agent.current_configuration = ((4, 4), 0)
     assert rewards.step_reward(agent, None, distance_map, 11) == rewards.empty()
 
     # second intermediate stop evaluation while stopped
-    agent.old_configuration = ((4, 4), 4)
+    agent.old_configuration = ((4, 4), 0)
     agent.current_configuration = ((2, 2), 2)
     agent.state = TrainState.STOPPED
     assert rewards.step_reward(agent, AgentTransitionData(Fraction(0), None, None, None, None), distance_map, 15) == rewards.empty()
@@ -181,11 +181,11 @@ def test_rewards_intermediate_served_and_stopped_multiple_times_but_late_arrival
 
     # depart
     agent.old_configuration = ((2, 2), 2)
-    agent.current_configuration = ((4, 4), 4)
+    agent.current_configuration = ((4, 4), 0)
     assert rewards.step_reward(agent, None, distance_map, 11) == rewards.empty()
 
     # second intermediate stop evaluation while stopped
-    agent.old_configuration = ((4, 4), 4)
+    agent.old_configuration = ((4, 4), 0)
     agent.current_configuration = ((2, 2), 2)
     agent.state = TrainState.STOPPED
     assert rewards.step_reward(agent, AgentTransitionData(Fraction(0), None, None, None, None), distance_map, 15) == rewards.empty()
@@ -504,8 +504,8 @@ def test_punctuality_rewards_intermediate():
     assert rewards.departures[0][((0, 0), 0)] == [2]
     assert rewards.arrivals[0][((2, 2), 2)] == [2]
     assert rewards.departures[0][((2, 2), 2)] == [5]
-    assert rewards.arrivals[0][((4, 4), 4)] == [5]
-    assert ((4, 4), 4) not in rewards.departures[0]
+    assert rewards.arrivals[0][((4, 4), 0)] == [5]
+    assert ((4, 4), 0) not in rewards.departures[0]
     assert ((3, 3), 3) not in rewards.arrivals[0]
     assert ((3, 3), 3) not in rewards.departures[0]
 
@@ -538,9 +538,9 @@ def test_punctuality_rewards_target():
     agent.current_configuration = ((2, 2), 2)
     collect.append(rewards.step_reward(agent=agent, agent_transition_data=None, distance_map=distance_map, elapsed_steps=2))
     agent.old_configuration = ((2, 2), 2)
-    agent.current_configuration = ((4, 4), 4)
+    agent.current_configuration = ((4, 4), 0)
     collect.append(rewards.step_reward(agent=agent, agent_transition_data=None, distance_map=distance_map, elapsed_steps=4))
-    agent.old_configuration = ((4, 4), 4)
+    agent.old_configuration = ((4, 4), 0)
     agent.current_configuration = ((3, 3), 3)
     collect.append(rewards.step_reward(agent=agent, agent_transition_data=None, distance_map=distance_map, elapsed_steps=10))
     collect.append(rewards.end_of_episode_reward(agent=agent, distance_map=distance_map, elapsed_steps=6))
@@ -549,8 +549,8 @@ def test_punctuality_rewards_target():
     assert rewards.departures[0][((0, 0), 0)] == [2]
     assert rewards.arrivals[0][((2, 2), 2)] == [2]
     assert rewards.departures[0][((2, 2), 2)] == [4]
-    assert rewards.arrivals[0][((4, 4), 4)] == [4]
-    assert rewards.departures[0][((4, 4), 4)] == [10]
+    assert rewards.arrivals[0][((4, 4), 0)] == [4]
+    assert rewards.departures[0][((4, 4), 0)] == [10]
     assert rewards.arrivals[0][((3, 3), 3)] == [10]
     assert ((3, 3), 3) not in rewards.departures[0]
 

--- a/tests/test_rewards.py
+++ b/tests/test_rewards.py
@@ -496,7 +496,7 @@ def test_punctuality_rewards_intermediate():
     agent.current_configuration = ((2, 2), 2)
     collect.append(rewards.step_reward(agent=agent, agent_transition_data=None, distance_map=distance_map, elapsed_steps=2))
     agent.old_configuration = ((2, 2), 2)
-    agent.current_configuration = ((4, 4), 4)
+    agent.current_configuration = ((4, 4), 0)
     collect.append(rewards.step_reward(agent=agent, agent_transition_data=None, distance_map=distance_map, elapsed_steps=5))
     collect.append(rewards.end_of_episode_reward(agent=agent, distance_map=distance_map, elapsed_steps=6))
 


### PR DESCRIPTION
## Changes

* refactor: use generic configuration type instead of grid-related Waypoint in rewards.

## Related issues

Closes #378 

## Checklist

- [ ] Tests are included for relevant behavior changes.
- [ ] Documentation is added in the [flatland-book](https://github.com/flatland-association/flatland-book) repo for relevant behavior changes.
- [ ] If you made important user-facing changes, describe them under the `[Unreleased]` tag in `CHANGELOG.md`.
- [ ] New package dependencies are declared in the `pyproject.toml` file.
  Requirement files have been updated by running `tox -e requirements`.
- [ ] Code works with all supported Python versions (3.10, 3.11, 3.12 and 3.13). Checks run with all supported version and are
  required to run successfully.
- [ ] Code is formatted according to PEP 8 (an IDE like PyCharm can do this for you).
- [ ] Technical guidelines listed in `CONTRIBUTING.md` are followed.
