### PR TITLE
refactor(observation builder): drop `set_env` hack in obs builder interface, use `reset` instead.

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -2,7 +2,7 @@ name: Checks
 
 env:
     # DEPENDENCY SWITCH:
-    flatland-baselines-ref: main
+    flatland-baselines-ref: 437-drop-set-env-hack-in-obs-builder-interface
     flatland-benchmarks-episodes-url: "https://github.com/flatland-association/flatland-scenarios/raw/refs/heads/main/trajectories/FLATLAND_BENCHMARK_EPISODES_FOLDER_v5.zip"
     flatland-scenarios-olten-partially-closed-url: "https://github.com/flatland-association/flatland-scenarios/raw/refs/heads/main/scenario_olten/data/OLTEN_PARTIALLY_CLOSED_v2.zip"
     ecml2026-pkl: "https://github.com/flatland-association/ecml2026-starterkit/raw/refs/heads/main/reinforcement_learning/sampling/level_0_scenario_1.pkl"

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -2,7 +2,7 @@ name: Checks
 
 env:
     # DEPENDENCY SWITCH:
-    flatland-baselines-ref: 437-drop-set-env-hack-in-obs-builder-interface
+    flatland-baselines-ref: main
     flatland-benchmarks-episodes-url: "https://github.com/flatland-association/flatland-scenarios/raw/refs/heads/main/trajectories/FLATLAND_BENCHMARK_EPISODES_FOLDER_v5.zip"
     flatland-scenarios-olten-partially-closed-url: "https://github.com/flatland-association/flatland-scenarios/raw/refs/heads/main/scenario_olten/data/OLTEN_PARTIALLY_CLOSED_v2.zip"
     ecml2026-pkl: "https://github.com/flatland-association/ecml2026-starterkit/raw/refs/heads/main/reinforcement_learning/sampling/level_0_scenario_1.pkl"

--- a/examples/custom_observation_example_01_SimpleObs.py
+++ b/examples/custom_observation_example_01_SimpleObs.py
@@ -17,12 +17,6 @@ class SimpleObs(ObservationBuilder):
     all equal to the ID of the respective agent.
     """
 
-    def __init__(self):
-        super().__init__()
-
-    def reset(self, env):
-        super().reset(env)
-
     def get(self, handle: int = 0) -> np.ndarray:
         observation = handle * np.ones((5,))
         return observation

--- a/examples/custom_observation_example_01_SimpleObs.py
+++ b/examples/custom_observation_example_01_SimpleObs.py
@@ -20,8 +20,8 @@ class SimpleObs(ObservationBuilder):
     def __init__(self):
         super().__init__()
 
-    def reset(self):
-        return
+    def reset(self, env):
+        super().reset(env)
 
     def get(self, handle: int = 0) -> np.ndarray:
         observation = handle * np.ones((5,))

--- a/examples/custom_observation_example_02_SingleAgentNavigationObs.py
+++ b/examples/custom_observation_example_02_SingleAgentNavigationObs.py
@@ -26,12 +26,6 @@ class SingleAgentNavigationObs(ObservationBuilder):
     will be [1, 0, 0].
     """
 
-    def __init__(self):
-        super().__init__()
-
-    def reset(self, env):
-        super().reset(env)
-
     def get(self, handle: int = 0) -> List[int]:
         agent = self.env.agents[handle]
 

--- a/examples/custom_observation_example_02_SingleAgentNavigationObs.py
+++ b/examples/custom_observation_example_02_SingleAgentNavigationObs.py
@@ -29,8 +29,8 @@ class SingleAgentNavigationObs(ObservationBuilder):
     def __init__(self):
         super().__init__()
 
-    def reset(self):
-        pass
+    def reset(self, env):
+        super().reset(env)
 
     def get(self, handle: int = 0) -> List[int]:
         agent = self.env.agents[handle]

--- a/examples/custom_observation_example_03_ObservePredictions.py
+++ b/examples/custom_observation_example_03_ObservePredictions.py
@@ -30,8 +30,10 @@ class ObservePredictions(ObservationBuilder):
         super().__init__()
         self.predictor = predictor
 
-    def reset(self):
-        pass
+    def reset(self, env: Environment):
+        super().reset(env)
+        if self.predictor:
+            self.predictor.reset(env)
 
     def get_many(self, handles: Optional[List[int]] = None) -> Dict[int, np.ndarray]:
         '''
@@ -95,11 +97,6 @@ class ObservePredictions(ObservationBuilder):
         self.env.dev_obs_dict[handle] = visited
 
         return observation
-
-    def set_env(self, env: Environment):
-        super().set_env(env)
-        if self.predictor:
-            self.predictor.set_env(self.env)
 
 
 def create_env(custom_obs_builder):

--- a/flatland/core/env_observation_builder.py
+++ b/flatland/core/env_observation_builder.py
@@ -1,8 +1,10 @@
 """
 ObservationBuilder objects are objects that can be passed to environments designed for customizability.
-The ObservationBuilder-derived custom classes implement 2 functions, reset() and get() or get(handle).
+The ObservationBuilder-derived custom classes implement 2 functions, reset(env) and get() or get(handle).
 
-+ `reset()` is called after each environment reset, to allow for pre-computing relevant data.
++ `reset(env)` is called after each environment reset, to allow for pre-computing relevant data. It receives the
+  (possibly newly generated) env instance, so any instantiations depending on env parameters (e.g. width, height)
+  should be done here rather than in `__init__`.
 
 + `get()` is called whenever an observation has to be computed, potentially for each agent independently in case of \
 multi-agent environments.
@@ -28,14 +30,20 @@ class ObservationBuilder(Generic[EnvType, ObservationType]):
     def __init__(self):
         self.env: Optional[EnvType] = None
 
-    def set_env(self, env: EnvType):
-        self.env: EnvType = env
+    def reset(self, env: EnvType):
+        """
+        Called after each environment reset, to allow for pre-computing relevant data. Receives the
+        (possibly newly generated) env instance, so any instantiations depending on env parameters
+        (e.g. width, height) should be made here rather than in `__init__`.
 
-    def reset(self):
+        Subclasses that need to pre-compute env-dependent data should override this method and call
+        `super().reset(env)` first to keep `self.env` up to date.
+
+        Parameters
+        ----------
+        env: EnvType
         """
-        Called after each environment reset.
-        """
-        raise NotImplementedError()
+        self.env: EnvType = env
 
     def get_many(self, handles: Optional[List[AgentHandle]] = None) -> Dict[AgentHandle, ObservationType]:
         """
@@ -93,8 +101,8 @@ class DummyObservationBuilder(ObservationBuilder[Environment, bool]):
     def __init__(self):
         super().__init__()
 
-    def reset(self):
-        pass
+    def reset(self, env: Environment):
+        super().reset(env)
 
     def get(self, handle: AgentHandle = 0) -> bool:
         return True
@@ -129,11 +137,9 @@ def gauss_perturbation_observation_builder_wrapper(
             self._builder = builder
             self._np_random = np_random
 
-        def set_env(self, env: Environment):
-            builder.set_env(env)
-
-        def reset(self):
-            builder.reset()
+        def reset(self, env: Environment):
+            super().reset(env)
+            builder.reset(env)
 
         def get(self, handle: AgentHandle = 0) -> ObservationBuilder[Environment, np.ndarray]:
             obs: np.ndarray = self._builder.get(handle)

--- a/flatland/core/env_observation_builder.py
+++ b/flatland/core/env_observation_builder.py
@@ -98,12 +98,6 @@ class DummyObservationBuilder(ObservationBuilder[Environment, bool]):
     This is used in the evaluation service
     """
 
-    def __init__(self):
-        super().__init__()
-
-    def reset(self, env: Environment):
-        super().reset(env)
-
     def get(self, handle: AgentHandle = 0) -> bool:
         return True
 

--- a/flatland/core/env_prediction_builder.py
+++ b/flatland/core/env_prediction_builder.py
@@ -1,9 +1,11 @@
 """
 PredictionBuilder objects are objects that can be passed to environments designed for customizability.
-The PredictionBuilder-derived custom classes implement 2 functions, reset() and get([handle]).
+The PredictionBuilder-derived custom classes implement 2 functions, reset(env) and get([handle]).
 If predictions are not required in every step or not for all agents, then
 
-+ `reset()` is called after each environment reset, to allow for pre-computing relevant data.
++ `reset(env)` is called after each environment reset, to allow for pre-computing relevant data. It receives the
+  (possibly newly generated) env instance, so any instantiations depending on env parameters should be done here
+  rather than in `__init__`.
 
 + `get()` is called whenever an step has to be computed, potentially for each agent independently in \
 case of multi-agent environments.
@@ -24,14 +26,16 @@ class PredictionBuilder(Generic[EnvType, PredictionType]):
         self.max_depth = max_depth
         self.env: EnvType = None
 
-    def set_env(self, env: EnvType):
-        self.env = env
+    def reset(self, env: EnvType):
+        """
+        Called after each environment reset. Receives the env instance so prediction-builder-specific
+        instantiations depending on env parameters can be made here.
 
-    def reset(self):
+        Parameters
+        ----------
+        env: EnvType
         """
-        Called after each environment reset.
-        """
-        pass
+        self.env = env
 
     def get(self, handle: int = 0) -> PredictionType:
         """

--- a/flatland/envs/observations.py
+++ b/flatland/envs/observations.py
@@ -53,7 +53,10 @@ class TreeObsForRailEnv(ObservationBuilder["RailEnv", Node]):
         self.predictor = predictor
         self.location_has_target = None
 
-    def reset(self):
+    def reset(self, env: "RailEnv"):
+        super().reset(env)
+        if self.predictor:
+            self.predictor.reset(env)
         self.location_has_target = {tuple(agent.target): 1 for agent in self.env.agents}
 
     def get_many(self, handles: Optional[List[AgentHandle]] = None) -> Dict[AgentHandle, Node]:
@@ -522,11 +525,6 @@ class TreeObsForRailEnv(ObservationBuilder["RailEnv", Node]):
         for direction in self.tree_explored_actions_char:
             self.print_subtree(node.childs[direction], direction, indent + "\t")
 
-    def set_env(self, env: Environment):
-        super().set_env(env)
-        if self.predictor:
-            self.predictor.set_env(self.env)
-
     def _reverse_dir(self, direction):
         return int((direction + 2) % 4)
 
@@ -553,10 +551,8 @@ class GlobalObsForRailEnv(ObservationBuilder["RailEnv", Tuple[np.ndarray, np.nda
     def __init__(self):
         super(GlobalObsForRailEnv, self).__init__()
 
-    def set_env(self, env: Environment):
-        super().set_env(env)
-
-    def reset(self):
+    def reset(self, env: Environment):
+        super().reset(env)
         self.rail_obs = np.zeros((self.env.height, self.env.width, 16))
         for i in range(self.rail_obs.shape[0]):
             for j in range(self.rail_obs.shape[1]):
@@ -648,7 +644,8 @@ class LocalObsForRailEnv(ObservationBuilder):
         self.center = center
         self.max_padding = max(self.view_width, self.view_height - self.center)
 
-    def reset(self):
+    def reset(self, env):
+        super().reset(env)
         # We build the transition map with a view_radius empty cells expansion on each side.
         # This helps to collect the local transition map view when the agent is close to a border.
         self.max_padding = max(self.view_width, self.view_height)
@@ -759,8 +756,5 @@ class FullEnvObservation(ObservationBuilder["RailEnv", "RailEnv"]):
     def get(self, handle: AgentHandle = 0) -> "RailEnv":
         return self.env
 
-    def reset(self):
-        pass
-
-    def set_env(self, env):
+    def reset(self, env):
         self.env = env

--- a/flatland/envs/observations.py
+++ b/flatland/envs/observations.py
@@ -750,11 +750,5 @@ class FullEnvObservation(ObservationBuilder["RailEnv", "RailEnv"]):
     Returns full env as observation.
     """
 
-    def __init__(self):
-        pass
-
     def get(self, handle: AgentHandle = 0) -> "RailEnv":
         return self.env
-
-    def reset(self, env):
-        self.env = env

--- a/flatland/envs/observations_perturbed.py
+++ b/flatland/envs/observations_perturbed.py
@@ -50,12 +50,9 @@ def perturbation_tree_observation_builder_wrapper(
             )
             self._blank = blank
 
-        def set_env(self, env: Environment):
-            super().set_env(env)
-            self._builder.set_env(env)
-
-        def reset(self):
-            self._builder.reset()
+        def reset(self, env: Environment):
+            super().reset(env)
+            self._builder.reset(env)
             self._malfunction_handlers = {
                 i: MalfunctionHandler() for i in self.env.get_agent_handles()
             }

--- a/flatland/envs/persistence.py
+++ b/flatland/envs/persistence.py
@@ -110,8 +110,7 @@ class RailEnvPersister(object):
         if obs_builder is None:
             obs_builder = DummyObservationBuilder()
         env.obs_builder = obs_builder
-        env.obs_builder.set_env(env)
-        env.obs_builder.reset()
+        env.obs_builder.reset(env)
 
     @classmethod
     def load_new(cls,
@@ -162,8 +161,7 @@ class RailEnvPersister(object):
         )
         cls.set_full_state(env, env_dict, effects_generator=effects_generator)
 
-        env.obs_builder.set_env(env)
-        env.obs_builder.reset()
+        env.obs_builder.reset(env)
 
         return env, env_dict
 

--- a/flatland/envs/rail_env.py
+++ b/flatland/envs/rail_env.py
@@ -175,7 +175,6 @@ class AbstractRailEnv(Environment, Generic[UnderlyingTransitionMapType, Underlyi
         self.remove_agents_at_target = remove_agents_at_target
 
         self.obs_builder = obs_builder_object
-        self.obs_builder.set_env(self)
 
         self._max_episode_steps: Optional[int] = None
         self._elapsed_steps = 0
@@ -303,12 +302,6 @@ class AbstractRailEnv(Environment, Generic[UnderlyingTransitionMapType, Underlyi
             optionals, rail = self._call_rail_generator(optionals)
             self.rail = rail
 
-
-            # Do a new set_env call on the obs_builder to ensure
-            # that obs_builder specific instantiations are made according to the
-            # specifications of the current environment : like width, height, etc
-            self.obs_builder.set_env(self)
-
         if regenerate_schedule or regenerate_rail or self.get_num_agents() == 0:
             agents_hints = None
             if optionals and 'agents_hints' in optionals:
@@ -342,7 +335,7 @@ class AbstractRailEnv(Environment, Generic[UnderlyingTransitionMapType, Underlyi
         self.dones = dict.fromkeys(list(range(self.get_num_agents())) + ["__all__"], False)
 
         # Reset the state of the observation builder with the new environment
-        self.obs_builder.reset()
+        self.obs_builder.reset(self)
 
         # Empty the episode store of agent positions
         self.cur_episode = []

--- a/flatland/ml/observations/gym_observation_builder.py
+++ b/flatland/ml/observations/gym_observation_builder.py
@@ -34,11 +34,8 @@ class GymObservationBuilderWrapper(GymObservationBuilder[EnvType, ObservationTyp
         self.wrap = wrap
         self.observation_space = observation_space
 
-    def set_env(self, env: EnvType):
-        self.wrap.set_env(env)
-
-    def reset(self):
-        self.wrap.reset()
+    def reset(self, env: EnvType):
+        self.wrap.reset(env)
 
     def get(self, handle: AgentHandle = 0) -> MultiAgentDict:
         return self.wrap.get(handle)
@@ -75,10 +72,6 @@ class GlobalObsForRailEnvGym(GymObservationBuilderWrapper):
         super().__init__(GlobalObsForRailEnv(), None)
         self.observation_space = None
 
-    def set_env(self, env: RailEnv):
-        self.wrap.set_env(env)
-        self._update_observation_space(env)
-
     def _update_observation_space(self, env):
         # workaround for multi-agent setting (i.e. do not flatten agent dict, only flatten per-agent observations)
         self.unflattened_observation_space = gym.spaces.Tuple(spaces=[
@@ -97,6 +90,6 @@ class GlobalObsForRailEnvGym(GymObservationBuilderWrapper):
         assert np.count_nonzero(np.isnan(obs)) == 0, obs
         return obs
 
-    def reset(self):
-        super().reset()
-        self._update_observation_space(self.wrap.env)
+    def reset(self, env: RailEnv):
+        super().reset(env)
+        self._update_observation_space(env)

--- a/flatland/trajectories/policy_runner.py
+++ b/flatland/trajectories/policy_runner.py
@@ -61,7 +61,7 @@ class PolicyRunner:
     def change_policy(self, policy: Policy, obs_builder: ObservationBuilder):
         self._policy = policy
         self.env.obs_builder = obs_builder
-        self.env.obs_builder.set_env(self.env)
+        self.env.obs_builder.reset(self.env)
         self.observations = self.env._get_observations()
 
     def step(self, persist: bool = False) -> Tuple["Trajectory", bool]:

--- a/tests/test_eval_timeout.py
+++ b/tests/test_eval_timeout.py
@@ -15,19 +15,15 @@ class CustomObservationBuilder(ObservationBuilder):
     def __init__(self):
         super(CustomObservationBuilder, self).__init__()
 
-    def set_env(self, env: Environment):
-        super().set_env(env)
-        # Note :
-        # The instantiations which depend on parameters of the Env object should be 
-        # done here, as it is only here that the updated self.env instance is available
+    def reset(self, env: Environment):
+        """
+        Called internally on every env.reset() call,
+        to reset any observation specific variables that are being used.
+        Also the place to do any instantiations which depend on parameters of the Env object,
+        since it is only here that the updated env instance is available.
+        """
+        super().reset(env)
         self.rail_obs = np.zeros((self.env.height, self.env.width))
-
-    def reset(self):
-        """
-        Called internally on every env.reset() call, 
-        to reset any observation specific variables that are being used
-        """
-        self.rail_obs[:] = 0        
         for _x in range(self.env.width):
             for _y in range(self.env.height):
                 # Get the transition map value at location _x, _y

--- a/tests/test_flatland_envs_observations.py
+++ b/tests/test_flatland_envs_observations.py
@@ -366,8 +366,8 @@ def test_gauss_perturbation_observation_builder_wrapper():
             super().__init__()
             self._shape = shape
 
-        def reset(self):
-            pass
+        def reset(self, env):
+            super().reset(env)
 
         def get(self, handle: int = 0) -> np.ndarray:
             return np.zeros(self._shape)

--- a/tests/test_flatland_envs_observations.py
+++ b/tests/test_flatland_envs_observations.py
@@ -366,9 +366,6 @@ def test_gauss_perturbation_observation_builder_wrapper():
             super().__init__()
             self._shape = shape
 
-        def reset(self, env):
-            super().reset(env)
-
         def get(self, handle: int = 0) -> np.ndarray:
             return np.zeros(self._shape)
 

--- a/tests/test_flatland_malfunction.py
+++ b/tests/test_flatland_malfunction.py
@@ -27,8 +27,8 @@ class SingleAgentNavigationObs(ObservationBuilder):
     def __init__(self):
         super().__init__()
 
-    def reset(self):
-        pass
+    def reset(self, env):
+        super().reset(env)
 
     def get(self, handle: int = 0) -> List[int]:
         agent = self.env.agents[handle]

--- a/tests/test_flatland_malfunction.py
+++ b/tests/test_flatland_malfunction.py
@@ -24,12 +24,6 @@ class SingleAgentNavigationObs(ObservationBuilder):
     will be [1, 0, 0].
     """
 
-    def __init__(self):
-        super().__init__()
-
-    def reset(self, env):
-        super().reset(env)
-
     def get(self, handle: int = 0) -> List[int]:
         agent = self.env.agents[handle]
 

--- a/tests/trajectories/test_policy_runner.py
+++ b/tests/trajectories/test_policy_runner.py
@@ -52,8 +52,8 @@ class EnvStepObservationBuilder(ObservationBuilder[RailEnv, int]):
     def get(self, handle: AgentHandle = 0) -> ObservationType:
         return self.env._elapsed_steps
 
-    def reset(self):
-        pass
+    def reset(self, env):
+        super().reset(env)
 
 
 def test_from_episode():

--- a/tests/trajectories/test_policy_runner.py
+++ b/tests/trajectories/test_policy_runner.py
@@ -52,9 +52,6 @@ class EnvStepObservationBuilder(ObservationBuilder[RailEnv, int]):
     def get(self, handle: AgentHandle = 0) -> ObservationType:
         return self.env._elapsed_steps
 
-    def reset(self, env):
-        super().reset(env)
-
 
 def test_from_episode():
     with tempfile.TemporaryDirectory() as tmpdirname:


### PR DESCRIPTION
## Changes

* refactor(observation builder): use `reset` instead of additional `set_env`.

## Related issues

Closes #437 
Depends on https://github.com/flatland-association/flatland-baselines/pull/72.

## Checklist

- [ ] Tests are included for relevant behavior changes.
- [ ] Documentation is added in the [flatland-book](https://github.com/flatland-association/flatland-book) repo for relevant behavior changes.
- [ ] If you made important user-facing changes, describe them under the `[Unreleased]` tag in `CHANGELOG.md`.
- [ ] New package dependencies are declared in the `pyproject.toml` file.
  Requirement files have been updated by running `tox -e requirements`.
- [ ] Code works with all supported Python versions (3.10, 3.11, 3.12 and 3.13). Checks run with all supported version and are
  required to run successfully.
- [ ] Code is formatted according to PEP 8 (an IDE like PyCharm can do this for you).
- [ ] Technical guidelines listed in `CONTRIBUTING.md` are followed.
