### PR TITLE
fix: line and timetable generators from file.

### DIFF
--- a/flatland/envs/agent_utils.py
+++ b/flatland/envs/agent_utils.py
@@ -271,28 +271,41 @@ class EnvAgent(Generic[ConfigurationType]):
     def load_legacy_static_agent(cls, static_agents_data: Tuple):
         agents = []
         for i, static_agent in enumerate(static_agents_data):
+            initial_configuration = (static_agent[0], static_agent[1])
+            targets = {(static_agent[2], d) for d in Grid4TransitionsEnum}
             if len(static_agent) >= 6:
                 speed = static_agent[4]['speed']
                 speed = _pseudo_fractional(speed)
+
                 agent = EnvAgent(
-                    initial_configuration=(static_agent[0], static_agent[1]),
-                    current_configuration=(static_agent[0], static_agent[1]),
+                    initial_configuration=initial_configuration,
+                    current_configuration=initial_configuration,
                     old_configuration=None,
                     # N.B. valid targets cleaned in _agents_from_line
-                    targets={(static_agent[2], d) for d in Grid4TransitionsEnum},
+                    targets=targets,
                     moving=static_agent[3],
                     speed_counter=SpeedCounter(speed), handle=i,
+                    waypoints=[[Waypoint(*initial_configuration)], [Waypoint(*target) for target in targets]],
+                    earliest_departure=0,
+                    waypoints_earliest_departure=[0, None],
+                    latest_arrival=sys.maxsize,
+                    waypoints_latest_arrival=[None, sys.maxsize],
                 )
             else:
                 agent = EnvAgent(
-                    initial_configuration=(static_agent[0], static_agent[1]),
-                    current_configuration=(static_agent[0], static_agent[1]),
+                    initial_configuration=initial_configuration,
+                    current_configuration=initial_configuration,
                     old_configuration=None,
                     # N.B. valid targets cleaned in _agents_from_line
                     targets={(static_agent[2], d) for d in Grid4TransitionsEnum},
                     moving=False,
                     speed_counter=SpeedCounter(1.0),
                     handle=i,
+                    waypoints=[[Waypoint(*initial_configuration)], [Waypoint(*target) for target in targets]],
+                    earliest_departure=0,
+                    waypoints_earliest_departure=[0, None],
+                    latest_arrival=sys.maxsize,
+                    waypoints_latest_arrival=[None, sys.maxsize],
                 )
             agents.append(agent)
         return agents

--- a/flatland/envs/line_generators.py
+++ b/flatland/envs/line_generators.py
@@ -227,7 +227,7 @@ def line_from_file(filename: Union[str, Path] = None, load_from_package=None, en
 
         # setup with loaded data
         # N.B. Line generator currently has no routing flexibility!
-        agent_waypoints = {i: [[Waypoint(a.initial_position, a.initial_direction)], [Waypoint(a.target, None)]] for i, a in enumerate(agents)}
+        agent_waypoints = {i: a.waypoints for i, a in enumerate(agents)}
         agents_speed = [a.speed_counter.speed for a in agents]
 
         return Line(agent_waypoints=agent_waypoints, agent_speeds=agents_speed)

--- a/flatland/envs/timetable_generators.py
+++ b/flatland/envs/timetable_generators.py
@@ -206,8 +206,8 @@ def timetable_from_file(filename: Union[str, Path] = None, load_from_package=Non
         if max_episode_steps == 0:
             warnings.warn("This env file has no max_episode_steps (deprecated) - setting to 100")
             max_episode_steps = 100
-        earliest_departures = [[a.earliest_departure] for a in agents]
-        latest_arrivals = [[a.latest_arrival] for a in agents]
+        earliest_departures = [a.waypoints_earliest_departure for a in agents]
+        latest_arrivals = [a.waypoints_latest_arrival for a in agents]
         return Timetable(earliest_departures=earliest_departures, latest_arrivals=latest_arrivals, max_episode_steps=max_episode_steps)
 
     return generator

--- a/tests/test_flatland_envs_file_line_generator.py
+++ b/tests/test_flatland_envs_file_line_generator.py
@@ -1,10 +1,13 @@
+import os.path
 import tempfile
 import uuid
 from pathlib import Path
 
 import numpy as np
 
+from flatland.env_generation.env_generator import env_generator
 from flatland.envs.line_generators import FileLineGenerator
+from flatland.envs.persistence import RailEnvPersister
 from flatland.envs.rail_trainrun_data_structures import Waypoint
 from flatland.envs.timetable_utils import Line
 
@@ -25,3 +28,19 @@ def test_generate():
 
         actual = FileLineGenerator(filename=pkl).generate(None, None)
         assert expected == actual
+
+
+def test_line_timetable_generator_from_file_behaves_in_reset_behaves_same_as_load_new():
+    env, _, _ = env_generator(seed=42)
+    with tempfile.TemporaryDirectory() as tmp_dir_name:
+        RailEnvPersister.save(env, os.path.join(tmp_dir_name, "env.pkl"))
+        env2, _ = RailEnvPersister.load_new(os.path.join(tmp_dir_name, "env.pkl"))
+
+    # same from file
+    assert np.array_equal(env.rail.grid, env2.rail.grid)
+    assert env.agents == env2.agents
+
+    # same from file even after reset
+    env2.reset()
+    assert np.array_equal(env.rail.grid, env2.rail.grid)
+    assert env.agents == env2.agents


### PR DESCRIPTION


## Changes
* line and timetable generator from file should produce same as `load_new`.
Describe the changes you made.

## Related issues

Link to every issue from the issue tracker (if any) you addressed in this PR.

## Checklist

- [ ] Tests are included for relevant behavior changes.
- [ ] Documentation is added in the [flatland-book](https://github.com/flatland-association/flatland-book) repo for relevant behavior changes.
- [ ] If you made important user-facing changes, describe them under the `[Unreleased]` tag in `CHANGELOG.md`.
- [ ] New package dependencies are declared in the `pyproject.toml` file.
  Requirement files have been updated by running `tox -e requirements`.
- [ ] Code works with all supported Python versions (3.10, 3.11, 3.12 and 3.13). Checks run with all supported version and are
  required to run successfully.
- [ ] Code is formatted according to PEP 8 (an IDE like PyCharm can do this for you).
- [ ] Technical guidelines listed in `CONTRIBUTING.md` are followed.
