### PR TITLE
refactor(core): extract RailEnv's record_steps into EffectsGenerator.

### DIFF
--- a/flatland/core/effects_generator.py
+++ b/flatland/core/effects_generator.py
@@ -1,4 +1,4 @@
-from typing import Callable, TypeVar, Generic, Dict, Any, List, Optional
+from typing import Callable, TypeVar, Generic, Dict, Any, List, Optional, Type
 
 from flatland.core.env import Environment
 from flatland.utils.cli_utils import resolve_type
@@ -155,21 +155,10 @@ def make_multi_effects_generator(*effects_generators: EffectsGenerator[EnvType])
     return MultiEffectsGeneratorWrapped(*effects_generators)
 
 
-def find_effects_generator(effects_generator: EffectsGenerator[EnvType], cls: type) -> Optional[EffectsGenerator[EnvType]]:
-    """
-    Recursively search a (possibly `MultiEffectsGeneratorWrapped`-composed) effects generator for an instance of `cls`.
-    """
-    if isinstance(effects_generator, cls):
-        return effects_generator
-    if isinstance(effects_generator, MultiEffectsGeneratorWrapped):
-        for eff in effects_generator.effects_generators:
-            found = find_effects_generator(eff, cls)
-            if found is not None:
-                return found
-    return None
+T = TypeVar('T', bound=EffectsGenerator)
 
 
-def find_all_effects_generators(effects_generator: EffectsGenerator[EnvType], cls: type) -> List[EffectsGenerator[EnvType]]:
+def find_all_effects_generators(effects_generator: EffectsGenerator[EnvType], cls: Type[T]) -> List[T]:
     """
     Recursively collect all instances of `cls` within a (possibly `MultiEffectsGeneratorWrapped`-composed) effects generator.
     """
@@ -180,3 +169,10 @@ def find_all_effects_generators(effects_generator: EffectsGenerator[EnvType], cl
         for eff in effects_generator.effects_generators:
             found.extend(find_all_effects_generators(eff, cls))
     return found
+
+
+def find_effects_generator(effects_generator: EffectsGenerator[EnvType], cls: Type[T]) -> Optional[T]:
+    """
+    Recursively search a (possibly `MultiEffectsGeneratorWrapped`-composed) effects generator for an instance of `cls`.
+    """
+    return next(iter(find_all_effects_generators(effects_generator, cls)), None)

--- a/flatland/core/effects_generator.py
+++ b/flatland/core/effects_generator.py
@@ -125,17 +125,17 @@ class MultiEffectsGeneratorWrapped(EffectsGenerator[EnvType]):
 
     def on_episode_start(self, env: EnvType, *args, **kwargs) -> EnvType:
         for eff in self.effects_generators:
-            env = eff.on_episode_start(env)
+            env = eff.on_episode_start(env, *args, **kwargs)
         return env
 
     def on_episode_step_start(self, env: EnvType, *args, **kwargs) -> EnvType:
         for eff in self.effects_generators:
-            env = eff.on_episode_step_start(env)
+            env = eff.on_episode_step_start(env, *args, **kwargs)
         return env
 
     def on_episode_step_end(self, env: EnvType, *args, **kwargs) -> EnvType:
         for eff in self.effects_generators:
-            env = eff.on_episode_step_end(env)
+            env = eff.on_episode_step_end(env, *args, **kwargs)
         return env
 
     def __getstate__(self):

--- a/flatland/core/effects_generator.py
+++ b/flatland/core/effects_generator.py
@@ -151,8 +151,23 @@ class MultiEffectsGeneratorWrapped(EffectsGenerator[EnvType]):
         self.__init__(*[EffectsGenerator.from_state(state_dict_) for state_dict_ in specs.get("args", [])])
 
 
+def _flatten_effects_generators(effects_generators):
+    flattened = []
+    for eff in effects_generators:
+        if isinstance(eff, MultiEffectsGeneratorWrapped):
+            flattened.extend(_flatten_effects_generators(eff.effects_generators))
+        else:
+            flattened.append(eff)
+    return flattened
+
+
 def make_multi_effects_generator(*effects_generators: EffectsGenerator[EnvType]) -> EffectsGenerator[EnvType]:
-    return MultiEffectsGeneratorWrapped(*effects_generators)
+    """
+    Compose effects generators into a single flat `MultiEffectsGeneratorWrapped` - any argument that is itself a
+    `MultiEffectsGeneratorWrapped` (however deeply nested) is unwrapped first, so nesting never accumulates
+    regardless of the shape of what's passed in.
+    """
+    return MultiEffectsGeneratorWrapped(*_flatten_effects_generators(effects_generators))
 
 
 T = TypeVar('T', bound=EffectsGenerator)

--- a/flatland/core/effects_generator.py
+++ b/flatland/core/effects_generator.py
@@ -1,4 +1,4 @@
-from typing import Callable, TypeVar, Generic, Dict, Any
+from typing import Callable, TypeVar, Generic, Dict, Any, List, Optional
 
 from flatland.core.env import Environment
 from flatland.utils.cli_utils import resolve_type
@@ -153,3 +153,30 @@ class MultiEffectsGeneratorWrapped(EffectsGenerator[EnvType]):
 
 def make_multi_effects_generator(*effects_generators: EffectsGenerator[EnvType]) -> EffectsGenerator[EnvType]:
     return MultiEffectsGeneratorWrapped(*effects_generators)
+
+
+def find_effects_generator(effects_generator: EffectsGenerator[EnvType], cls: type) -> Optional[EffectsGenerator[EnvType]]:
+    """
+    Recursively search a (possibly `MultiEffectsGeneratorWrapped`-composed) effects generator for an instance of `cls`.
+    """
+    if isinstance(effects_generator, cls):
+        return effects_generator
+    if isinstance(effects_generator, MultiEffectsGeneratorWrapped):
+        for eff in effects_generator.effects_generators:
+            found = find_effects_generator(eff, cls)
+            if found is not None:
+                return found
+    return None
+
+
+def find_all_effects_generators(effects_generator: EffectsGenerator[EnvType], cls: type) -> List[EffectsGenerator[EnvType]]:
+    """
+    Recursively collect all instances of `cls` within a (possibly `MultiEffectsGeneratorWrapped`-composed) effects generator.
+    """
+    found = []
+    if isinstance(effects_generator, cls):
+        found.append(effects_generator)
+    if isinstance(effects_generator, MultiEffectsGeneratorWrapped):
+        for eff in effects_generator.effects_generators:
+            found.extend(find_all_effects_generators(eff, cls))
+    return found

--- a/flatland/envs/persistence.py
+++ b/flatland/envs/persistence.py
@@ -298,17 +298,17 @@ class RailEnvPersister(object):
         if effects_generator is not None:
             env.effects_generator = effects_generator
         else:
-            # `record_steps` is not part of the serialized `effects_generator` state (see `RecordStepsEffectsGenerator.__getstate__`),
-            # so carry over whatever is currently configured on `env` (e.g. from the `RailEnv` constructor) across the rebuild below.
-            current_record_steps_generator = find_effects_generator(env.effects_generator, RecordStepsEffectsGenerator)
-            record_steps = current_record_steps_generator.record_steps if current_record_steps_generator is not None else False
-            env.effects_generator = cls._apply_malfunction(env_dict, record_steps=record_steps)
+            # a `RecordStepsEffectsGenerator`'s mere presence (not a flag on it) is what makes an env record steps,
+            # and for "old format" files that presence isn't part of the serialized `effects_generator` state, so
+            # carry over whether one was configured on `env` (e.g. from the `RailEnv` constructor) across the rebuild below.
+            had_record_steps_effects_generator = find_effects_generator(env.effects_generator, RecordStepsEffectsGenerator) is not None
+            env.effects_generator = cls._apply_malfunction(env_dict, add_record_steps_effects_generator=had_record_steps_effects_generator)
 
         if "stations_links" in env_dict:
             env.stations_links = env_dict["stations_links"]
 
     @classmethod
-    def _apply_malfunction(cls, env_dict: dict, record_steps: bool = False):
+    def _apply_malfunction(cls, env_dict: dict, add_record_steps_effects_generator: bool = False):
         effects_generator = EffectsGenerator()
         # backwards compatibility
         if env_dict.get('malfunction') is not None and isinstance(env_dict.get('malfunction').malfunction_rate, float) and isinstance(
@@ -321,17 +321,17 @@ class RailEnvPersister(object):
         if effects_generators_specs is not None:
             effects_generator = EffectsGenerator.from_state(effects_generators_specs)
 
-        # ensure exactly one `RecordStepsEffectsGenerator` is present - restored from the "new format" `effects_generator`
-        # state above if it was saved with one, otherwise added here so record_steps keeps working after loading
+        # a `RecordStepsEffectsGenerator` records unconditionally whenever it's present - restore it from the "new
+        # format" `effects_generator` state above if it was saved with one, otherwise add it back here if the caller
+        # says one was configured before this rebuild, so recording keeps working after loading (old format)
         record_steps_effects_generator = find_effects_generator(effects_generator, RecordStepsEffectsGenerator)
-        if record_steps_effects_generator is None:
+        if record_steps_effects_generator is None and add_record_steps_effects_generator:
             record_steps_effects_generator = RecordStepsEffectsGenerator()
             effects_generator = make_multi_effects_generator(effects_generator, record_steps_effects_generator)
-        record_steps_effects_generator.record_steps = record_steps
 
         # old format: actions recorded by `save_episode` under a dedicated top-level key, not part of `effects_generator` state
         list_actions = env_dict.get("actions", None)
-        if list_actions is not None:
+        if list_actions is not None and record_steps_effects_generator is not None:
             record_steps_effects_generator.set_state(list_actions)
 
         return effects_generator

--- a/flatland/envs/persistence.py
+++ b/flatland/envs/persistence.py
@@ -305,18 +305,30 @@ class RailEnvPersister(object):
 
     @classmethod
     def _apply_effects_generator(cls, env_dict: dict):
-        effects_generator = EffectsGenerator()
-        # backwards compatibility
-        if env_dict.get('malfunction') is not None and isinstance(env_dict.get('malfunction').malfunction_rate, float) and isinstance(
-            env_dict.get('malfunction').min_duration, int) and isinstance(env_dict.get('malfunction').max_duration, int):
-            malfunction_generator = mal_gen.ParamMalfunctionGen.extract_malfunction_generator(env_dict)
-            effects_generator = mal_eff_gen.MalfunctionEffectsGenerator(malfunction_generator)
-
-        # new format
+        # new format takes precedence: if the full effects_generator state was saved, that alone is authoritative
         effects_generators_specs = env_dict.get("effects_generator", None)
         if effects_generators_specs is not None:
             effects_generator = EffectsGenerator.from_state(effects_generators_specs)
+        else:
+            effects_generator = cls._patch_malfunction_effects_generator(EffectsGenerator(), env_dict)
 
+        effects_generator = cls._patch_record_steps_effects_generator(effects_generator, env_dict)
+        return effects_generator
+
+    @classmethod
+    def _patch_malfunction_effects_generator(cls, effects_generator: EffectsGenerator, env_dict: dict) -> EffectsGenerator:
+        """
+        Backwards compatibility: legacy files (pre-dating the "effects_generator" state key) stored malfunction
+        parameters directly under a top-level "malfunction" key - reconstruct a MalfunctionEffectsGenerator from it.
+        """
+        if env_dict.get('malfunction') is not None and isinstance(env_dict.get('malfunction').malfunction_rate, float) and isinstance(
+            env_dict.get('malfunction').min_duration, int) and isinstance(env_dict.get('malfunction').max_duration, int):
+            malfunction_generator = mal_gen.ParamMalfunctionGen.extract_malfunction_generator(env_dict)
+            return mal_eff_gen.MalfunctionEffectsGenerator(malfunction_generator)
+        return effects_generator
+
+    @classmethod
+    def _patch_record_steps_effects_generator(cls, effects_generator: EffectsGenerator, env_dict: dict) -> EffectsGenerator:
         # old format: actions recorded by `save_episode` under a dedicated top-level key, not part of `effects_generator`
         # state. Its mere presence is the signal that recording was desired - patch a `RecordStepsEffectsGenerator` in
         # with that history if the "new format" restore above didn't already deserialize one.
@@ -327,7 +339,6 @@ class RailEnvPersister(object):
                 record_steps_effects_generator = RecordStepsEffectsGenerator()
                 effects_generator = make_multi_effects_generator(effects_generator, record_steps_effects_generator)
             record_steps_effects_generator.set_state(list_actions)
-
         return effects_generator
 
     @classmethod

--- a/flatland/envs/persistence.py
+++ b/flatland/envs/persistence.py
@@ -298,17 +298,13 @@ class RailEnvPersister(object):
         if effects_generator is not None:
             env.effects_generator = effects_generator
         else:
-            # a `RecordStepsEffectsGenerator`'s mere presence (not a flag on it) is what makes an env record steps,
-            # and for "old format" files that presence isn't part of the serialized `effects_generator` state, so
-            # carry over whether one was configured on `env` (e.g. from the `RailEnv` constructor) across the rebuild below.
-            had_record_steps_effects_generator = find_effects_generator(env.effects_generator, RecordStepsEffectsGenerator) is not None
-            env.effects_generator = cls._apply_malfunction(env_dict, add_record_steps_effects_generator=had_record_steps_effects_generator)
+            env.effects_generator = cls._apply_effects_generator(env_dict)
 
         if "stations_links" in env_dict:
             env.stations_links = env_dict["stations_links"]
 
     @classmethod
-    def _apply_malfunction(cls, env_dict: dict, add_record_steps_effects_generator: bool = False):
+    def _apply_effects_generator(cls, env_dict: dict):
         effects_generator = EffectsGenerator()
         # backwards compatibility
         if env_dict.get('malfunction') is not None and isinstance(env_dict.get('malfunction').malfunction_rate, float) and isinstance(
@@ -321,17 +317,15 @@ class RailEnvPersister(object):
         if effects_generators_specs is not None:
             effects_generator = EffectsGenerator.from_state(effects_generators_specs)
 
-        # a `RecordStepsEffectsGenerator` records unconditionally whenever it's present - restore it from the "new
-        # format" `effects_generator` state above if it was saved with one, otherwise add it back here if the caller
-        # says one was configured before this rebuild, so recording keeps working after loading (old format)
-        record_steps_effects_generator = find_effects_generator(effects_generator, RecordStepsEffectsGenerator)
-        if record_steps_effects_generator is None and add_record_steps_effects_generator:
-            record_steps_effects_generator = RecordStepsEffectsGenerator()
-            effects_generator = make_multi_effects_generator(effects_generator, record_steps_effects_generator)
-
-        # old format: actions recorded by `save_episode` under a dedicated top-level key, not part of `effects_generator` state
+        # old format: actions recorded by `save_episode` under a dedicated top-level key, not part of `effects_generator`
+        # state. Its mere presence is the signal that recording was desired - patch a `RecordStepsEffectsGenerator` in
+        # with that history if the "new format" restore above didn't already deserialize one.
         list_actions = env_dict.get("actions", None)
-        if list_actions is not None and record_steps_effects_generator is not None:
+        if list_actions is not None:
+            record_steps_effects_generator = find_effects_generator(effects_generator, RecordStepsEffectsGenerator)
+            if record_steps_effects_generator is None:
+                record_steps_effects_generator = RecordStepsEffectsGenerator()
+                effects_generator = make_multi_effects_generator(effects_generator, record_steps_effects_generator)
             record_steps_effects_generator.set_state(list_actions)
 
         return effects_generator

--- a/flatland/envs/persistence.py
+++ b/flatland/envs/persistence.py
@@ -6,9 +6,10 @@ import msgpack
 import msgpack_numpy
 import numpy as np
 
-from flatland.core.effects_generator import EffectsGenerator
+from flatland.core.effects_generator import EffectsGenerator, find_effects_generator, make_multi_effects_generator
 from flatland.core.grid.grid_resource_map import GridResourceMap
 from flatland.envs.rail_trainrun_data_structures import Waypoint
+from flatland.envs.record_steps_effects_generator import RecordStepsEffectsGenerator
 
 msgpack_numpy.patch()
 from flatland.envs.step_utils.states import StateTransitionSignals
@@ -73,7 +74,8 @@ class RailEnvPersister(object):
 
         # Add additional info to dict_env before saving
         dict_env["episode"] = env.cur_episode
-        dict_env["actions"] = env.list_actions
+        record_steps_effects_generator = find_effects_generator(env.effects_generator, RecordStepsEffectsGenerator)
+        dict_env["actions"] = record_steps_effects_generator.list_actions if record_steps_effects_generator is not None else []
         dict_env["shape"] = (env.width, env.height)
         dict_env["max_episode_steps"] = env._max_episode_steps
 
@@ -296,13 +298,17 @@ class RailEnvPersister(object):
         if effects_generator is not None:
             env.effects_generator = effects_generator
         else:
-            env.effects_generator = cls._apply_malfunction(env_dict)
+            # `record_steps` is not part of the serialized `effects_generator` state (see `RecordStepsEffectsGenerator.__getstate__`),
+            # so carry over whatever is currently configured on `env` (e.g. from the `RailEnv` constructor) across the rebuild below.
+            current_record_steps_generator = find_effects_generator(env.effects_generator, RecordStepsEffectsGenerator)
+            record_steps = current_record_steps_generator.record_steps if current_record_steps_generator is not None else False
+            env.effects_generator = cls._apply_malfunction(env_dict, record_steps=record_steps)
 
         if "stations_links" in env_dict:
             env.stations_links = env_dict["stations_links"]
 
     @classmethod
-    def _apply_malfunction(cls, env_dict: dict):
+    def _apply_malfunction(cls, env_dict: dict, record_steps: bool = False):
         effects_generator = EffectsGenerator()
         # backwards compatibility
         if env_dict.get('malfunction') is not None and isinstance(env_dict.get('malfunction').malfunction_rate, float) and isinstance(
@@ -314,6 +320,20 @@ class RailEnvPersister(object):
         effects_generators_specs = env_dict.get("effects_generator", None)
         if effects_generators_specs is not None:
             effects_generator = EffectsGenerator.from_state(effects_generators_specs)
+
+        # ensure exactly one `RecordStepsEffectsGenerator` is present - restored from the "new format" `effects_generator`
+        # state above if it was saved with one, otherwise added here so record_steps keeps working after loading
+        record_steps_effects_generator = find_effects_generator(effects_generator, RecordStepsEffectsGenerator)
+        if record_steps_effects_generator is None:
+            record_steps_effects_generator = RecordStepsEffectsGenerator()
+            effects_generator = make_multi_effects_generator(effects_generator, record_steps_effects_generator)
+        record_steps_effects_generator.record_steps = record_steps
+
+        # old format: actions recorded by `save_episode` under a dedicated top-level key, not part of `effects_generator` state
+        list_actions = env_dict.get("actions", None)
+        if list_actions is not None:
+            record_steps_effects_generator.set_state(list_actions)
+
         return effects_generator
 
     @classmethod

--- a/flatland/envs/rail_env.py
+++ b/flatland/envs/rail_env.py
@@ -12,7 +12,7 @@ import numpy as np
 
 import flatland.envs.timetable_generators as ttg
 from flatland.core.distance_map import AbstractDistanceMap
-from flatland.core.effects_generator import EffectsGenerator, make_multi_effects_generator
+from flatland.core.effects_generator import EffectsGenerator, MultiEffectsGeneratorWrapped, make_multi_effects_generator
 from flatland.core.env import Environment
 from flatland.core.env_observation_builder import ObservationBuilder
 from flatland.core.grid.grid_resource_map import GridResourceMap
@@ -28,6 +28,7 @@ from flatland.envs.grid.distance_map import DistanceMap
 from flatland.envs.grid.rail_env_grid import RailEnvTransitionsEnum
 from flatland.envs.observations import GlobalObsForRailEnv
 from flatland.envs.rail_env_action import RailEnvActions
+from flatland.envs.record_steps_effects_generator import RecordStepsEffectsGenerator
 from flatland.envs.rewards import DefaultRewards, Rewards
 from flatland.envs.step_utils import env_utils
 from flatland.envs.step_utils.speed_counter import cached_cap_speed
@@ -597,7 +598,7 @@ class AbstractRailEnv(Environment, Generic[UnderlyingTransitionMapType, Underlyi
 
         self._verify_mutually_exclusive_resource_allocation()
 
-        self.effects_generator.on_episode_step_end(self)
+        self.effects_generator.on_episode_step_end(self, action_dict=action_dict)
 
         return self._get_observations(), self.rewards_dict, self.dones, self.get_info_dict()
 
@@ -714,11 +715,14 @@ class RailEnv(AbstractRailEnv[GridTransitionMap, GridResourceMap, Tuple[Tuple[in
 
         self.agent_positions = None
 
-        # save episode timesteps ie agent positions, orientations.  (not yet actions / observations)
-        self.record_steps = record_steps  # whether to save timesteps
         # save timesteps in here: [[[row, col, dir, malfunction],...nAgents], ...nSteps]
         self.cur_episode = []
-        self.list_actions = []  # save actions in here
+        record_steps_effects_generator = RecordStepsEffectsGenerator(record_steps=record_steps)
+        if isinstance(self.effects_generator, MultiEffectsGeneratorWrapped):
+            # flatten instead of nesting another `MultiEffectsGeneratorWrapped` layer around the existing one
+            self.effects_generator = make_multi_effects_generator(*self.effects_generator.effects_generators, record_steps_effects_generator)
+        else:
+            self.effects_generator = make_multi_effects_generator(self.effects_generator, record_steps_effects_generator)
 
         # Agent positions map
         self.agent_positions = np.zeros((self.height, self.width), dtype=int) - 1
@@ -766,41 +770,11 @@ class RailEnv(AbstractRailEnv[GridTransitionMap, GridResourceMap, Tuple[Tuple[in
     def step(self, action_dict: Dict[int, RailEnvActions]):
         obs, rewards, dones, info = super().step(action_dict=action_dict)
         # TODO https://github.com/flatland-association/flatland-rl/issues/195 add idiomatic wrapper instead of override
-        if self.record_steps:
-            self.record_timestep(action_dict)
-        # TODO https://github.com/flatland-association/flatland-rl/issues/195 add idiomatic wrapper instead of override
         self._update_agent_positions_map()
         return obs, rewards, dones, info
 
     def _infrastructure_representation(self, configuration: Tuple[Tuple[int, int], int]) -> str:
         return RailEnvTransitionsEnum(self.rail.get_full_transitions(*configuration.position)).name
-
-    # TODO https://github.com/flatland-association/flatland-rl/issues/195  extract to callbacks instead!
-    def record_timestep(self, dActions):
-        """
-        Record the positions and orientations of all agents in memory, in the cur_episode
-        """
-        list_agents_state = []
-        for i_agent in range(self.get_num_agents()):
-            agent = self.agents[i_agent]
-            # the int cast is to avoid numpy types which may cause problems with msgpack
-            # in env v2, agents may have position None, before starting
-            if agent.position is None:
-                pos = (None, None)
-                dir = None
-            else:
-                pos = (int(agent.position[0]), int(agent.position[1]))
-                dir = int(agent.direction)
-            # print("pos:", pos, type(pos[0]))
-            list_agents_state.append([
-                *pos, dir,
-                agent.malfunction_handler.malfunction_down_counter,
-                agent.state.value,
-                int(agent.position in self.motion_check.deadlocked),
-            ])
-
-        self.cur_episode.append(list_agents_state)
-        self.list_actions.append(dActions)
 
     def _apply_timetable_to_agents(self, agents, timetable: "Timetable") -> List[EnvAgent[Tuple[Tuple[int, int], int]]]:
         return EnvAgent.apply_timetable(self.agents, timetable)

--- a/flatland/envs/rail_env.py
+++ b/flatland/envs/rail_env.py
@@ -12,7 +12,7 @@ import numpy as np
 
 import flatland.envs.timetable_generators as ttg
 from flatland.core.distance_map import AbstractDistanceMap
-from flatland.core.effects_generator import EffectsGenerator, MultiEffectsGeneratorWrapped, make_multi_effects_generator
+from flatland.core.effects_generator import EffectsGenerator, find_effects_generator, make_multi_effects_generator
 from flatland.core.env import Environment
 from flatland.core.env_observation_builder import ObservationBuilder
 from flatland.core.grid.grid_resource_map import GridResourceMap
@@ -717,12 +717,11 @@ class RailEnv(AbstractRailEnv[GridTransitionMap, GridResourceMap, Tuple[Tuple[in
 
         # save timesteps in here: [[[row, col, dir, malfunction],...nAgents], ...nSteps]
         self.cur_episode = []
-        record_steps_effects_generator = RecordStepsEffectsGenerator(record_steps=record_steps)
-        if isinstance(self.effects_generator, MultiEffectsGeneratorWrapped):
-            # flatten instead of nesting another `MultiEffectsGeneratorWrapped` layer around the existing one
-            self.effects_generator = make_multi_effects_generator(*self.effects_generator.effects_generators, record_steps_effects_generator)
-        else:
-            self.effects_generator = make_multi_effects_generator(self.effects_generator, record_steps_effects_generator)
+        if record_steps and find_effects_generator(self.effects_generator, RecordStepsEffectsGenerator) is None:
+            # `make_multi_effects_generator` flattens automatically, so this never nests regardless of what the
+            # caller passed as `effects_generator`; the `find_effects_generator` check above avoids adding a
+            # second `RecordStepsEffectsGenerator` if the caller's `effects_generator` already contains one.
+            self.effects_generator = make_multi_effects_generator(self.effects_generator, RecordStepsEffectsGenerator())
 
         # Agent positions map
         self.agent_positions = np.zeros((self.height, self.width), dtype=int) - 1

--- a/flatland/envs/record_steps_effects_generator.py
+++ b/flatland/envs/record_steps_effects_generator.py
@@ -7,18 +7,19 @@ from flatland.envs.rail_env_action import RailEnvActions
 class RecordStepsEffectsGenerator(EffectsGenerator["RailEnv"]):
     """
     Records agent positions, orientations, malfunction status, state and deadlock status for each step
-    into `env.cur_episode`, and the actions into `self.list_actions`, whenever `self.record_steps` is set.
+    into `env.cur_episode`, and the actions into `self.list_actions`, for every step, whenever composed into an env's
+    `effects_generator`. Whether steps are recorded at all is controlled by whether this generator is present in the
+    chain (see `RailEnv`'s `record_steps` constructor argument), not by any flag on this class.
     """
 
-    def __init__(self, record_steps: bool = False):
+    def __init__(self):
         super().__init__()
-        self.record_steps = record_steps  # whether to save timesteps
         self.list_actions = []  # save actions in here
 
     def on_episode_step_end(self, env: "RailEnv", action_dict: Optional[Dict[int, RailEnvActions]] = None, *args, **kwargs) -> "RailEnv":
         # `env` may be `None` here if an earlier effects generator composed alongside this one in a
         # `MultiEffectsGeneratorWrapped` chain does not return it (e.g. mutates in place and returns `None`).
-        if env is None or not self.record_steps:
+        if env is None:
             return env
 
         list_agents_state = []

--- a/flatland/envs/record_steps_effects_generator.py
+++ b/flatland/envs/record_steps_effects_generator.py
@@ -17,11 +17,6 @@ class RecordStepsEffectsGenerator(EffectsGenerator["RailEnv"]):
         self.list_actions = []  # save actions in here
 
     def on_episode_step_end(self, env: "RailEnv", action_dict: Optional[Dict[int, RailEnvActions]] = None, *args, **kwargs) -> "RailEnv":
-        # `env` may be `None` here if an earlier effects generator composed alongside this one in a
-        # `MultiEffectsGeneratorWrapped` chain does not return it (e.g. mutates in place and returns `None`).
-        if env is None:
-            return env
-
         list_agents_state = []
         for i_agent in range(env.get_num_agents()):
             agent = env.agents[i_agent]

--- a/flatland/envs/record_steps_effects_generator.py
+++ b/flatland/envs/record_steps_effects_generator.py
@@ -1,0 +1,55 @@
+from typing import Dict, List, Optional
+
+from flatland.core.effects_generator import EffectsGenerator
+from flatland.envs.rail_env_action import RailEnvActions
+
+
+class RecordStepsEffectsGenerator(EffectsGenerator["RailEnv"]):
+    """
+    Records agent positions, orientations, malfunction status, state and deadlock status for each step
+    into `env.cur_episode`, and the actions into `self.list_actions`, whenever `self.record_steps` is set.
+    """
+
+    def __init__(self, record_steps: bool = False):
+        super().__init__()
+        self.record_steps = record_steps  # whether to save timesteps
+        self.list_actions = []  # save actions in here
+
+    def on_episode_step_end(self, env: "RailEnv", action_dict: Optional[Dict[int, RailEnvActions]] = None, *args, **kwargs) -> "RailEnv":
+        # `env` may be `None` here if an earlier effects generator composed alongside this one in a
+        # `MultiEffectsGeneratorWrapped` chain does not return it (e.g. mutates in place and returns `None`).
+        if env is None or not self.record_steps:
+            return env
+
+        list_agents_state = []
+        for i_agent in range(env.get_num_agents()):
+            agent = env.agents[i_agent]
+            # the int cast is to avoid numpy types which may cause problems with msgpack
+            # in env v2, agents may have position None, before starting
+            if agent.position is None:
+                pos = (None, None)
+                dir = None
+            else:
+                pos = (int(agent.position[0]), int(agent.position[1]))
+                dir = int(agent.direction)
+            list_agents_state.append([
+                *pos, dir,
+                agent.malfunction_handler.malfunction_down_counter,
+                agent.state.value,
+                int(agent.position in env.motion_check.deadlocked),
+            ])
+
+        env.cur_episode.append(list_agents_state)
+        self.list_actions.append(action_dict)
+        return env
+
+    def set_state(self, list_actions: List[Optional[Dict[int, RailEnvActions]]]):
+        """
+        Restore `list_actions` from persisted state, e.g. the "actions" recorded by `RailEnvPersister.save_episode`.
+        Not part of the generic `EffectsGenerator.__getstate__`/`__setstate__` roundtrip, since actions are stored
+        under a dedicated top-level key rather than embedded in the serialized `effects_generator` state.
+        """
+        self.list_actions = list(list_actions)
+
+    def __getstate__(self):
+        return {"cls": self.fullname}

--- a/tests/test_flatland_envs_persistence.py
+++ b/tests/test_flatland_envs_persistence.py
@@ -269,6 +269,23 @@ def _make_env_with_record_steps():
     return env
 
 
+def test_record_steps_effects_generator_records_live_action_dict():
+    """
+    `env.step(action_dict)` must deliver `action_dict` all the way through `effects_generator.on_episode_step_end`
+    to the composed `RecordStepsEffectsGenerator`, not just seed `list_actions` directly via `set_state`.
+    """
+    env = _make_env_with_record_steps()
+
+    action_dict_1 = {0: RailEnvActions.MOVE_FORWARD, 1: RailEnvActions.STOP_MOVING}
+    action_dict_2 = {0: RailEnvActions.MOVE_FORWARD, 1: RailEnvActions.MOVE_FORWARD}
+    env.step(action_dict_1)
+    env.step(action_dict_2)
+
+    record_steps_effects_generator = find_effects_generator(env.effects_generator, RecordStepsEffectsGenerator)
+    assert record_steps_effects_generator.list_actions == [action_dict_1, action_dict_2]
+    assert len(env.cur_episode) == 2
+
+
 def test_record_steps_effects_generator_deserialization_new_format():
     """
     Post-refactor episode files have both a "new format" `effects_generator` state (which already embeds a

--- a/tests/test_flatland_envs_persistence.py
+++ b/tests/test_flatland_envs_persistence.py
@@ -5,7 +5,7 @@ import importlib_resources as ir
 import numpy as np
 import pytest
 
-from flatland.core.effects_generator import EffectsGenerator
+from flatland.core.effects_generator import EffectsGenerator, find_all_effects_generators, find_effects_generator
 from flatland.core.env_observation_builder import DummyObservationBuilder
 from flatland.env_generation.env_generator import env_generator_legacy
 from flatland.envs.line_generators import sparse_line_generator
@@ -15,6 +15,7 @@ from flatland.envs.persistence import RailEnvPersister
 from flatland.envs.rail_env import RailEnv
 from flatland.envs.rail_env_action import RailEnvActions
 from flatland.envs.rail_generators import rail_from_grid_transition_map
+from flatland.envs.record_steps_effects_generator import RecordStepsEffectsGenerator
 from flatland.envs.rewards import DefaultRewards
 from flatland.utils.simple_rail import make_simple_rail
 
@@ -236,6 +237,9 @@ def test_multiple_malfunction_generators():
                             'malfunction_rand_idx': 0
                         }
                     }
+                },
+                {
+                    'cls': 'flatland.envs.record_steps_effects_generator.RecordStepsEffectsGenerator',
                 }
             ],
         }
@@ -255,3 +259,66 @@ def test_multiple_malfunction_generators():
         RailEnvPersister.save(env, filename=os.path.join(tmpdirname, "env.pkl"))
         env, _ = RailEnvPersister.load_new(filename=os.path.join(tmpdirname, "env.pkl"))
     assert env.effects_generator.__getstate__() == expected
+
+
+def _make_env_with_record_steps():
+    rail, rail_map, optionals = make_simple_rail()
+    env = RailEnv(width=rail_map.shape[1], height=rail_map.shape[0], rail_generator=rail_from_grid_transition_map(rail, optionals),
+                  line_generator=sparse_line_generator(), number_of_agents=2, record_steps=True)
+    env.reset(False, False)
+    return env
+
+
+def test_record_steps_effects_generator_deserialization_new_format():
+    """
+    Post-refactor episode files have both a "new format" `effects_generator` state (which already embeds a
+    `RecordStepsEffectsGenerator`, since it is composed into every `RailEnv`) and a top-level "actions" key
+    (written by `save_episode`). Deserialization must reuse the `RecordStepsEffectsGenerator` restored from the
+    `effects_generator` state - filling it with `list_actions` from the top-level "actions" key - rather than
+    adding a second one.
+    """
+    env = _make_env_with_record_steps()
+    action_dicts = [
+        {0: RailEnvActions.MOVE_FORWARD, 1: RailEnvActions.STOP_MOVING},
+        {0: RailEnvActions.MOVE_FORWARD, 1: RailEnvActions.MOVE_FORWARD},
+    ]
+    # seed list_actions directly so the test does not depend on what step() itself passes through the effects_generator chain
+    find_effects_generator(env.effects_generator, RecordStepsEffectsGenerator).set_state(action_dicts)
+
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        filename = os.path.join(tmpdirname, "episode.pkl")
+        RailEnvPersister.save_episode(env, filename)
+        env_loaded, env_dict = RailEnvPersister.load_new(filename)
+
+    assert env_dict["actions"] == action_dicts
+    assert env_dict["effects_generator"] is not None
+
+    found = find_all_effects_generators(env_loaded.effects_generator, RecordStepsEffectsGenerator)
+    assert len(found) == 1, f"expected exactly one RecordStepsEffectsGenerator after deserialization, found {len(found)}"
+    assert found[0].list_actions == action_dicts
+
+
+def test_record_steps_effects_generator_deserialization_old_format():
+    """
+    Legacy episode files (pre-dating `RecordStepsEffectsGenerator`) have a top-level "actions" key from
+    `save_episode`, but no `RecordStepsEffectsGenerator` in their (possibly absent) `effects_generator` state.
+    Deserialization must add exactly one `RecordStepsEffectsGenerator` and fill it from that legacy "actions" key.
+    """
+    env = _make_env_with_record_steps()
+
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        filename = os.path.join(tmpdirname, "episode.pkl")
+        RailEnvPersister.save_episode(env, filename)
+        env_dict = RailEnvPersister.load_env_dict(filename)
+
+    # simulate a legacy episode file: no "effects_generator" key at all
+    del env_dict["effects_generator"]
+    action_dicts = [{0: RailEnvActions.MOVE_FORWARD, 1: RailEnvActions.STOP_MOVING}]
+    env_dict["actions"] = action_dicts
+
+    env_loaded = _make_env_with_record_steps()
+    RailEnvPersister.set_full_state(env_loaded, env_dict)
+
+    found = find_all_effects_generators(env_loaded.effects_generator, RecordStepsEffectsGenerator)
+    assert len(found) == 1, f"expected exactly one RecordStepsEffectsGenerator after deserialization, found {len(found)}"
+    assert found[0].list_actions == action_dicts

--- a/tests/test_flatland_envs_persistence.py
+++ b/tests/test_flatland_envs_persistence.py
@@ -250,6 +250,7 @@ def test_multiple_malfunction_generators():
                   malfunction_generator=ParamMalfunctionGen(MalfunctionParameters(min_duration=20, max_duration=30, malfunction_rate=1.0 / 200)),
                   effects_generator=MalfunctionEffectsGenerator(
                       ParamMalfunctionGen(MalfunctionParameters(min_duration=22, max_duration=33, malfunction_rate=1.0 / 222))),
+                  record_steps=True,
                   )
     env.reset()
     assert env.effects_generator.__getstate__() == expected

--- a/tests/test_flatland_envs_rail_env_effects_generator.py
+++ b/tests/test_flatland_envs_rail_env_effects_generator.py
@@ -32,6 +32,7 @@ def test_rail_env_effects_generator_on_episode_step_end():
     class TestMalfunctionEffectsGenerator(EffectsGenerator[RailEnv]):
         def on_episode_step_end(self, env: RailEnv, *args, **kwargs) -> RailEnv:
             env.agents[0].malfunction_handler._set_malfunction_down_counter(999999)
+            return env
 
     env, _, _ = env_generator(seed=42, effects_generator=TestMalfunctionEffectsGenerator())
     assert env.agents[0].malfunction_handler.malfunction_down_counter == 0

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -89,7 +89,9 @@ def run_replay_config(env: RailEnv, test_configs: List[ReplayConfig], rendering:
         'action_required': [True for _ in test_configs]
     }
 
-    find_effects_generator(env.effects_generator, RecordStepsEffectsGenerator).record_steps = True
+    record_steps_effects_generator = find_effects_generator(env.effects_generator, RecordStepsEffectsGenerator)
+    if record_steps_effects_generator is not None:
+        record_steps_effects_generator.record_steps = True
 
     for step in range(len(test_configs[0].replay)):
         if step == 0:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,6 +4,7 @@ from typing import List, Tuple, Optional
 import numpy as np
 from attr import attrs, attrib
 
+from flatland.core.effects_generator import find_effects_generator
 from flatland.core.grid.grid4 import Grid4TransitionsEnum
 from flatland.envs.agent_utils import EnvAgent
 from flatland.envs.line_generators import LineGenerator
@@ -11,6 +12,7 @@ from flatland.envs.malfunction_generators import MalfunctionParameters, malfunct
 from flatland.envs.persistence import RailEnvPersister
 from flatland.envs.rail_env import RailEnvActions, RailEnv
 from flatland.envs.rail_generators import RailGenerator
+from flatland.envs.record_steps_effects_generator import RecordStepsEffectsGenerator
 from flatland.envs.step_utils.speed_counter import SpeedCounter
 from flatland.envs.step_utils.states import TrainState
 from flatland.utils.rendertools import RenderTool
@@ -87,7 +89,7 @@ def run_replay_config(env: RailEnv, test_configs: List[ReplayConfig], rendering:
         'action_required': [True for _ in test_configs]
     }
 
-    env.record_steps = True
+    find_effects_generator(env.effects_generator, RecordStepsEffectsGenerator).record_steps = True
 
     for step in range(len(test_configs[0].replay)):
         if step == 0:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,7 @@ from typing import List, Tuple, Optional
 import numpy as np
 from attr import attrs, attrib
 
-from flatland.core.effects_generator import find_effects_generator
+from flatland.core.effects_generator import find_effects_generator, make_multi_effects_generator
 from flatland.core.grid.grid4 import Grid4TransitionsEnum
 from flatland.envs.agent_utils import EnvAgent
 from flatland.envs.line_generators import LineGenerator
@@ -89,9 +89,8 @@ def run_replay_config(env: RailEnv, test_configs: List[ReplayConfig], rendering:
         'action_required': [True for _ in test_configs]
     }
 
-    record_steps_effects_generator = find_effects_generator(env.effects_generator, RecordStepsEffectsGenerator)
-    if record_steps_effects_generator is not None:
-        record_steps_effects_generator.record_steps = True
+    if find_effects_generator(env.effects_generator, RecordStepsEffectsGenerator) is None:
+        env.effects_generator = make_multi_effects_generator(env.effects_generator, RecordStepsEffectsGenerator())
 
     for step in range(len(test_configs[0].replay)):
         if step == 0:


### PR DESCRIPTION
## Changes

* refactor(core): extract RailEnv's record_steps into EffectsGenerator.

## Related issues

Closes #195 

## Checklist

- [ ] Tests are included for relevant behavior changes.
- [ ] Documentation is added in the [flatland-book](https://github.com/flatland-association/flatland-book) repo for relevant behavior changes.
- [ ] If you made important user-facing changes, describe them under the `[Unreleased]` tag in `CHANGELOG.md`.
- [ ] New package dependencies are declared in the `pyproject.toml` file.
  Requirement files have been updated by running `tox -e requirements`.
- [ ] Code works with all supported Python versions (3.10, 3.11, 3.12 and 3.13). Checks run with all supported version and are
  required to run successfully.
- [ ] Code is formatted according to PEP 8 (an IDE like PyCharm can do this for you).
- [ ] Technical guidelines listed in `CONTRIBUTING.md` are followed.
