### PR TITLE
fix(sparse rail gen): one link per gate-gate pair according to data model.

### DIFF
--- a/flatland/envs/rail_generators.py
+++ b/flatland/envs/rail_generators.py
@@ -390,14 +390,16 @@ class SparseRailGen(RailGen):
             city_open_set = {cell for track in free_rails_city for cell in track}
             free_rails_flooded.append([list(find_connected_cells(grid_map, open_set=city_open_set, forbidden_cells=city_pin_cells))])
 
-        gates_to_fibres: Dict[Tuple[str, str], List[IntVector2DArray]] = defaultdict(list)
+        gates_to_fibres: Dict[Tuple[str, str], List[Tuple[str, str, IntVector2DArray]]] = defaultdict(list)
         for city, fibre in enumerate(inter_city_lines_split):
             fibre_start_pin = fibre[0]
             fibre_end_pin = fibre[-1]
-            from_pin = f"{pin_to_gate[fibre_start_pin]}.{pin_to_track[fibre_start_pin]}"
-            to_pin = f"{pin_to_gate[fibre_end_pin]}.{pin_to_track[fibre_end_pin]}"
+            from_gate = pin_to_gate[fibre_start_pin]
+            to_gate = pin_to_gate[fibre_end_pin]
+            from_pin = f"{from_gate}.{pin_to_track[fibre_start_pin]}"
+            to_pin = f"{to_gate}.{pin_to_track[fibre_end_pin]}"
 
-            gates_to_fibres[(from_pin, to_pin)].append(fibre)
+            gates_to_fibres[(from_gate, to_gate)].append((from_pin, to_pin, fibre))
 
         stations = {
             _city_name(i): Station(
@@ -423,10 +425,10 @@ class SparseRailGen(RailGen):
 
         links = [
             Link(
-                from_pin=from_pin,
-                to_pin=to_pin,
-                fibres=[Fibre(edges=fibre) for fibre in fibres]
-            ) for (from_pin, to_pin), fibres in gates_to_fibres.items()
+                from_gate=from_gate,
+                to_gate=to_gate,
+                fibres=[Fibre(edges=fibre, from_pin=from_pin, to_pin=to_pin) for from_pin, to_pin, fibre in fibres]
+            ) for (from_gate, to_gate), fibres in gates_to_fibres.items()
         ]
         stations_links = StationsLinks(stations=stations, links=links)
         return stations_links

--- a/flatland/envs/stations_links.py
+++ b/flatland/envs/stations_links.py
@@ -41,13 +41,16 @@ class Station:
 @dataclass(frozen=True)
 class Fibre:
     edges: List[IntVector2D]
+    # A.N.0, A.N.1, ...
+    from_pin: str
+    to_pin: str
 
 
 @dataclass(frozen=True)
 class Link:
-    # A.N.0, A.N.1, ...
-    from_pin: str
-    to_pin: str
+    # A.N, A.S, ...
+    from_gate: str
+    to_gate: str
     fibres: List[Fibre]
 
 

--- a/tests/test_flatland_envs_sparse_rail_generator.py
+++ b/tests/test_flatland_envs_sparse_rail_generator.py
@@ -643,7 +643,8 @@ def test_stopping_point_name():
 def test_sparse_rail_generator_gates_to_fibres_reuses_connecting_line():
     """gates_to_fibres/stations_links.links[*].fibres must directly reuse the path _connect_cities
     drew for each inter-city connection instead of re-deriving it with a shortest-path search -
-    each fibre's edges must start/end exactly at its link's from_pin/to_pin node."""
+    each fibre's edges must start/end exactly at its own from_pin/to_pin node, and each link must
+    connect a gate to a gate (not a pin to a pin)."""
     generate = sparse_rail_generator(max_num_cities=3, max_rails_between_cities=2, grid_mode=False)
     grid_map, optionals = generate(width=40, height=40, num_agents=5, np_random=RandomState(1))
 
@@ -656,12 +657,19 @@ def test_sparse_rail_generator_gates_to_fibres_reuses_connecting_line():
         station_name, gate_char, track = pin_name.split(".")
         return stations[station_name].gates[gate_char].pins[int(track)].node
 
+    def gate_of(pin_name):
+        station_name, gate_char, _ = pin_name.split(".")
+        return f"{station_name}.{gate_char}"
+
     for link in links:
+        assert len(link.fibres) > 0
         for fibre in link.fibres:
             edges = fibre.edges
             assert len(edges) > 0
-            assert edges[0] == pin_node(link.from_pin)
-            assert edges[-1] == pin_node(link.to_pin)
+            assert edges[0] == pin_node(fibre.from_pin)
+            assert edges[-1] == pin_node(fibre.to_pin)
+            assert gate_of(fibre.from_pin) == link.from_gate
+            assert gate_of(fibre.to_pin) == link.to_gate
 
 
 def test_stations_links_dataclasses_are_frozen():


### PR DESCRIPTION


## Changes

* fix(sparse rail gen): one link per gate-gate pair according to data model.

## Related issues

Fix for https://github.com/flatland-association/flatland-rl/pull/441
Required by https://github.com/flatland-association/flatland-hmi/pull/26/changes.

## Checklist

- [ ] Tests are included for relevant behavior changes.
- [ ] Documentation is added in the [flatland-book](https://github.com/flatland-association/flatland-book) repo for relevant behavior changes.
- [ ] If you made important user-facing changes, describe them under the `[Unreleased]` tag in `CHANGELOG.md`.
- [ ] New package dependencies are declared in the `pyproject.toml` file.
  Requirement files have been updated by running `tox -e requirements`.
- [ ] Code works with all supported Python versions (3.10, 3.11, 3.12 and 3.13). Checks run with all supported version and are
  required to run successfully.
- [ ] Code is formatted according to PEP 8 (an IDE like PyCharm can do this for you).
- [ ] Technical guidelines listed in `CONTRIBUTING.md` are followed.
