### PR TITLE
perf(rewards): use dict.from_keys from tuple instead of comprehension from set.

### DIFF
--- a/flatland/envs/rewards.py
+++ b/flatland/envs/rewards.py
@@ -150,7 +150,7 @@ class BaseDefaultRewards(Rewards[Dict[str, float]], Generic[ConfigurationType]):
         Crash penalty factor :math:`\kappa \geq 0`. Defaults to 0.0.
     """
     # cache enumeration
-    _cached_default_penalties = set(DefaultPenalties)
+    _cached_default_penalty_values = tuple(p.value for p in DefaultPenalties)
 
     def __init__(self,
                  cancellation_factor: float = 1,
@@ -282,7 +282,11 @@ class BaseDefaultRewards(Rewards[Dict[str, float]], Generic[ConfigurationType]):
         return d
 
     def cumulate(self, *rewards: Dict[str, float]) -> Dict[str, float]:
-        return {p.value: sum([r[p.value] for r in rewards]) for p in self._cached_default_penalties}
+        result = dict.fromkeys(self._cached_default_penalty_values, 0.0)
+        for r in rewards:
+            for k, v in r.items():
+                result[k] += v
+        return result
 
     # policy runner calls normalization: normalize sum over all keys instead of per key.
     def normalize(self, *rewards: np.ndarray, num_agents: int, max_episode_steps: int) -> float:
@@ -297,7 +301,7 @@ class BaseDefaultRewards(Rewards[Dict[str, float]], Generic[ConfigurationType]):
         return sum(rewards_capped) / (max_episode_steps * num_agents) + 1
 
     def empty(self) -> Dict[str, float]:
-        return {p.value: 0 for p in self._cached_default_penalties}
+        return dict.fromkeys(self._cached_default_penalty_values, 0.0)
 
 
 class DefaultRewards(Rewards[float]):

--- a/flatland/envs/rewards.py
+++ b/flatland/envs/rewards.py
@@ -282,7 +282,7 @@ class BaseDefaultRewards(Rewards[Dict[str, float]], Generic[ConfigurationType]):
         return d
 
     def cumulate(self, *rewards: Dict[str, float]) -> Dict[str, float]:
-        result = dict.fromkeys(self._cached_default_penalty_values, 0.0)
+        result = dict.fromkeys(self._cached_default_penalty_values, 0)
         for r in rewards:
             for k, v in r.items():
                 result[k] += v
@@ -301,7 +301,7 @@ class BaseDefaultRewards(Rewards[Dict[str, float]], Generic[ConfigurationType]):
         return sum(rewards_capped) / (max_episode_steps * num_agents) + 1
 
     def empty(self) -> Dict[str, float]:
-        return dict.fromkeys(self._cached_default_penalty_values, 0.0)
+        return dict.fromkeys(self._cached_default_penalty_values, 0)
 
 
 class DefaultRewards(Rewards[float]):


### PR DESCRIPTION


## Changes

* perf(rewards): use dict.from_keys from tuple instead of comprehension from set.

## Related issues

Closes #465 . 

## Checklist

- [ ] Tests are included for relevant behavior changes.
- [ ] Documentation is added in the [flatland-book](https://github.com/flatland-association/flatland-book) repo for relevant behavior changes.
- [ ] If you made important user-facing changes, describe them under the `[Unreleased]` tag in `CHANGELOG.md`.
- [ ] New package dependencies are declared in the `pyproject.toml` file.
  Requirement files have been updated by running `tox -e requirements`.
- [ ] Code works with all supported Python versions (3.10, 3.11, 3.12 and 3.13). Checks run with all supported version and are
  required to run successfully.
- [ ] Code is formatted according to PEP 8 (an IDE like PyCharm can do this for you).
- [ ] Technical guidelines listed in `CONTRIBUTING.md` are followed.
