### PR TITLE
fix: evaluation of ECML2026Rewards.

### DIFF
--- a/flatland/envs/rewards.py
+++ b/flatland/envs/rewards.py
@@ -220,7 +220,8 @@ class BaseDefaultRewards(Rewards[Dict[str, float]]):
 
             # target not reached
             if agent.state.is_on_map_state():
-                d[DefaultPenalties.TARGET_NOT_REACHED.value] = min(-1 * self.target_not_reached_minimum_penalty, agent.get_current_delay(elapsed_steps, distance_map))
+                d[DefaultPenalties.TARGET_NOT_REACHED.value] = min(-1 * self.target_not_reached_minimum_penalty,
+                                                                   agent.get_current_delay(elapsed_steps, distance_map))
         for intermediate_alternatives, la, ed in zip(agent.waypoints[1:-1], agent.waypoints_latest_arrival[1:-1],
                                                      agent.waypoints_earliest_departure[1:-1]):
             agent_arrivals: Set[Waypoint] = set(self.arrivals[agent.handle])
@@ -252,7 +253,7 @@ class BaseDefaultRewards(Rewards[Dict[str, float]]):
 
     def cumulate(self, *rewards: Dict[str, float]) -> Dict[str, float]:
         return {p.value: sum([r[p.value] for r in rewards]) for p in DefaultPenalties}
-    
+
     def normalize(self, *rewards: Dict[str, float], num_agents: int, max_episode_steps: int) -> float:
         # https://flatland-association.github.io/flatland-book/challenges/ecml2026/eval.html
         return sum([np.maximum(sum([r[p.value] for p in DefaultPenalties]), - max_episode_steps) for r in rewards]) / (max_episode_steps * num_agents) + 1
@@ -267,10 +268,10 @@ class DefaultRewards(Rewards[float]):
     """
 
     def __init__(self,
-                 cancellation_factor: float = 1,
-                 cancellation_time_buffer: float = 0,
-                 target_not_reached_minimum_penalty: float = 0,
-                 intermediate_not_served_penalty: float = 1,
+                 cancellation_factor: float = 1.0,
+                 cancellation_time_buffer: float = 0.0,
+                 target_not_reached_minimum_penalty: float = 0.0,
+                 intermediate_not_served_penalty: float = 1.0,
                  intermediate_late_arrival_penalty_factor: float = 0.2,
                  intermediate_early_departure_penalty_factor: float = 0.5,
                  collision_factor: float = 0.0
@@ -365,13 +366,13 @@ class ECML2026Rewards(DefaultRewards):
 
     def __init__(self):
         super().__init__(
-            cancellation_factor = 5,
-            cancellation_time_buffer = 0,
-            target_not_reached_minimum_penalty = 100,
-            intermediate_not_served_penalty = 50,
-            intermediate_late_arrival_penalty_factor = 0.5,
-            intermediate_early_departure_penalty_factor = 0.5,
-            collision_factor = 250
+            cancellation_factor=5.0,
+            cancellation_time_buffer=0.0,
+            target_not_reached_minimum_penalty=100.0,
+            intermediate_not_served_penalty=50.0,
+            intermediate_late_arrival_penalty_factor=0.5,
+            intermediate_early_departure_penalty_factor=0.5,
+            collision_factor=250.0,
         )
 
 

--- a/flatland/evaluators/trajectory_evaluator.py
+++ b/flatland/evaluators/trajectory_evaluator.py
@@ -162,13 +162,20 @@ class TrajectoryEvaluator:
               help="Skip verification of rewards/dones/infos.",
               required=False
               )
+@click.option('--rewards',
+              type=str,
+              help="Defaults to `flatland.envs.rewards.DefaultRewards`. Can also be provided through env var REWARDS (command-line option takes priority).",
+              required=False,
+              default=None,
+              )
 def evaluate_trajectory(
     data_dir: Path,
     ep_id: str,
     callbacks: str = None,
     callbacks_pkg: str = None,
     callbacks_cls: str = None,
-    skip_rewards_dones_infos: bool = False
+    skip_rewards_dones_infos: bool = False,
+    rewards: str = None,
 ):
     if callbacks is None:
         callbacks = os.environ.get("CALLBACKS", None)
@@ -179,6 +186,10 @@ def evaluate_trajectory(
     callbacks = resolve_type(callbacks, callbacks_pkg, callbacks_cls)
     if callbacks is not None:
         callbacks = callbacks()
+    rewards = resolve_type(rewards)
+    if rewards is not None:
+        rewards = rewards()
+
 
     trajectory = Trajectory.load_existing(data_dir=data_dir, ep_id=ep_id)
-    TrajectoryEvaluator(trajectory, callbacks=callbacks).evaluate(skip_rewards_dones_infos=skip_rewards_dones_infos)
+    TrajectoryEvaluator(trajectory, callbacks=callbacks).evaluate(skip_rewards_dones_infos=skip_rewards_dones_infos, rewards=rewards)

--- a/tests/trajectories/test_trajectories.py
+++ b/tests/trajectories/test_trajectories.py
@@ -97,13 +97,21 @@ def test_from_submission():
             TrajectoryEvaluator(trajectory).evaluate(start_step=4)
 
 
-def test_cli_from_submission():
+@pytest.mark.parametrize(
+    'rewards',
+    [None,
+     'flatland.envs.rewards.DefaultRewards',
+     'flatland.envs.rewards.ECML2026Rewards', ]
+)
+def test_cli_from_submission(rewards):
     with tempfile.TemporaryDirectory() as tmpdirname:
         data_dir = Path(tmpdirname)
         with pytest.raises(SystemExit) as e_info:
-            generate_trajectory_from_policy(
-                ["--data-dir", str(data_dir), "--policy-pkg", "tests.trajectories.test_trajectories", "--policy-cls", "RandomPolicy", "--seed", 42,
-                 "--legacy-env-generator", "True"])
+            args = ["--data-dir", str(data_dir), "--policy-pkg", "tests.trajectories.test_trajectories", "--policy-cls", "RandomPolicy", "--seed", 42,
+                    "--legacy-env-generator", "True", ]
+            if rewards is not None:
+                args.extend(["--rewards", rewards])
+            generate_trajectory_from_policy(args)
         assert e_info.value.code == 0
 
         ep_id = re.sub(r"_step.*", "", str(next((data_dir / SERIALISED_STATE_SUBDIR).glob("*step*.pkl")).name))
@@ -123,9 +131,11 @@ def test_cli_from_submission():
         assert "episode_id	env_time	agent_id	position" in (data_dir / TRAINS_POSITIONS_FNAME).read_text()
 
         with pytest.raises(SystemExit) as e_info:
-            evaluate_trajectory(
-                ["--data-dir", str(data_dir), "--ep-id", ep_id, "--callbacks-pkg", "flatland.callbacks.generate_movie_callbacks", "--callbacks-cls",
-                 "GenerateMovieCallbacks"])
+            args = ["--data-dir", str(data_dir), "--ep-id", ep_id, "--callbacks-pkg", "flatland.callbacks.generate_movie_callbacks", "--callbacks-cls",
+                    "GenerateMovieCallbacks"]
+            if rewards is not None:
+                args.extend(["--rewards", rewards])
+            evaluate_trajectory(args)
         assert e_info.value.code == 0
         # requires ffmpeg
         assert len(list((data_dir / OUTPUTS_SUBDIR).glob("*.mp4"))) == 2


### PR DESCRIPTION
## Changes

* fix: evaluation of `ECML2026Rewards`: by using `coefficients`,  fractions are coerced to `float`s.

## Related issues

Link to every issue from the issue tracker (if any) you addressed in this PR.

## Checklist

- [ ] Tests are included for relevant behavior changes.
- [ ] Documentation is added in the [flatland-book](https://github.com/flatland-association/flatland-book) repo for relevant behavior changes.
- [ ] If you made important user-facing changes, describe them under the `[Unreleased]` tag in `CHANGELOG.md`.
- [ ] New package dependencies are declared in the `pyproject.toml` file.
  Requirement files have been updated by running `tox -e requirements`.
- [ ] Code works with all supported Python versions (3.10, 3.11, 3.12 and 3.13). Checks run with all supported version and are
  required to run successfully.
- [ ] Code is formatted according to PEP 8 (an IDE like PyCharm can do this for you).
- [ ] Technical guidelines listed in `CONTRIBUTING.md` are followed.
