### PR TITLE
ci: cleanup.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 *
 !requirements-dev.txt
 !requirements-ml.txt
+!docker/install-build-toolchain.sh

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+*
+!requirements-dev.txt
+!requirements-ml.txt

--- a/.github/actions/profiling-comment/action.yml
+++ b/.github/actions/profiling-comment/action.yml
@@ -38,7 +38,7 @@ runs:
     steps:
         -   name: Find existing comment
             id: find-comment
-            uses: peter-evans/find-comment@v3
+            uses: peter-evans/find-comment@v4
             with:
                 issue-number: ${{ github.event.pull_request.number }}
                 comment-author: 'github-actions[bot]'
@@ -87,7 +87,7 @@ runs:
                     echo "short_sha=$short_sha"
                 } >> "$GITHUB_OUTPUT"
         -   name: Create or update comment
-            uses: peter-evans/create-or-update-comment@v4
+            uses: peter-evans/create-or-update-comment@v5
             with:
                 comment-id: ${{ steps.find-comment.outputs.comment-id }}
                 issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/build-ci-env.yml
+++ b/.github/workflows/build-ci-env.yml
@@ -16,6 +16,13 @@ name: Build CI-env image
 # this a near-instant no-op once requirements-dev.txt/requirements-ml.txt stop changing, since every RUN
 # layer stays cache-hit - unlike actions/cache, multiple concurrent pushes to the same cache ref don't stomp
 # each other either.
+#
+# Known risk, deliberately not mitigated: if GHCR itself is unavailable, every job that depends on this
+# workflow fails outright - there's no fallback path (e.g. building the image locally and skipping the
+# registry). Considered and rejected as not worth the added complexity: GHCR shares GitHub's own
+# infrastructure/auth with Actions itself, so a GHCR outage severe enough to break this is likely to come
+# with broader GitHub Actions disruption anyway, making a bespoke fallback path low-value relative to its
+# upkeep cost (a second, rarely-exercised way to build/run everything that has to be kept working too).
 on:
     workflow_call:
         inputs:

--- a/.github/workflows/build-ci-env.yml
+++ b/.github/workflows/build-ci-env.yml
@@ -1,0 +1,127 @@
+name: Build CI-env image
+
+# Reusable workflow: builds/pushes the CI-only dependency image (see Dockerfile.ci-env, a separate,
+# non-user-facing image from the ones docker.yml/publish.yml build and publish to end users). Used by
+# checks.yml's deptry/testml/test/examples jobs and publish.yml's pre-release test job alike, so the
+# build/cache-check/push logic - and any fix to it - only has to exist in one place.
+#
+# GHCR (not actions/cache) specifically because actions/cache caps out at 10GB per repository, shared across
+# every cache this repo uses (not per-job), evicting oldest-accessed first once exceeded:
+# https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows
+# A single ml tox env (torch/dm-tree/scipy etc.) already runs ~3GB - with 5 Python versions x 2 variants,
+# naively caching each venv/build would blow past 10GB on its own, causing exactly the kind of premature
+# eviction/thrashing (a cache saved this run gets evicted before the next run that could reuse it) this
+# whole approach exists to avoid. GHCR has no such cap (see ci-env-cleanup.yml instead, for the different
+# problem of it also having no automatic eviction). BuildKit's registry cache (cache-from/cache-to) makes
+# this a near-instant no-op once requirements-dev.txt/requirements-ml.txt stop changing, since every RUN
+# layer stays cache-hit - unlike actions/cache, multiple concurrent pushes to the same cache ref don't stomp
+# each other either.
+on:
+    workflow_call:
+        inputs:
+            python-version:
+                required: true
+                type: string
+            with-ml:
+                required: true
+                type: boolean
+            ref:
+                description: "Git ref to build the image's requirements/Dockerfile from - defaults to whatever ref triggered the calling workflow."
+                required: false
+                type: string
+                default: ""
+        outputs:
+            image-hash:
+                description: "Content hash of requirements-dev.txt(/-ml.txt)/Dockerfile.ci-env/docker/install-build-toolchain.sh baked into the built image's tag."
+                value: ${{ jobs.build.outputs.image-hash }}
+
+jobs:
+    build:
+        runs-on: ubuntu-24.04
+        permissions:
+            contents: read
+            packages: write
+        outputs:
+            image-hash: ${{ steps.image-hash.outputs.hash }}
+        steps:
+            -   uses: actions/checkout@v6
+                with:
+                    ref: ${{ inputs.ref || github.ref }}
+            -   name: Log in to GHCR
+                uses: docker/login-action@v4
+                with:
+                    registry: ghcr.io
+                    username: ${{ github.actor }}
+                    password: ${{ secrets.GITHUB_TOKEN }}
+            -   uses: docker/setup-buildx-action@v4
+            -   name: Build image name
+                id: image-name
+                run: echo "IMAGE_NAME=$(echo 'ghcr.io/${{ github.repository }}-ci-env' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+            -   name: Compute variant name
+                id: variant
+                run: echo "name=${{ inputs.with-ml && 'ml' || 'default' }}" >> "$GITHUB_OUTPUT"
+            # hashFiles() needs the checkout above to have already populated the workspace - it can't be
+            # computed directly in a consumer job's own container: (see the tag comment below). Includes
+            # Dockerfile.ci-env and docker/install-build-toolchain.sh (COPY'd into it), not just the
+            # requirements file(s): otherwise a Dockerfile/toolchain-script-only change (e.g. adding a
+            # missing apt package) would keep the same tag, and the "already exists" check below would keep
+            # serving the stale pre-fix image forever.
+            -   name: Compute image hash
+                id: image-hash
+                run: |
+                    if [ "${{ inputs.with-ml }}" = "true" ]; then
+                        echo "hash=${{ hashFiles('requirements-dev.txt', 'requirements-ml.txt', 'Dockerfile.ci-env', 'docker/install-build-toolchain.sh') }}" >> "$GITHUB_OUTPUT"
+                    else
+                        echo "hash=${{ hashFiles('requirements-dev.txt', 'Dockerfile.ci-env', 'docker/install-build-toolchain.sh') }}" >> "$GITHUB_OUTPUT"
+                    fi
+            # Lets everything below skip the disk-space dance (and the build itself) when this exact
+            # (python-version, variant, hash) combination was already built and pushed - most runs, once the
+            # cache is warm, since requirements change far less often than commits.
+            -   name: Check if CI-env image already exists
+                id: image-exists
+                run: |
+                    if docker buildx imagetools inspect "${{ steps.image-name.outputs.IMAGE_NAME }}:py${{ inputs.python-version }}-${{ steps.variant.outputs.name }}-${{ steps.image-hash.outputs.hash }}" > /dev/null 2>&1; then
+                        echo "exists=true" >> "$GITHUB_OUTPUT"
+                    else
+                        echo "exists=false" >> "$GITHUB_OUTPUT"
+                    fi
+            -   name: Inspect disk
+                if: steps.image-exists.outputs.exists != 'true'
+                run: |
+                    df -h
+                    docker system df
+            # https://stackoverflow.com/questions/30604846/docker-complains-about-no-space-left-on-device-how-to-clean-up
+            -   name: Prune docker system
+                if: steps.image-exists.outputs.exists != 'true'
+                run: |
+                    docker system prune --all --force
+            # https://www.dzombak.com/blog/2024/09/freeing-disk-space-on-github-actions-runners/
+            -   name: Free disk space
+                if: steps.image-exists.outputs.exists != 'true'
+                run: |
+                    curl -fsSL https://raw.githubusercontent.com/kou/arrow/e49d8ae15583ceff03237571569099a6ad62be32/ci/scripts/util_free_space.sh | bash
+            -   name: Build and push CI-env image
+                if: steps.image-exists.outputs.exists != 'true'
+                uses: docker/build-push-action@v7
+                with:
+                    context: .
+                    file: Dockerfile.ci-env
+                    platforms: linux/amd64
+                    build-args: |
+                        PYTHON_VERSION=${{ inputs.python-version }}
+                        WITH_ML=${{ inputs.with-ml }}
+                    cache-from: type=registry,ref=${{ steps.image-name.outputs.IMAGE_NAME }}:cache-py${{ inputs.python-version }}-${{ steps.variant.outputs.name }}
+                    cache-to: type=registry,ref=${{ steps.image-name.outputs.IMAGE_NAME }}:cache-py${{ inputs.python-version }}-${{ steps.variant.outputs.name }},mode=max
+                    push: true
+                    # Tagged by a hash of requirements-dev.txt/requirements-ml.txt/Dockerfile.ci-env/
+                    # docker/install-build-toolchain.sh, not by commit SHA: the runnable tag is a mutable
+                    # pointer any workflow run can overwrite, and each calling workflow's own concurrency
+                    # group already allows genuinely-parallel runs across branches/PRs. Keying on content
+                    # (not the commit) means two runs with identical inputs safely share one tag/image, and
+                    # two with different inputs never collide, since they get different tags. A per-commit
+                    # tag would "solve" the race too, but at the cost of a fresh image (and GHCR tag) on
+                    # every commit even when nothing dependency-related changed, defeating the point of
+                    # caching.
+                    tags: ${{ steps.image-name.outputs.IMAGE_NAME }}:py${{ inputs.python-version }}-${{ steps.variant.outputs.name }}-${{ steps.image-hash.outputs.hash }}
+            -   name: Check disk space
+                run: df . -h

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -1,0 +1,118 @@
+name: Build Docker image
+
+# Reusable workflow: builds/pushes the published, multi-arch flatland-rl runtime image (see the sibling
+# Dockerfile - not to be confused with build-ci-env.yml/Dockerfile.ci-env, the throwaway CI-only test
+# image). Used by both docker.yml (on-push/nightly "latest" builds) and publish.yml (release/test-pypi
+# builds), so this build/skip-if-unchanged/retag logic only has to exist in one place.
+#
+# Skip-if-unchanged works differently here than build-ci-env.yml, because this Dockerfile's actual content
+# depends on a *remote* ref: requirements.txt/requirements-ml.txt are curl'd from flatland-rl-ref, and
+# flatland-rl itself is installed via `pip install git+...@flatland-rl-ref`. Docker's own layer cache can't
+# see past a RUN command's literal (always-identical) text to notice that a moving ref like "main" has new
+# content - naively caching those layers risks silently serving a stale requirements.txt/flatland-rl
+# install forever. Instead of relying on layer caching, this resolves flatland-rl-ref to its exact
+# (immutable) commit SHA up front and folds that into the image tag alongside a hash of this repo's own
+# Dockerfile/toolchain script - so "does this already exist" is precise regardless of Docker's cache
+# semantics, and a real content change (anywhere) always produces a new tag.
+on:
+    workflow_call:
+        inputs:
+            python-version:
+                required: true
+                type: string
+            with-ml:
+                required: true
+                type: boolean
+            flatland-rl-ref:
+                description: "Git ref (branch, tag, or commit SHA) of flatland-rl to build the image from."
+                required: true
+                type: string
+            human-facing-tag:
+                description: "Mutable tag consumers actually pull, e.g. 'latest-py3.12' or 'v4.3.0-py3.12' - always repointed at the resulting image, whether freshly built or already existing."
+                required: true
+                type: string
+            force-rebuild:
+                description: "Rebuild even if an image already exists for this exact (ref, Dockerfile) combination - set true for scheduled/nightly runs, so they keep exercising a genuinely fresh build."
+                required: false
+                type: boolean
+                default: false
+            push:
+                description: "Whether to push/tag at all - false for pull_request validation builds, which just build once and skip all registry interaction entirely."
+                required: false
+                type: boolean
+                default: true
+
+jobs:
+    build:
+        runs-on: ubuntu-24.04
+        permissions:
+            contents: read
+            packages: write
+        steps:
+            -   uses: actions/checkout@v6
+            -   uses: docker/setup-qemu-action@v4
+            -   uses: docker/setup-buildx-action@v4
+            -   name: Log in to GHCR
+                if: inputs.push
+                uses: docker/login-action@v4
+                with:
+                    registry: ghcr.io
+                    username: ${{ github.actor }}
+                    password: ${{ secrets.GITHUB_TOKEN }}
+            -   name: Build image name
+                id: image-name
+                run: echo "IMAGE_NAME=$(echo 'ghcr.io/${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+            -   name: Compute variant name
+                id: variant
+                run: echo "name=${{ inputs.with-ml && 'ml' || 'default' }}" >> "$GITHUB_OUTPUT"
+            # Resolves to an immutable commit SHA rather than trusting Docker's layer cache to notice a
+            # moving ref's remote content changed - see the header comment. `git ls-remote` only resolves
+            # branch/tag names; if flatland-rl-ref is already a commit SHA (no matching ref), fall back to
+            # using it as-is.
+            -   name: Resolve flatland-rl-ref to a commit SHA
+                id: resolve-ref
+                run: |
+                    sha=$(git ls-remote "https://github.com/${{ github.repository }}.git" "${{ inputs.flatland-rl-ref }}" | cut -f1 | cut -c1-8)
+                    if [ -z "$sha" ]; then
+                        sha=$(echo "${{ inputs.flatland-rl-ref }}" | cut -c1-8)
+                    fi
+                    echo "sha=$sha" >> "$GITHUB_OUTPUT"
+            -   name: Compute content tag
+                id: content-tag
+                run: echo "tag=py${{ inputs.python-version }}-${{ steps.variant.outputs.name }}-${{ steps.resolve-ref.outputs.sha }}-${{ hashFiles('Dockerfile', 'docker/install-build-toolchain.sh') }}" >> "$GITHUB_OUTPUT"
+            # Lets the build step below be skipped when this exact (python-version, variant, resolved
+            # commit, Dockerfile/toolchain) combination was already built and pushed. Not consulted at all
+            # for pull_request validation builds (inputs.push is false) or when force-rebuild is set.
+            -   name: Check if image already exists
+                if: inputs.push
+                id: image-exists
+                run: |
+                    if [ "${{ inputs.force-rebuild }}" != "true" ] && docker buildx imagetools inspect "${{ steps.image-name.outputs.IMAGE_NAME }}:${{ steps.content-tag.outputs.tag }}" > /dev/null 2>&1; then
+                        echo "exists=true" >> "$GITHUB_OUTPUT"
+                    else
+                        echo "exists=false" >> "$GITHUB_OUTPUT"
+                    fi
+            -   name: Build and push image
+                if: ${{ !inputs.push || steps.image-exists.outputs.exists != 'true' }}
+                uses: docker/build-push-action@v7
+                with:
+                    context: .
+                    platforms: linux/amd64,linux/arm64
+                    build-args: |
+                        PYTHON_VERSION=${{ inputs.python-version }}
+                        WITH_ML=${{ inputs.with-ml }}
+                        FLATLAND_RL_REF=${{ inputs.flatland-rl-ref }}
+                    push: ${{ inputs.push }}
+                    tags: |
+                        ${{ steps.image-name.outputs.IMAGE_NAME }}:${{ steps.content-tag.outputs.tag }}
+                        ${{ steps.image-name.outputs.IMAGE_NAME }}:${{ inputs.human-facing-tag }}
+            # No rebuild happened above (content tag already existed and force-rebuild wasn't set) - still
+            # make sure the mutable human-facing tag actually points at this content. Server-side manifest
+            # re-tag (no layer download/upload), not a rebuild:
+            # https://docs.docker.com/reference/cli/docker/buildx/imagetools/create/
+            -   name: Repoint human-facing tag at existing image
+                if: ${{ inputs.push && steps.image-exists.outputs.exists == 'true' }}
+                run: |
+                    docker buildx imagetools create \
+                        --tag "${{ steps.image-name.outputs.IMAGE_NAME }}:${{ inputs.human-facing-tag }}" \
+                        "${{ steps.image-name.outputs.IMAGE_NAME }}:${{ steps.content-tag.outputs.tag }}"

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -170,18 +170,6 @@ jobs:
         outputs:
             reqs-hash: ${{ steps.reqs-hash.outputs.hash }}
         steps:
-            -   name: Inspect disk
-                run: |
-                    df -h
-                    docker system df
-            # https://stackoverflow.com/questions/30604846/docker-complains-about-no-space-left-on-device-how-to-clean-up
-            -   name: Prune docker system
-                run: |
-                    docker system prune --all --force
-            # https://www.dzombak.com/blog/2024/09/freeing-disk-space-on-github-actions-runners/
-            -   name: Free disk space
-                run: |
-                    curl -fsSL https://raw.githubusercontent.com/kou/arrow/e49d8ae15583ceff03237571569099a6ad62be32/ci/scripts/util_free_space.sh | bash
             -   uses: actions/checkout@v6
             -   name: Log in to GHCR
                 uses: docker/login-action@v3
@@ -198,7 +186,34 @@ jobs:
             -   name: Compute requirements hash
                 id: reqs-hash
                 run: echo "hash=${{ hashFiles('requirements-dev.txt', 'requirements-ml.txt') }}" >> "$GITHUB_OUTPUT"
+            # Lets everything below skip the disk-space dance (and the build itself) when this exact
+            # (python-version, requirements-hash) combination was already built and pushed - most runs, once
+            # the cache is warm, since requirements change far less often than commits.
+            -   name: Check if CI-env image already exists
+                id: image-exists
+                run: |
+                    if docker buildx imagetools inspect "${{ steps.image-name.outputs.IMAGE_NAME }}:py${{ matrix.python-version }}-ml-${{ steps.reqs-hash.outputs.hash }}" > /dev/null 2>&1; then
+                        echo "exists=true" >> "$GITHUB_OUTPUT"
+                    else
+                        echo "exists=false" >> "$GITHUB_OUTPUT"
+                    fi
+            -   name: Inspect disk
+                if: steps.image-exists.outputs.exists != 'true'
+                run: |
+                    df -h
+                    docker system df
+            # https://stackoverflow.com/questions/30604846/docker-complains-about-no-space-left-on-device-how-to-clean-up
+            -   name: Prune docker system
+                if: steps.image-exists.outputs.exists != 'true'
+                run: |
+                    docker system prune --all --force
+            # https://www.dzombak.com/blog/2024/09/freeing-disk-space-on-github-actions-runners/
+            -   name: Free disk space
+                if: steps.image-exists.outputs.exists != 'true'
+                run: |
+                    curl -fsSL https://raw.githubusercontent.com/kou/arrow/e49d8ae15583ceff03237571569099a6ad62be32/ci/scripts/util_free_space.sh | bash
             -   name: Build and push testml CI-env image
+                if: steps.image-exists.outputs.exists != 'true'
                 uses: docker/build-push-action@v6
                 with:
                     context: .

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -200,11 +200,26 @@ jobs:
                     cache-dependency-path: |
                         requirements-dev.txt
                         requirements-ml.txt
+            # The archive is versioned in its URL (v5), so a plain URL-keyed cache is safe indefinitely -
+            # no invalidation is needed until the workflow itself is updated to a new URL.
+            -   name: Restore cached episodes
+                id: cache-episodes
+                uses: actions/cache/restore@v5
+                with:
+                    path: episodes
+                    key: episodes-${{ env.flatland-benchmarks-episodes-url }}
             -   name: Download episodes
+                if: steps.cache-episodes.outputs.cache-hit != 'true'
                 run: |
                     wget "${{ env.flatland-benchmarks-episodes-url }}" -O FLATLAND_BENCHMARK_EPISODES_FOLDER.zip
                     mkdir -p episodes
                     unzip FLATLAND_BENCHMARK_EPISODES_FOLDER -d episodes
+            -   name: Save cached episodes
+                if: ${{ always() && steps.cache-episodes.outputs.cache-hit != 'true' }}
+                uses: actions/cache/save@v5
+                with:
+                    path: episodes
+                    key: episodes-${{ env.flatland-benchmarks-episodes-url }}
             # https://adamj.eu/tech/2023/11/02/github-actions-faster-python-virtual-environments/ - skipped on
             # scheduled runs so the nightly cron always exercises a from-scratch install.
             -   name: Restore cached tox environments
@@ -272,11 +287,26 @@ jobs:
                     cache-dependency-path: |
                         requirements-dev.txt
                         requirements-ml.txt
+            # The archive is versioned in its URL (v5), so a plain URL-keyed cache is safe indefinitely -
+            # no invalidation is needed until the workflow itself is updated to a new URL.
+            -   name: Restore cached episodes
+                id: cache-episodes
+                uses: actions/cache/restore@v5
+                with:
+                    path: episodes
+                    key: episodes-${{ env.flatland-benchmarks-episodes-url }}
             -   name: Download episodes
+                if: steps.cache-episodes.outputs.cache-hit != 'true'
                 run: |
                     wget "${{ env.flatland-benchmarks-episodes-url }}" -O FLATLAND_BENCHMARK_EPISODES_FOLDER.zip
                     mkdir -p episodes
                     unzip FLATLAND_BENCHMARK_EPISODES_FOLDER -d episodes
+            -   name: Save cached episodes
+                if: ${{ always() && steps.cache-episodes.outputs.cache-hit != 'true' }}
+                uses: actions/cache/save@v5
+                with:
+                    path: episodes
+                    key: episodes-${{ env.flatland-benchmarks-episodes-url }}
             # https://adamj.eu/tech/2023/11/02/github-actions-faster-python-virtual-environments/ - skipped on
             # scheduled runs so the nightly cron always exercises a from-scratch install.
             -   name: Restore cached tox environments
@@ -585,12 +615,27 @@ jobs:
                 uses: actions/setup-python@v6
                 with:
                     python-version: ${{ matrix.python-version }}
+            # The archive is versioned in its URL (v5), so a plain URL-keyed cache is safe indefinitely -
+            # no invalidation is needed until the workflow itself is updated to a new URL.
+            -   name: Restore cached episodes
+                id: cache-episodes
+                uses: actions/cache/restore@v5
+                with:
+                    path: episodes
+                    key: episodes-${{ env.flatland-benchmarks-episodes-url }}
             -   name: Download episodes
+                if: steps.cache-episodes.outputs.cache-hit != 'true'
                 run: |
                     wget "${{ env.flatland-benchmarks-episodes-url }}" -O FLATLAND_BENCHMARK_EPISODES_FOLDER.zip
                     mkdir -p episodes
                     unzip FLATLAND_BENCHMARK_EPISODES_FOLDER -d episodes
                 working-directory: ${{ github.workspace }}
+            -   name: Save cached episodes
+                if: ${{ always() && steps.cache-episodes.outputs.cache-hit != 'true' }}
+                uses: actions/cache/save@v5
+                with:
+                    path: episodes
+                    key: episodes-${{ env.flatland-benchmarks-episodes-url }}
             -   name: Download ecml2026 scenario
                 run: wget "${{ env.ecml2026-pkl }}" -O level_0_scenario_1.pkl
                 working-directory: ${{ github.workspace }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -112,13 +112,17 @@ jobs:
                 uses: actions/setup-python@v6
                 with:
                     python-version: ${{ matrix.python-version }}
-                    # scipy/dm-tree build from source (see "Install ffmpeg" step above); cache pip's built
-                    # wheels so only a requirements bump triggers a recompile. Same file list as the
-                    # test/testml jobs below so the cache is shared across all three.
-                    cache: pip
-                    cache-dependency-path: |
-                        requirements-dev.txt
-                        requirements-ml.txt
+            # scipy/dm-tree build from source (see "Install ffmpeg" step above); cache pip's built wheels
+            # so only a requirements bump triggers a recompile. Same key as the test/testml jobs below so
+            # the cache is shared across all three. Skipped (read-only) on scheduled runs, like the .tox
+            # cache below, so the nightly cron always exercises a from-scratch build - but nightly's
+            # freshly-built wheels are still saved (see the Save step below), so PR/push runs benefit.
+            -   name: Restore cached pip wheels
+                if: ${{ github.event_name != 'schedule' }}
+                uses: actions/cache/restore@v5
+                with:
+                    path: ~/.cache/pip
+                    key: pip-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('requirements-dev.txt', 'requirements-ml.txt') }}
             # https://adamj.eu/tech/2023/11/02/github-actions-faster-python-virtual-environments/ - skipped on
             # scheduled runs so the nightly cron always exercises a from-scratch install.
             -   name: Restore cached tox environments
@@ -133,6 +137,12 @@ jobs:
                     python -m pip install -U tox tox-gh-actions
             -   name: Run deptry
                 run: tox -e py${{ matrix.python-version }}-verify-requirements
+            -   name: Save cached pip wheels
+                if: always()
+                uses: actions/cache/save@v5
+                with:
+                    path: ~/.cache/pip
+                    key: pip-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('requirements-dev.txt', 'requirements-ml.txt') }}
             -   name: Save cached tox environments
                 if: ${{ always() && github.event_name != 'schedule' }}
                 uses: actions/cache/save@v5
@@ -193,13 +203,17 @@ jobs:
                 uses: actions/setup-python@v6
                 with:
                     python-version: ${{ matrix.python-version }}
-                    # scipy/dm-tree build from source (see "Install ffmpeg" step above); cache pip's built
-                    # wheels so only a requirements bump triggers a recompile. Same file list as the
-                    # deptry/test jobs so the cache is shared across all three.
-                    cache: pip
-                    cache-dependency-path: |
-                        requirements-dev.txt
-                        requirements-ml.txt
+            # scipy/dm-tree build from source (see "Install ffmpeg" step above); cache pip's built wheels
+            # so only a requirements bump triggers a recompile. Same key as the deptry/test jobs so the
+            # cache is shared across all three. Skipped (read-only) on scheduled runs, like the .tox cache
+            # below, so the nightly cron always exercises a from-scratch build - but nightly's freshly-built
+            # wheels are still saved (see the Save step below), so PR/push runs benefit.
+            -   name: Restore cached pip wheels
+                if: ${{ github.event_name != 'schedule' }}
+                uses: actions/cache/restore@v5
+                with:
+                    path: ~/.cache/pip
+                    key: pip-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('requirements-dev.txt', 'requirements-ml.txt') }}
             # The archive is versioned in its URL (v5), so a plain URL-keyed cache is safe indefinitely -
             # no invalidation is needed until the workflow itself is updated to a new URL.
             -   name: Restore cached episodes
@@ -234,6 +248,12 @@ jobs:
                     python -m pip install -U tox tox-gh-actions
             -   name: Run tests
                 run: tox run -e py${{ matrix.python-version }}-ml
+            -   name: Save cached pip wheels
+                if: always()
+                uses: actions/cache/save@v5
+                with:
+                    path: ~/.cache/pip
+                    key: pip-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('requirements-dev.txt', 'requirements-ml.txt') }}
             -   name: Save cached tox environments
                 if: ${{ always() && github.event_name != 'schedule' }}
                 uses: actions/cache/save@v5
@@ -280,13 +300,18 @@ jobs:
                 uses: actions/setup-python@v6
                 with:
                     python-version: ${{ matrix.python-version }}
-                    # scipy builds from source (see "Install ffmpeg" step above); cache pip's built wheels
-                    # so only a requirements bump triggers a recompile. Same file list as the deptry/testml
-                    # jobs (even though this job doesn't install requirements-ml.txt) so the cache is shared.
-                    cache: pip
-                    cache-dependency-path: |
-                        requirements-dev.txt
-                        requirements-ml.txt
+            # scipy builds from source (see "Install ffmpeg" step above); cache pip's built wheels so only
+            # a requirements bump triggers a recompile. Same key as the deptry/testml jobs (even though
+            # this job doesn't install requirements-ml.txt) so the cache is shared across all three.
+            # Skipped (read-only) on scheduled runs, like the .tox cache below, so the nightly cron always
+            # exercises a from-scratch build - but nightly's freshly-built wheels are still saved (see the
+            # Save step below), so PR/push runs benefit.
+            -   name: Restore cached pip wheels
+                if: ${{ github.event_name != 'schedule' }}
+                uses: actions/cache/restore@v5
+                with:
+                    path: ~/.cache/pip
+                    key: pip-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('requirements-dev.txt', 'requirements-ml.txt') }}
             # The archive is versioned in its URL (v5), so a plain URL-keyed cache is safe indefinitely -
             # no invalidation is needed until the workflow itself is updated to a new URL.
             -   name: Restore cached episodes
@@ -321,6 +346,12 @@ jobs:
                     python -m pip install -U tox tox-gh-actions
             -   name: Run tests
                 run: tox -e py${{ matrix.python-version }},py${{ matrix.python-version }}-verify-install
+            -   name: Save cached pip wheels
+                if: always()
+                uses: actions/cache/save@v5
+                with:
+                    path: ~/.cache/pip
+                    key: pip-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('requirements-dev.txt', 'requirements-ml.txt') }}
             -   name: Save cached tox environments
                 if: ${{ always() && github.event_name != 'schedule' }}
                 uses: actions/cache/save@v5

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -172,12 +172,12 @@ jobs:
         steps:
             -   uses: actions/checkout@v6
             -   name: Log in to GHCR
-                uses: docker/login-action@v3
+                uses: docker/login-action@v4
                 with:
                     registry: ghcr.io
                     username: ${{ github.actor }}
                     password: ${{ secrets.GITHUB_TOKEN }}
-            -   uses: docker/setup-buildx-action@v3
+            -   uses: docker/setup-buildx-action@v4
             -   name: Build image name
                 id: image-name
                 run: echo "IMAGE_NAME=$(echo 'ghcr.io/${{ github.repository }}-ci-env' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
@@ -214,7 +214,7 @@ jobs:
                     curl -fsSL https://raw.githubusercontent.com/kou/arrow/e49d8ae15583ceff03237571569099a6ad62be32/ci/scripts/util_free_space.sh | bash
             -   name: Build and push testml CI-env image
                 if: steps.image-exists.outputs.exists != 'true'
-                uses: docker/build-push-action@v6
+                uses: docker/build-push-action@v7
                 with:
                     context: .
                     file: Dockerfile.ci-env

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -439,42 +439,46 @@ jobs:
                     key: tox-notebooks-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('tox.ini', 'requirements-dev.txt') }}
 
     examples:
+        needs: [ build-ci-env-default ]
         runs-on: ubuntu-24.04
+        permissions:
+            contents: read
+            packages: read
         strategy:
             fail-fast: false
             matrix:
                 python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
+        # requirements-dev.txt (incl. scipy, already built from source) is baked into this image by
+        # build-ci-env-default above - nothing left to install here. Same image as test (no Redis/other
+        # service dependency here, so no networking wrinkle - see notebooks, which does have one and isn't
+        # containerized yet for that reason).
+        container:
+            image: ghcr.io/${{ github.repository }}-ci-env:py${{ matrix.python-version }}-default-${{ needs.build-ci-env-default.outputs.reqs-hash }}
+            credentials:
+                username: ${{ github.actor }}
+                password: ${{ secrets.GITHUB_TOKEN }}
         steps:
             -   uses: actions/checkout@v6
-            -   name: Set up Python ${{ matrix.python-version }}
-                uses: actions/setup-python@v6
-                with:
-                    python-version: ${{ matrix.python-version }}
             -   name: Download Olten scenario
                 run: |
                     wget "${{ env.flatland-scenarios-olten-partially-closed-url }}" -O OLTEN_PARTIALLY_CLOSED_v2.zip
                     mkdir -p scenarios/scenario_olten/data
                     unzip OLTEN_PARTIALLY_CLOSED_v2 -d scenarios/scenario_olten/data
-            # https://adamj.eu/tech/2023/11/02/github-actions-faster-python-virtual-environments/ - skipped on
-            # scheduled runs so the nightly cron always exercises a from-scratch install.
-            -   name: Restore cached tox environments
-                if: ${{ github.event_name != 'schedule' }}
-                uses: actions/cache/restore@v5
-                with:
-                    path: .tox
-                    key: tox-examples-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('tox.ini', 'requirements-dev.txt') }}
-            -   name: Install tox
-                run: |
-                    python -m pip install --upgrade pip
-                    python -m pip install -U tox tox-gh-actions
+            # Runs the script directly rather than `tox run -e py{version}-examples`: tox would create its
+            # own venv and reinstall requirements-dev.txt into it regardless of what the image's system
+            # Python already has, rebuilding scipy from source again and defeating the point of this image.
+            # Mirrors tox.ini's [testenv:py{...}-examples] set_env/commands exactly; that env remains the
+            # source of truth for local/non-container runs. Doesn't install flatland-rl itself even though
+            # tox's env technically does (default skip_install=false) - PYTHONPATH alone is enough (same
+            # reasoning as testml/test's main pytest run - see those jobs).
             -   name: Run examples
-                run: tox run -e py${{ matrix.python-version }}-examples
-            -   name: Save cached tox environments
-                if: ${{ always() && github.event_name != 'schedule' }}
-                uses: actions/cache/save@v5
-                with:
-                    path: .tox
-                    key: tox-examples-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('tox.ini', 'requirements-dev.txt') }}
+                env:
+                    PYTHONPATH: ${{ github.workspace }}
+                    SCENARIOS_FOLDER: ${{ github.workspace }}/scenarios
+                    CMAKE_POLICY_VERSION_MINIMUM: "3.5"
+                run: |
+                    python --version
+                    python benchmarks/run_all_examples.py
 
     verify-cython-build:
         runs-on: ubuntu-24.04

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -75,9 +75,9 @@ jobs:
             fail-fast: false
             matrix:
                 python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
-        # Same value on every matrix leg (it only depends on the two requirements files and
-        # Dockerfile.ci-env, not matrix.python-version), so which leg "wins" the usual matrix-job-output
-        # ambiguity doesn't matter.
+        # Same value on every matrix leg (it only depends on the two requirements files, Dockerfile.ci-env,
+        # and docker/install-build-toolchain.sh, not matrix.python-version), so which leg "wins" the usual
+        # matrix-job-output ambiguity doesn't matter.
         outputs:
             image-hash: ${{ steps.image-hash.outputs.hash }}
         steps:
@@ -94,12 +94,13 @@ jobs:
                 run: echo "IMAGE_NAME=$(echo 'ghcr.io/${{ github.repository }}-ci-env' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
             # hashFiles() needs the checkout above to have already populated the workspace - it can't be
             # computed directly in deptry's/testml's own container: (see the tag comment below). Includes
-            # Dockerfile.ci-env itself, not just the requirements files: otherwise a Dockerfile-only change
-            # (e.g. adding a missing apt package) would keep the same tag, and the "already exists" check
-            # below would keep serving the stale pre-fix image forever.
+            # Dockerfile.ci-env and docker/install-build-toolchain.sh (COPY'd into it) too, not just the
+            # requirements files: otherwise a Dockerfile/toolchain-script-only change (e.g. adding a missing
+            # apt package) would keep the same tag, and the "already exists" check below would keep serving
+            # the stale pre-fix image forever.
             -   name: Compute image hash
                 id: image-hash
-                run: echo "hash=${{ hashFiles('requirements-dev.txt', 'requirements-ml.txt', 'Dockerfile.ci-env') }}" >> "$GITHUB_OUTPUT"
+                run: echo "hash=${{ hashFiles('requirements-dev.txt', 'requirements-ml.txt', 'Dockerfile.ci-env', 'docker/install-build-toolchain.sh') }}" >> "$GITHUB_OUTPUT"
             # Lets everything below skip the disk-space dance (and the build itself) when this exact
             # (python-version, requirements-hash) combination was already built and pushed - most runs, once
             # the cache is warm, since requirements change far less often than commits.
@@ -139,7 +140,8 @@ jobs:
                     cache-from: type=registry,ref=${{ steps.image-name.outputs.IMAGE_NAME }}:cache-py${{ matrix.python-version }}-ml
                     cache-to: type=registry,ref=${{ steps.image-name.outputs.IMAGE_NAME }}:cache-py${{ matrix.python-version }}-ml,mode=max
                     push: true
-                    # Tagged by a hash of requirements-dev.txt/requirements-ml.txt/Dockerfile.ci-env, not by
+                    # Tagged by a hash of requirements-dev.txt/requirements-ml.txt/Dockerfile.ci-env/
+                    # docker/install-build-toolchain.sh, not by
                     # commit SHA: the runnable tag is a mutable pointer any workflow run can overwrite, and
                     # checks.yml's concurrency group is scoped per-branch, so two different PRs' runs (or a
                     # PR vs. main) genuinely execute in parallel. Keying on content (not the commit) means
@@ -163,8 +165,9 @@ jobs:
             fail-fast: false
             matrix:
                 python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
-        # Same value on every matrix leg (it only depends on requirements-dev.txt and Dockerfile.ci-env, not
-        # matrix.python-version), so which leg "wins" the usual matrix-job-output ambiguity doesn't matter.
+        # Same value on every matrix leg (it only depends on requirements-dev.txt, Dockerfile.ci-env, and
+        # docker/install-build-toolchain.sh, not matrix.python-version), so which leg "wins" the usual
+        # matrix-job-output ambiguity doesn't matter.
         outputs:
             image-hash: ${{ steps.image-hash.outputs.hash }}
         steps:
@@ -179,11 +182,11 @@ jobs:
             -   name: Build image name
                 id: image-name
                 run: echo "IMAGE_NAME=$(echo 'ghcr.io/${{ github.repository }}-ci-env' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
-            # Includes Dockerfile.ci-env itself, not just requirements-dev.txt - see build-ci-env-ml's
-            # equivalent step for why.
+            # Includes Dockerfile.ci-env and docker/install-build-toolchain.sh, not just requirements-dev.txt
+            # - see build-ci-env-ml's equivalent step for why.
             -   name: Compute image hash
                 id: image-hash
-                run: echo "hash=${{ hashFiles('requirements-dev.txt', 'Dockerfile.ci-env') }}" >> "$GITHUB_OUTPUT"
+                run: echo "hash=${{ hashFiles('requirements-dev.txt', 'Dockerfile.ci-env', 'docker/install-build-toolchain.sh') }}" >> "$GITHUB_OUTPUT"
             -   name: Check if CI-env image already exists
                 id: image-exists
                 run: |

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -165,6 +165,10 @@ jobs:
             fail-fast: false
             matrix:
                 python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
+        # Same value on every matrix leg (it only depends on the two requirements files, not
+        # matrix.python-version), so which leg "wins" the usual matrix-job-output ambiguity doesn't matter.
+        outputs:
+            reqs-hash: ${{ steps.reqs-hash.outputs.hash }}
         steps:
             -   name: Inspect disk
                 run: |
@@ -189,6 +193,11 @@ jobs:
             -   name: Build image name
                 id: image-name
                 run: echo "IMAGE_NAME=$(echo 'ghcr.io/${{ github.repository }}-ci-env' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+            # hashFiles() needs the checkout above to have already populated the workspace - it can't be
+            # computed directly in testml's own container: (see the tag comment below for why that matters).
+            -   name: Compute requirements hash
+                id: reqs-hash
+                run: echo "hash=${{ hashFiles('requirements-dev.txt', 'requirements-ml.txt') }}" >> "$GITHUB_OUTPUT"
             -   name: Build and push testml CI-env image
                 uses: docker/build-push-action@v6
                 with:
@@ -200,14 +209,15 @@ jobs:
                     cache-from: type=registry,ref=${{ steps.image-name.outputs.IMAGE_NAME }}:cache-py${{ matrix.python-version }}-ml
                     cache-to: type=registry,ref=${{ steps.image-name.outputs.IMAGE_NAME }}:cache-py${{ matrix.python-version }}-ml,mode=max
                     push: true
-                    # Tagged by commit SHA, not just Python version: this tag is a mutable pointer any
-                    # workflow run can overwrite, and checks.yml's concurrency group is scoped per-branch,
-                    # so two different PRs' runs (or a PR vs. main) genuinely execute in parallel - without
-                    # the SHA, one run's push could overwrite another's tag mid-flight, and testml below
-                    # could pull a different commit's requirements than the one it's actually testing. Can't
-                    # key on hashFiles(requirements-*.txt) instead: testml's `container:` (like `runs-on:`)
-                    # is resolved before that job's own checkout runs, so hashFiles() would see no files yet.
-                    tags: ${{ steps.image-name.outputs.IMAGE_NAME }}:py${{ matrix.python-version }}-ml-${{ github.sha }}
+                    # Tagged by a hash of requirements-dev.txt/requirements-ml.txt, not by commit SHA: the
+                    # runnable tag is a mutable pointer any workflow run can overwrite, and checks.yml's
+                    # concurrency group is scoped per-branch, so two different PRs' runs (or a PR vs. main)
+                    # genuinely execute in parallel. Keying on content (not the commit) means two commits
+                    # with identical requirements safely share one tag/image - and two commits with
+                    # different requirements never collide, since they get different tags. A per-commit tag
+                    # would "solve" the race too, but at the cost of a fresh image (and GHCR tag) on every
+                    # commit even when nothing dependency-related changed, defeating the point of caching.
+                    tags: ${{ steps.image-name.outputs.IMAGE_NAME }}:py${{ matrix.python-version }}-ml-${{ steps.reqs-hash.outputs.hash }}
             -   name: Check disk space
                 run: df . -h
 
@@ -224,9 +234,12 @@ jobs:
         # All requirements-dev.txt/requirements-ml.txt deps (incl. scipy/dm-tree, already built from source)
         # are baked into this image by build-ci-env-testml above - nothing left to install here.
         container:
-            # Matches build-ci-env-testml's tag exactly (see the comment there for why it's SHA-qualified,
-            # not just Python-version).
-            image: ghcr.io/${{ github.repository }}-ci-env:py${{ matrix.python-version }}-ml-${{ github.sha }}
+            # Matches build-ci-env-testml's tag exactly (see the comment there for why it's keyed on a
+            # requirements hash, not just Python-version). Read via needs.*.outputs rather than computing
+            # hashFiles() here directly: container: is resolved before this job's own checkout runs, so
+            # hashFiles() would see no files yet - needs.*.outputs works because it's just a stored value
+            # from the already-completed build-ci-env-testml job, not a live filesystem read.
+            image: ghcr.io/${{ github.repository }}-ci-env:py${{ matrix.python-version }}-ml-${{ needs.build-ci-env-testml.outputs.reqs-hash }}
             credentials:
                 username: ${{ github.actor }}
                 password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -112,10 +112,12 @@ jobs:
                 with:
                     python-version: ${{ matrix.python-version }}
             # scipy/dm-tree build from source (see "Install ffmpeg" step above); cache pip's built wheels
-            # so only a requirements bump triggers a recompile. Same key as the test/testml jobs below so
-            # the cache is shared across all three. Skipped (read-only) on scheduled runs, like the .tox
-            # cache below, so the nightly cron always exercises a from-scratch build - but nightly's
-            # freshly-built wheels are still saved (see the Save step below), so PR/push runs benefit.
+            # so only a requirements bump triggers a recompile. Same key as the test job below so the
+            # cache is shared between the two (testml gets its dependencies from a prebuilt Docker image
+            # instead - see build-ci-env-testml/testml above). Skipped (read-only) on scheduled runs, like
+            # the .tox cache below, so the nightly cron always exercises a from-scratch build - but
+            # nightly's freshly-built wheels are still saved (see the Save step below), so PR/push runs
+            # benefit.
             -   name: Restore cached pip wheels
                 if: ${{ github.event_name != 'schedule' }}
                 uses: actions/cache/restore@v5
@@ -149,17 +151,20 @@ jobs:
                     path: .tox
                     key: tox-deptry-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('tox.ini', 'requirements-dev.txt', 'requirements-ml.txt') }}
 
-    testml:
+    # Builds/pushes the CI-only dependency image consumed by the testml job below (see Dockerfile.ci-env,
+    # a separate, non-user-facing image from the ones docker.yml/publish.yml build and publish to end
+    # users). BuildKit's registry cache (cache-from/cache-to) makes this a near-instant no-op once
+    # requirements-dev.txt/requirements-ml.txt stop changing, since every RUN layer stays cache-hit -
+    # unlike actions/cache, multiple concurrent pushes to the same cache ref don't stomp each other.
+    build-ci-env-testml:
         runs-on: ubuntu-24.04
+        permissions:
+            contents: read
+            packages: write
         strategy:
             fail-fast: false
             matrix:
                 python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
-        # dm-tree's vendored abseil-cpp (20210324.2) fails to compile with GCC 13+ (the runner's default);
-        # gcc-12/g++-12 (installed below) build it fine. tox passes CC/CXX through by default.
-        env:
-            CC: gcc-12
-            CXX: g++-12
         steps:
             -   name: Inspect disk
                 run: |
@@ -173,45 +178,51 @@ jobs:
             -   name: Free disk space
                 run: |
                     curl -fsSL https://raw.githubusercontent.com/kou/arrow/e49d8ae15583ceff03237571569099a6ad62be32/ci/scripts/util_free_space.sh | bash
-            -   name: Inspect disk again
-                run: |
-                    df -h
-                    docker system df
-            -   name: Install ffmpeg
-                run: |
-                    set -euxo pipefail
-                    # https://askubuntu.com/questions/1512042/ubuntu-24-04-getting-error-you-must-put-some-deb-src-uris-in-your-sources-list
-                    sudo sed -i 's/^Types: deb/Types: deb deb-src/' /etc/apt/sources.list.d/ubuntu.sources
-                    sudo apt-get update
-                    sudo apt-get -y install ffmpeg
-                    # TODO As long as scipy is pinned to < 1.16 (to ensure to support for Python 3.10), we need to install it from source
-                    # https://docs.scipy.org/doc/scipy/building/index.html
-                    sudo apt-get -y build-dep scipy
-                    # scipy's build-dep pulls in an old pybind11-dev that meson picks up via pkg-config ahead of
-                    # the newer pip-installed pybind11, breaking contourpy's from-source build on newer Pythons
-                    sudo apt-get -y remove pybind11-dev || true
-                    # dm-tree's vendored abseil-cpp (20210324.2) fails to compile with GCC 13+ (the runner's
-                    # default); gcc-12/g++-12 build it fine. CC/CXX are set at job level below (tox passes them through by default).
-                    sudo apt-get -y install gcc-12 g++-12
-                    # scipy's meson build looks for OpenBLAS specifically via pkg-config; the generic BLAS/LAPACK
-                    # virtual package satisfied by `build-dep scipy` doesn't necessarily provide openblas.pc.
-                    sudo apt-get -y install libopenblas-dev
             -   uses: actions/checkout@v6
-            -   name: Set up Python ${{ matrix.python-version }}
-                uses: actions/setup-python@v6
+            -   name: Log in to GHCR
+                uses: docker/login-action@v3
                 with:
-                    python-version: ${{ matrix.python-version }}
-            # scipy/dm-tree build from source (see "Install ffmpeg" step above); cache pip's built wheels
-            # so only a requirements bump triggers a recompile. Same key as the deptry/test jobs so the
-            # cache is shared across all three. Skipped (read-only) on scheduled runs, like the .tox cache
-            # below, so the nightly cron always exercises a from-scratch build - but nightly's freshly-built
-            # wheels are still saved (see the Save step below), so PR/push runs benefit.
-            -   name: Restore cached pip wheels
-                if: ${{ github.event_name != 'schedule' }}
-                uses: actions/cache/restore@v5
+                    registry: ghcr.io
+                    username: ${{ github.actor }}
+                    password: ${{ secrets.GITHUB_TOKEN }}
+            -   uses: docker/setup-buildx-action@v3
+            -   name: Build image name
+                id: image-name
+                run: echo "IMAGE_NAME=$(echo 'ghcr.io/${{ github.repository }}-ci-env' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+            -   name: Build and push testml CI-env image
+                uses: docker/build-push-action@v6
                 with:
-                    path: ~/.cache/pip
-                    key: pip-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('requirements-dev.txt', 'requirements-ml.txt') }}
+                    context: .
+                    file: Dockerfile.ci-env
+                    platforms: linux/amd64
+                    build-args: |
+                        PYTHON_VERSION=${{ matrix.python-version }}
+                    cache-from: type=registry,ref=${{ steps.image-name.outputs.IMAGE_NAME }}:cache-py${{ matrix.python-version }}-ml
+                    cache-to: type=registry,ref=${{ steps.image-name.outputs.IMAGE_NAME }}:cache-py${{ matrix.python-version }}-ml,mode=max
+                    push: true
+                    tags: ${{ steps.image-name.outputs.IMAGE_NAME }}:py${{ matrix.python-version }}-ml
+            -   name: Check disk space
+                run: df . -h
+
+    testml:
+        needs: [ build-ci-env-testml ]
+        runs-on: ubuntu-24.04
+        permissions:
+            contents: read
+            packages: read
+        strategy:
+            fail-fast: false
+            matrix:
+                python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
+        # All requirements-dev.txt/requirements-ml.txt deps (incl. scipy/dm-tree, already built from source)
+        # are baked into this image by build-ci-env-testml above - nothing left to install here.
+        container:
+            image: ghcr.io/${{ github.repository }}-ci-env:py${{ matrix.python-version }}-ml
+            credentials:
+                username: ${{ github.actor }}
+                password: ${{ secrets.GITHUB_TOKEN }}
+        steps:
+            -   uses: actions/checkout@v6
             # The archive is versioned in its URL (v5), so a plain URL-keyed cache is safe indefinitely -
             # no invalidation is needed until the workflow itself is updated to a new URL.
             -   name: Restore cached episodes
@@ -232,34 +243,18 @@ jobs:
                 with:
                     path: episodes
                     key: episodes-${{ env.flatland-benchmarks-episodes-url }}
-            # https://adamj.eu/tech/2023/11/02/github-actions-faster-python-virtual-environments/ - skipped on
-            # scheduled runs so the nightly cron always exercises a from-scratch install.
-            -   name: Restore cached tox environments
-                if: ${{ github.event_name != 'schedule' }}
-                uses: actions/cache/restore@v5
-                with:
-                    path: .tox
-                    key: tox-testml-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('tox.ini', 'requirements-dev.txt', 'requirements-ml.txt') }}
-            -   name: Install tox
-                run: |
-                    python -m pip install --upgrade pip
-                    python -m pip install -U tox tox-gh-actions
+            # Runs pytest directly rather than `tox run -e py{version}-ml`: tox would create its own venv
+            # and reinstall requirements-dev.txt/requirements-ml.txt into it regardless of what the image's
+            # system Python already has, rebuilding scipy/dm-tree from source again and defeating the point
+            # of this image. Mirrors tox.ini's [testenv:py{...}-ml] set_env/commands exactly; that env
+            # remains the source of truth for local/non-container runs.
             -   name: Run tests
-                run: tox run -e py${{ matrix.python-version }}-ml
-            -   name: Save cached pip wheels
-                if: always()
-                uses: actions/cache/save@v5
-                with:
-                    path: ~/.cache/pip
-                    key: pip-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('requirements-dev.txt', 'requirements-ml.txt') }}
-            -   name: Save cached tox environments
-                if: ${{ always() && github.event_name != 'schedule' }}
-                uses: actions/cache/save@v5
-                with:
-                    path: .tox
-                    key: tox-testml-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('tox.ini', 'requirements-dev.txt', 'requirements-ml.txt') }}
-            -   name: Check disk space
-                run: df . -h
+                env:
+                    PYTHONPATH: ${{ github.workspace }}
+                    BENCHMARK_EPISODES_FOLDER: ${{ github.workspace }}/episodes
+                    PYTHONDONTWRITEBYTECODE: "1"
+                    CMAKE_POLICY_VERSION_MINIMUM: "3.5"
+                run: python -m pytest -n auto --retries 2 --retry-delay 5 tests/ml
 
     test:
         runs-on: ubuntu-24.04
@@ -298,14 +293,15 @@ jobs:
                 with:
                     python-version: ${{ matrix.python-version }}
             # scipy builds from source (see "Install ffmpeg" step above); cache pip's built wheels so only
-            # a requirements bump triggers a recompile. Same key as the deptry/testml jobs so the cache is
-            # shared - restore-only here, deliberately: this job only installs requirements-dev.txt, a
-            # strict subset of what deptry/testml install, so it's always the fastest of the three and
-            # would tend to win the cache-save race on a cold key. actions/cache keys are immutable
-            # (a save to an existing key is silently skipped), so whichever job's save "wins" locks in its
-            # content until the key changes - if that were this job, the shared cache would end up missing
-            # the dm-tree/torch/ray wheels deptry/testml need. Leaving the save to deptry/testml (which
-            # both install the full superset) avoids that.
+            # a requirements bump triggers a recompile. Same key as the deptry job so the cache is shared -
+            # restore-only here, deliberately: this job only installs requirements-dev.txt, a strict subset
+            # of what deptry installs (requirements-dev.txt + requirements-ml.txt), so it's the faster of
+            # the two and would tend to win the cache-save race on a cold key. actions/cache keys are
+            # immutable (a save to an existing key is silently skipped), so whichever job's save "wins"
+            # locks in its content until the key changes - if that were this job, the shared cache would
+            # end up missing the dm-tree/torch/ray wheels deptry needs. Leaving the save to deptry (which
+            # installs the full superset) avoids that. (testml gets its dependencies from a prebuilt Docker
+            # image instead - see build-ci-env-testml/testml above - so it no longer participates here.)
             -   name: Restore cached pip wheels
                 if: ${{ github.event_name != 'schedule' }}
                 uses: actions/cache/restore@v5

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -62,10 +62,18 @@ jobs:
 
     # Builds/pushes the CI-only dependency image consumed by the deptry/testml jobs below (see
     # Dockerfile.ci-env, a separate, non-user-facing image from the ones docker.yml/publish.yml build and
-    # publish to end users). BuildKit's registry cache (cache-from/cache-to) makes this a near-instant
-    # no-op once requirements-dev.txt/requirements-ml.txt stop changing, since every RUN layer stays
-    # cache-hit - unlike actions/cache, multiple concurrent pushes to the same cache ref don't stomp each
-    # other.
+    # publish to end users). GHCR (not actions/cache) specifically because actions/cache caps out at 10GB
+    # per repository, shared across every cache this repo uses (not per-job), evicting oldest-accessed first
+    # once exceeded:
+    # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows
+    # A single ml tox env (torch/dm-tree/scipy etc.) already runs ~3GB - with 5 Python versions x 2 variants,
+    # naively caching each venv/build would blow past 10GB on its own, causing exactly the kind of premature
+    # eviction/thrashing (a cache saved this run gets evicted before the next run that could reuse it) this
+    # whole approach exists to avoid. GHCR has no such cap (see ci-env-cleanup.yml instead, for the different
+    # problem of it also having no automatic eviction). BuildKit's registry cache
+    # (cache-from/cache-to) makes this a near-instant no-op once requirements-dev.txt/requirements-ml.txt
+    # stop changing, since every RUN layer stays cache-hit - unlike actions/cache, multiple concurrent pushes
+    # to the same cache ref don't stomp each other either.
     build-ci-env-ml:
         runs-on: ubuntu-24.04
         permissions:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -298,11 +298,14 @@ jobs:
                 with:
                     python-version: ${{ matrix.python-version }}
             # scipy builds from source (see "Install ffmpeg" step above); cache pip's built wheels so only
-            # a requirements bump triggers a recompile. Same key as the deptry/testml jobs (even though
-            # this job doesn't install requirements-ml.txt) so the cache is shared across all three.
-            # Skipped (read-only) on scheduled runs, like the .tox cache below, so the nightly cron always
-            # exercises a from-scratch build - but nightly's freshly-built wheels are still saved (see the
-            # Save step below), so PR/push runs benefit.
+            # a requirements bump triggers a recompile. Same key as the deptry/testml jobs so the cache is
+            # shared - restore-only here, deliberately: this job only installs requirements-dev.txt, a
+            # strict subset of what deptry/testml install, so it's always the fastest of the three and
+            # would tend to win the cache-save race on a cold key. actions/cache keys are immutable
+            # (a save to an existing key is silently skipped), so whichever job's save "wins" locks in its
+            # content until the key changes - if that were this job, the shared cache would end up missing
+            # the dm-tree/torch/ray wheels deptry/testml need. Leaving the save to deptry/testml (which
+            # both install the full superset) avoids that.
             -   name: Restore cached pip wheels
                 if: ${{ github.event_name != 'schedule' }}
                 uses: actions/cache/restore@v5
@@ -343,12 +346,8 @@ jobs:
                     python -m pip install -U tox tox-gh-actions
             -   name: Run tests
                 run: tox -e py${{ matrix.python-version }},py${{ matrix.python-version }}-verify-install
-            -   name: Save cached pip wheels
-                if: always()
-                uses: actions/cache/save@v5
-                with:
-                    path: ~/.cache/pip
-                    key: pip-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('requirements-dev.txt', 'requirements-ml.txt') }}
+            # No "Save cached pip wheels" step here - see the comment on "Restore cached pip wheels" above:
+            # this job never writes to the shared pip-wheel cache, only reads from it.
             -   name: Save cached tox environments
                 if: ${{ always() && github.event_name != 'schedule' }}
                 uses: actions/cache/save@v5

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -428,8 +428,7 @@ jobs:
     #    hostname would just trade one failure (no --network host) for another (wrong hostname).
     #
     # So this needs an actual code change (parameterize the Redis host in the two notebooks, then add
-    # `container:` + keep `services:` here), not just a workflow tweak - see S6 in the ongoing CI cache/
-    # containerization cleanup plan.
+    # `container:` + keep `services:` here), not just a workflow tweak.
     notebooks:
         runs-on: ubuntu-24.04
         strategy:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -62,176 +62,29 @@ jobs:
 
     # Builds/pushes the CI-only dependency image consumed by the deptry/testml jobs below (see
     # Dockerfile.ci-env, a separate, non-user-facing image from the ones docker.yml/publish.yml build and
-    # publish to end users). GHCR (not actions/cache) specifically because actions/cache caps out at 10GB
-    # per repository, shared across every cache this repo uses (not per-job), evicting oldest-accessed first
-    # once exceeded:
-    # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows
-    # A single ml tox env (torch/dm-tree/scipy etc.) already runs ~3GB - with 5 Python versions x 2 variants,
-    # naively caching each venv/build would blow past 10GB on its own, causing exactly the kind of premature
-    # eviction/thrashing (a cache saved this run gets evicted before the next run that could reuse it) this
-    # whole approach exists to avoid. GHCR has no such cap (see ci-env-cleanup.yml instead, for the different
-    # problem of it also having no automatic eviction). BuildKit's registry cache
-    # (cache-from/cache-to) makes this a near-instant no-op once requirements-dev.txt/requirements-ml.txt
-    # stop changing, since every RUN layer stays cache-hit - unlike actions/cache, multiple concurrent pushes
-    # to the same cache ref don't stomp each other either.
+    # publish to end users). See build-ci-env.yml (shared with publish.yml's own pre-release test job) for
+    # the actual build/cache-check/push logic and why GHCR was chosen over actions/cache for this.
     build-ci-env-ml:
-        runs-on: ubuntu-24.04
-        permissions:
-            contents: read
-            packages: write
         strategy:
             fail-fast: false
             matrix:
                 python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
-        # Same value on every matrix leg (it only depends on the two requirements files, Dockerfile.ci-env,
-        # and docker/install-build-toolchain.sh, not matrix.python-version), so which leg "wins" the usual
-        # matrix-job-output ambiguity doesn't matter.
-        outputs:
-            image-hash: ${{ steps.image-hash.outputs.hash }}
-        steps:
-            -   uses: actions/checkout@v6
-            -   name: Log in to GHCR
-                uses: docker/login-action@v4
-                with:
-                    registry: ghcr.io
-                    username: ${{ github.actor }}
-                    password: ${{ secrets.GITHUB_TOKEN }}
-            -   uses: docker/setup-buildx-action@v4
-            -   name: Build image name
-                id: image-name
-                run: echo "IMAGE_NAME=$(echo 'ghcr.io/${{ github.repository }}-ci-env' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
-            # hashFiles() needs the checkout above to have already populated the workspace - it can't be
-            # computed directly in deptry's/testml's own container: (see the tag comment below). Includes
-            # Dockerfile.ci-env and docker/install-build-toolchain.sh (COPY'd into it) too, not just the
-            # requirements files: otherwise a Dockerfile/toolchain-script-only change (e.g. adding a missing
-            # apt package) would keep the same tag, and the "already exists" check below would keep serving
-            # the stale pre-fix image forever.
-            -   name: Compute image hash
-                id: image-hash
-                run: echo "hash=${{ hashFiles('requirements-dev.txt', 'requirements-ml.txt', 'Dockerfile.ci-env', 'docker/install-build-toolchain.sh') }}" >> "$GITHUB_OUTPUT"
-            # Lets everything below skip the disk-space dance (and the build itself) when this exact
-            # (python-version, requirements-hash) combination was already built and pushed - most runs, once
-            # the cache is warm, since requirements change far less often than commits.
-            -   name: Check if CI-env image already exists
-                id: image-exists
-                run: |
-                    if docker buildx imagetools inspect "${{ steps.image-name.outputs.IMAGE_NAME }}:py${{ matrix.python-version }}-ml-${{ steps.image-hash.outputs.hash }}" > /dev/null 2>&1; then
-                        echo "exists=true" >> "$GITHUB_OUTPUT"
-                    else
-                        echo "exists=false" >> "$GITHUB_OUTPUT"
-                    fi
-            -   name: Inspect disk
-                if: steps.image-exists.outputs.exists != 'true'
-                run: |
-                    df -h
-                    docker system df
-            # https://stackoverflow.com/questions/30604846/docker-complains-about-no-space-left-on-device-how-to-clean-up
-            -   name: Prune docker system
-                if: steps.image-exists.outputs.exists != 'true'
-                run: |
-                    docker system prune --all --force
-            # https://www.dzombak.com/blog/2024/09/freeing-disk-space-on-github-actions-runners/
-            -   name: Free disk space
-                if: steps.image-exists.outputs.exists != 'true'
-                run: |
-                    curl -fsSL https://raw.githubusercontent.com/kou/arrow/e49d8ae15583ceff03237571569099a6ad62be32/ci/scripts/util_free_space.sh | bash
-            -   name: Build and push CI-env image (ml variant)
-                if: steps.image-exists.outputs.exists != 'true'
-                uses: docker/build-push-action@v7
-                with:
-                    context: .
-                    file: Dockerfile.ci-env
-                    platforms: linux/amd64
-                    build-args: |
-                        PYTHON_VERSION=${{ matrix.python-version }}
-                        WITH_ML=true
-                    cache-from: type=registry,ref=${{ steps.image-name.outputs.IMAGE_NAME }}:cache-py${{ matrix.python-version }}-ml
-                    cache-to: type=registry,ref=${{ steps.image-name.outputs.IMAGE_NAME }}:cache-py${{ matrix.python-version }}-ml,mode=max
-                    push: true
-                    # Tagged by a hash of requirements-dev.txt/requirements-ml.txt/Dockerfile.ci-env/
-                    # docker/install-build-toolchain.sh, not by
-                    # commit SHA: the runnable tag is a mutable pointer any workflow run can overwrite, and
-                    # checks.yml's concurrency group is scoped per-branch, so two different PRs' runs (or a
-                    # PR vs. main) genuinely execute in parallel. Keying on content (not the commit) means
-                    # two commits with identical inputs safely share one tag/image - and two commits with
-                    # different inputs never collide, since they get different tags. A per-commit tag
-                    # would "solve" the race too, but at the cost of a fresh image (and GHCR tag) on every
-                    # commit even when nothing dependency-related changed, defeating the point of caching.
-                    tags: ${{ steps.image-name.outputs.IMAGE_NAME }}:py${{ matrix.python-version }}-ml-${{ steps.image-hash.outputs.hash }}
-            -   name: Check disk space
-                run: df . -h
+        uses: ./.github/workflows/build-ci-env.yml
+        with:
+            python-version: ${{ matrix.python-version }}
+            with-ml: true
 
-    # Leaner counterpart to build-ci-env-ml, consumed by the test job below: no requirements-ml.txt, no
-    # dm-tree/cmake, since test only ever installs requirements-dev.txt. Still gets git from the base image
-    # stage though - test's "pip install ." step needs it for setuptools_scm regardless of ML variant.
+    # Leaner counterpart to build-ci-env-ml, consumed by the test/examples jobs below: no
+    # requirements-ml.txt, no dm-tree/cmake, since neither ever installs it.
     build-ci-env-default:
-        runs-on: ubuntu-24.04
-        permissions:
-            contents: read
-            packages: write
         strategy:
             fail-fast: false
             matrix:
                 python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
-        # Same value on every matrix leg (it only depends on requirements-dev.txt, Dockerfile.ci-env, and
-        # docker/install-build-toolchain.sh, not matrix.python-version), so which leg "wins" the usual
-        # matrix-job-output ambiguity doesn't matter.
-        outputs:
-            image-hash: ${{ steps.image-hash.outputs.hash }}
-        steps:
-            -   uses: actions/checkout@v6
-            -   name: Log in to GHCR
-                uses: docker/login-action@v4
-                with:
-                    registry: ghcr.io
-                    username: ${{ github.actor }}
-                    password: ${{ secrets.GITHUB_TOKEN }}
-            -   uses: docker/setup-buildx-action@v4
-            -   name: Build image name
-                id: image-name
-                run: echo "IMAGE_NAME=$(echo 'ghcr.io/${{ github.repository }}-ci-env' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
-            # Includes Dockerfile.ci-env and docker/install-build-toolchain.sh, not just requirements-dev.txt
-            # - see build-ci-env-ml's equivalent step for why.
-            -   name: Compute image hash
-                id: image-hash
-                run: echo "hash=${{ hashFiles('requirements-dev.txt', 'Dockerfile.ci-env', 'docker/install-build-toolchain.sh') }}" >> "$GITHUB_OUTPUT"
-            -   name: Check if CI-env image already exists
-                id: image-exists
-                run: |
-                    if docker buildx imagetools inspect "${{ steps.image-name.outputs.IMAGE_NAME }}:py${{ matrix.python-version }}-default-${{ steps.image-hash.outputs.hash }}" > /dev/null 2>&1; then
-                        echo "exists=true" >> "$GITHUB_OUTPUT"
-                    else
-                        echo "exists=false" >> "$GITHUB_OUTPUT"
-                    fi
-            -   name: Inspect disk
-                if: steps.image-exists.outputs.exists != 'true'
-                run: |
-                    df -h
-                    docker system df
-            -   name: Prune docker system
-                if: steps.image-exists.outputs.exists != 'true'
-                run: |
-                    docker system prune --all --force
-            -   name: Free disk space
-                if: steps.image-exists.outputs.exists != 'true'
-                run: |
-                    curl -fsSL https://raw.githubusercontent.com/kou/arrow/e49d8ae15583ceff03237571569099a6ad62be32/ci/scripts/util_free_space.sh | bash
-            -   name: Build and push CI-env image (default variant)
-                if: steps.image-exists.outputs.exists != 'true'
-                uses: docker/build-push-action@v7
-                with:
-                    context: .
-                    file: Dockerfile.ci-env
-                    platforms: linux/amd64
-                    build-args: |
-                        PYTHON_VERSION=${{ matrix.python-version }}
-                        WITH_ML=false
-                    cache-from: type=registry,ref=${{ steps.image-name.outputs.IMAGE_NAME }}:cache-py${{ matrix.python-version }}-default
-                    cache-to: type=registry,ref=${{ steps.image-name.outputs.IMAGE_NAME }}:cache-py${{ matrix.python-version }}-default,mode=max
-                    push: true
-                    tags: ${{ steps.image-name.outputs.IMAGE_NAME }}:py${{ matrix.python-version }}-default-${{ steps.image-hash.outputs.hash }}
-            -   name: Check disk space
-                run: df . -h
+        uses: ./.github/workflows/build-ci-env.yml
+        with:
+            python-version: ${{ matrix.python-version }}
+            with-ml: false
 
     deptry:
         needs: [ build-ci-env-ml ]
@@ -246,8 +99,8 @@ jobs:
         # All requirements-dev.txt/requirements-ml.txt deps (incl. scipy/dm-tree, already built from source)
         # are baked into this image by build-ci-env-ml above - nothing left to install here.
         container:
-            # Matches build-ci-env-ml's tag exactly (see the comment there for why it's keyed on a
-            # requirements hash, not just Python-version). Read via needs.*.outputs rather than computing
+            # Matches build-ci-env-ml's tag exactly (see build-ci-env.yml for why it's keyed on a content
+            # hash, not just Python-version). Read via needs.*.outputs rather than computing
             # hashFiles() here directly: container: is resolved before this job's own checkout runs, so
             # hashFiles() would see no files yet - needs.*.outputs works because it's just a stored value
             # from the already-completed build-ci-env-ml job, not a live filesystem read.
@@ -289,8 +142,8 @@ jobs:
         # All requirements-dev.txt/requirements-ml.txt deps (incl. scipy/dm-tree, already built from source)
         # are baked into this image by build-ci-env-ml above - nothing left to install here.
         container:
-            # Matches build-ci-env-ml's tag exactly (see the comment there for why it's keyed on a
-            # requirements hash, not just Python-version). Read via needs.*.outputs rather than computing
+            # Matches build-ci-env-ml's tag exactly (see build-ci-env.yml for why it's keyed on a content
+            # hash, not just Python-version). Read via needs.*.outputs rather than computing
             # hashFiles() here directly: container: is resolved before this job's own checkout runs, so
             # hashFiles() would see no files yet - needs.*.outputs works because it's just a stored value
             # from the already-completed build-ci-env-ml job, not a live filesystem read.
@@ -333,87 +186,18 @@ jobs:
                     CMAKE_POLICY_VERSION_MINIMUM: "3.5"
                 run: python -m pytest -n auto --retries 2 --retry-delay 5 tests/ml
 
+    # See run-ci-env-test.yml (shared with publish.yml's own pre-release test job) for the actual test
+    # invocation.
     test:
         needs: [ build-ci-env-default ]
-        runs-on: ubuntu-24.04
-        permissions:
-            contents: read
-            packages: read
         strategy:
             fail-fast: false
             matrix:
                 python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
-        # requirements-dev.txt (incl. scipy, already built from source) is baked into this image by
-        # build-ci-env-default above - nothing left to install here except flatland-rl itself, for the
-        # "Install flatland-rl and verify entry points" step below (its whole point is to test that install
-        # path, so unlike the pytest step it can't be skipped the way testml/deptry skip installing the
-        # package).
-        container:
-            image: ghcr.io/${{ github.repository }}-ci-env:py${{ matrix.python-version }}-default-${{ needs.build-ci-env-default.outputs.image-hash }}
-            credentials:
-                username: ${{ github.actor }}
-                password: ${{ secrets.GITHUB_TOKEN }}
-        steps:
-            # The "Install flatland-rl and verify entry points" step below does `pip install .`, which needs
-            # setuptools_scm to run `git describe --tags` to infer a version. fetch-depth: 0 alone isn't
-            # enough for that - it gives full commit history but actions/checkout still doesn't fetch tags
-            # unless fetch-tags is explicitly set (confirmed: fetch-depth: 0 by itself still hit
-            # "setuptools-scm was unable to detect version" here), so both are needed together.
-            -   uses: actions/checkout@v6
-                with:
-                    fetch-depth: 0
-                    fetch-tags: true
-            # The archive is versioned in its URL (v5), so a plain URL-keyed cache is safe indefinitely -
-            # no invalidation is needed until the workflow itself is updated to a new URL.
-            -   name: Restore cached episodes
-                id: cache-episodes
-                uses: actions/cache/restore@v5
-                with:
-                    path: episodes
-                    key: episodes-${{ env.flatland-benchmarks-episodes-url }}
-            -   name: Download episodes
-                if: steps.cache-episodes.outputs.cache-hit != 'true'
-                run: |
-                    wget "${{ env.flatland-benchmarks-episodes-url }}" -O FLATLAND_BENCHMARK_EPISODES_FOLDER.zip
-                    mkdir -p episodes
-                    unzip FLATLAND_BENCHMARK_EPISODES_FOLDER -d episodes
-            -   name: Save cached episodes
-                if: ${{ always() && steps.cache-episodes.outputs.cache-hit != 'true' }}
-                uses: actions/cache/save@v5
-                with:
-                    path: episodes
-                    key: episodes-${{ env.flatland-benchmarks-episodes-url }}
-            # Runs pytest directly rather than `tox run -e py{version}`: tox would create its own venv and
-            # reinstall requirements-dev.txt into it regardless of what the image's system Python already
-            # has, rebuilding scipy from source again and defeating the point of this image. Mirrors
-            # tox.ini's [testenv:py{...}] set_env/commands exactly; that env remains the source of truth
-            # for local/non-container runs. Doesn't install flatland-rl itself even though tox's env
-            # technically does (default skip_install=false) - PYTHONPATH alone is enough for tests to
-            # import it (confirmed empirically: testml's equivalent tox env has the identical default, and
-            # its container-based run already passes without installing the package).
-            -   name: Run tests
-                env:
-                    PYTHONPATH: ${{ github.workspace }}
-                    BENCHMARK_EPISODES_FOLDER: ${{ github.workspace }}/episodes
-                    PYTHONDONTWRITEBYTECODE: "1"
-                    CMAKE_POLICY_VERSION_MINIMUM: "3.5"
-                run: python -m pytest -n auto --ignore=tests/ml -m "not slow"
-            # Mirrors tox.ini's [testenv:py{...}-verify-install] - unlike the step above, this one's whole
-            # point is to test the installed-package/entry-points path, so it genuinely needs `pip install
-            # .` rather than relying on PYTHONPATH.
-            -   name: Install flatland-rl and verify entry points
-                run: |
-                    python --version
-                    pip install --no-cache-dir .
-                    python -c 'from flatland.evaluators.service import FlatlandRemoteEvaluationService'
-                    python -c 'import flatland.integrations.interactiveai.interactiveai'
-                    evaluator --help
-                    flatland-demo --help
-                    flatland-evaluator --help
-                    flatland-trajectory-evaluate --help
-                    flatland-trajectory-generate-from-policy --help
-                    flatland-trajectory-generate-from-metadata --help
-                    flatland-trajectory-analysis --help
+        uses: ./.github/workflows/run-ci-env-test.yml
+        with:
+            python-version: ${{ matrix.python-version }}
+            image-hash: ${{ needs.build-ci-env-default.outputs.image-hash }}
 
     # Not containerized (unlike deptry/testml/test/examples above) despite using the same requirements-dev.txt
     # - blocked on this job's "Start Redis" services: container below, for two compounding reasons:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -200,7 +200,14 @@ jobs:
                     cache-from: type=registry,ref=${{ steps.image-name.outputs.IMAGE_NAME }}:cache-py${{ matrix.python-version }}-ml
                     cache-to: type=registry,ref=${{ steps.image-name.outputs.IMAGE_NAME }}:cache-py${{ matrix.python-version }}-ml,mode=max
                     push: true
-                    tags: ${{ steps.image-name.outputs.IMAGE_NAME }}:py${{ matrix.python-version }}-ml
+                    # Tagged by commit SHA, not just Python version: this tag is a mutable pointer any
+                    # workflow run can overwrite, and checks.yml's concurrency group is scoped per-branch,
+                    # so two different PRs' runs (or a PR vs. main) genuinely execute in parallel - without
+                    # the SHA, one run's push could overwrite another's tag mid-flight, and testml below
+                    # could pull a different commit's requirements than the one it's actually testing. Can't
+                    # key on hashFiles(requirements-*.txt) instead: testml's `container:` (like `runs-on:`)
+                    # is resolved before that job's own checkout runs, so hashFiles() would see no files yet.
+                    tags: ${{ steps.image-name.outputs.IMAGE_NAME }}:py${{ matrix.python-version }}-ml-${{ github.sha }}
             -   name: Check disk space
                 run: df . -h
 
@@ -217,7 +224,9 @@ jobs:
         # All requirements-dev.txt/requirements-ml.txt deps (incl. scipy/dm-tree, already built from source)
         # are baked into this image by build-ci-env-testml above - nothing left to install here.
         container:
-            image: ghcr.io/${{ github.repository }}-ci-env:py${{ matrix.python-version }}-ml
+            # Matches build-ci-env-testml's tag exactly (see the comment there for why it's SHA-qualified,
+            # not just Python-version).
+            image: ghcr.io/${{ github.repository }}-ci-env:py${{ matrix.python-version }}-ml-${{ github.sha }}
             credentials:
                 username: ${{ github.actor }}
                 password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -336,14 +336,15 @@ jobs:
                 username: ${{ github.actor }}
                 password: ${{ secrets.GITHUB_TOKEN }}
         steps:
-            # fetch-depth: 0 (full history, incl. tags) - the "Install flatland-rl and verify entry points"
-            # step below does `pip install .`, which needs setuptools_scm to run `git describe --tags` to
-            # infer a version; the default shallow (depth-1, no tags) checkout doesn't give it enough
-            # history for that and fails with "setuptools-scm was unable to detect version". Same reasoning
-            # as publish.yml's build-related checkout steps.
+            # The "Install flatland-rl and verify entry points" step below does `pip install .`, which needs
+            # setuptools_scm to run `git describe --tags` to infer a version. fetch-depth: 0 alone isn't
+            # enough for that - it gives full commit history but actions/checkout still doesn't fetch tags
+            # unless fetch-tags is explicitly set (confirmed: fetch-depth: 0 by itself still hit
+            # "setuptools-scm was unable to detect version" here), so both are needed together.
             -   uses: actions/checkout@v6
                 with:
                     fetch-depth: 0
+                    fetch-tags: true
             # The archive is versioned in its URL (v5), so a plain URL-keyed cache is safe indefinitely -
             # no invalidation is needed until the workflow itself is updated to a new URL.
             -   name: Restore cached episodes

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -75,10 +75,11 @@ jobs:
             fail-fast: false
             matrix:
                 python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
-        # Same value on every matrix leg (it only depends on the two requirements files, not
-        # matrix.python-version), so which leg "wins" the usual matrix-job-output ambiguity doesn't matter.
+        # Same value on every matrix leg (it only depends on the two requirements files and
+        # Dockerfile.ci-env, not matrix.python-version), so which leg "wins" the usual matrix-job-output
+        # ambiguity doesn't matter.
         outputs:
-            reqs-hash: ${{ steps.reqs-hash.outputs.hash }}
+            image-hash: ${{ steps.image-hash.outputs.hash }}
         steps:
             -   uses: actions/checkout@v6
             -   name: Log in to GHCR
@@ -92,17 +93,20 @@ jobs:
                 id: image-name
                 run: echo "IMAGE_NAME=$(echo 'ghcr.io/${{ github.repository }}-ci-env' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
             # hashFiles() needs the checkout above to have already populated the workspace - it can't be
-            # computed directly in deptry's/testml's own container: (see the tag comment below).
-            -   name: Compute requirements hash
-                id: reqs-hash
-                run: echo "hash=${{ hashFiles('requirements-dev.txt', 'requirements-ml.txt') }}" >> "$GITHUB_OUTPUT"
+            # computed directly in deptry's/testml's own container: (see the tag comment below). Includes
+            # Dockerfile.ci-env itself, not just the requirements files: otherwise a Dockerfile-only change
+            # (e.g. adding a missing apt package) would keep the same tag, and the "already exists" check
+            # below would keep serving the stale pre-fix image forever.
+            -   name: Compute image hash
+                id: image-hash
+                run: echo "hash=${{ hashFiles('requirements-dev.txt', 'requirements-ml.txt', 'Dockerfile.ci-env') }}" >> "$GITHUB_OUTPUT"
             # Lets everything below skip the disk-space dance (and the build itself) when this exact
             # (python-version, requirements-hash) combination was already built and pushed - most runs, once
             # the cache is warm, since requirements change far less often than commits.
             -   name: Check if CI-env image already exists
                 id: image-exists
                 run: |
-                    if docker buildx imagetools inspect "${{ steps.image-name.outputs.IMAGE_NAME }}:py${{ matrix.python-version }}-ml-${{ steps.reqs-hash.outputs.hash }}" > /dev/null 2>&1; then
+                    if docker buildx imagetools inspect "${{ steps.image-name.outputs.IMAGE_NAME }}:py${{ matrix.python-version }}-ml-${{ steps.image-hash.outputs.hash }}" > /dev/null 2>&1; then
                         echo "exists=true" >> "$GITHUB_OUTPUT"
                     else
                         echo "exists=false" >> "$GITHUB_OUTPUT"
@@ -135,20 +139,21 @@ jobs:
                     cache-from: type=registry,ref=${{ steps.image-name.outputs.IMAGE_NAME }}:cache-py${{ matrix.python-version }}-ml
                     cache-to: type=registry,ref=${{ steps.image-name.outputs.IMAGE_NAME }}:cache-py${{ matrix.python-version }}-ml,mode=max
                     push: true
-                    # Tagged by a hash of requirements-dev.txt/requirements-ml.txt, not by commit SHA: the
-                    # runnable tag is a mutable pointer any workflow run can overwrite, and checks.yml's
-                    # concurrency group is scoped per-branch, so two different PRs' runs (or a PR vs. main)
-                    # genuinely execute in parallel. Keying on content (not the commit) means two commits
-                    # with identical requirements safely share one tag/image - and two commits with
-                    # different requirements never collide, since they get different tags. A per-commit tag
+                    # Tagged by a hash of requirements-dev.txt/requirements-ml.txt/Dockerfile.ci-env, not by
+                    # commit SHA: the runnable tag is a mutable pointer any workflow run can overwrite, and
+                    # checks.yml's concurrency group is scoped per-branch, so two different PRs' runs (or a
+                    # PR vs. main) genuinely execute in parallel. Keying on content (not the commit) means
+                    # two commits with identical inputs safely share one tag/image - and two commits with
+                    # different inputs never collide, since they get different tags. A per-commit tag
                     # would "solve" the race too, but at the cost of a fresh image (and GHCR tag) on every
                     # commit even when nothing dependency-related changed, defeating the point of caching.
-                    tags: ${{ steps.image-name.outputs.IMAGE_NAME }}:py${{ matrix.python-version }}-ml-${{ steps.reqs-hash.outputs.hash }}
+                    tags: ${{ steps.image-name.outputs.IMAGE_NAME }}:py${{ matrix.python-version }}-ml-${{ steps.image-hash.outputs.hash }}
             -   name: Check disk space
                 run: df . -h
 
     # Leaner counterpart to build-ci-env-ml, consumed by the test job below: no requirements-ml.txt, no
-    # dm-tree/cmake/git, since test only ever installs requirements-dev.txt.
+    # dm-tree/cmake, since test only ever installs requirements-dev.txt. Still gets git from the base image
+    # stage though - test's "pip install ." step needs it for setuptools_scm regardless of ML variant.
     build-ci-env-default:
         runs-on: ubuntu-24.04
         permissions:
@@ -158,10 +163,10 @@ jobs:
             fail-fast: false
             matrix:
                 python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
-        # Same value on every matrix leg (it only depends on requirements-dev.txt, not
+        # Same value on every matrix leg (it only depends on requirements-dev.txt and Dockerfile.ci-env, not
         # matrix.python-version), so which leg "wins" the usual matrix-job-output ambiguity doesn't matter.
         outputs:
-            reqs-hash: ${{ steps.reqs-hash.outputs.hash }}
+            image-hash: ${{ steps.image-hash.outputs.hash }}
         steps:
             -   uses: actions/checkout@v6
             -   name: Log in to GHCR
@@ -174,13 +179,15 @@ jobs:
             -   name: Build image name
                 id: image-name
                 run: echo "IMAGE_NAME=$(echo 'ghcr.io/${{ github.repository }}-ci-env' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
-            -   name: Compute requirements hash
-                id: reqs-hash
-                run: echo "hash=${{ hashFiles('requirements-dev.txt') }}" >> "$GITHUB_OUTPUT"
+            # Includes Dockerfile.ci-env itself, not just requirements-dev.txt - see build-ci-env-ml's
+            # equivalent step for why.
+            -   name: Compute image hash
+                id: image-hash
+                run: echo "hash=${{ hashFiles('requirements-dev.txt', 'Dockerfile.ci-env') }}" >> "$GITHUB_OUTPUT"
             -   name: Check if CI-env image already exists
                 id: image-exists
                 run: |
-                    if docker buildx imagetools inspect "${{ steps.image-name.outputs.IMAGE_NAME }}:py${{ matrix.python-version }}-default-${{ steps.reqs-hash.outputs.hash }}" > /dev/null 2>&1; then
+                    if docker buildx imagetools inspect "${{ steps.image-name.outputs.IMAGE_NAME }}:py${{ matrix.python-version }}-default-${{ steps.image-hash.outputs.hash }}" > /dev/null 2>&1; then
                         echo "exists=true" >> "$GITHUB_OUTPUT"
                     else
                         echo "exists=false" >> "$GITHUB_OUTPUT"
@@ -211,7 +218,7 @@ jobs:
                     cache-from: type=registry,ref=${{ steps.image-name.outputs.IMAGE_NAME }}:cache-py${{ matrix.python-version }}-default
                     cache-to: type=registry,ref=${{ steps.image-name.outputs.IMAGE_NAME }}:cache-py${{ matrix.python-version }}-default,mode=max
                     push: true
-                    tags: ${{ steps.image-name.outputs.IMAGE_NAME }}:py${{ matrix.python-version }}-default-${{ steps.reqs-hash.outputs.hash }}
+                    tags: ${{ steps.image-name.outputs.IMAGE_NAME }}:py${{ matrix.python-version }}-default-${{ steps.image-hash.outputs.hash }}
             -   name: Check disk space
                 run: df . -h
 
@@ -233,7 +240,7 @@ jobs:
             # hashFiles() here directly: container: is resolved before this job's own checkout runs, so
             # hashFiles() would see no files yet - needs.*.outputs works because it's just a stored value
             # from the already-completed build-ci-env-ml job, not a live filesystem read.
-            image: ghcr.io/${{ github.repository }}-ci-env:py${{ matrix.python-version }}-ml-${{ needs.build-ci-env-ml.outputs.reqs-hash }}
+            image: ghcr.io/${{ github.repository }}-ci-env:py${{ matrix.python-version }}-ml-${{ needs.build-ci-env-ml.outputs.image-hash }}
             credentials:
                 username: ${{ github.actor }}
                 password: ${{ secrets.GITHUB_TOKEN }}
@@ -276,7 +283,7 @@ jobs:
             # hashFiles() here directly: container: is resolved before this job's own checkout runs, so
             # hashFiles() would see no files yet - needs.*.outputs works because it's just a stored value
             # from the already-completed build-ci-env-ml job, not a live filesystem read.
-            image: ghcr.io/${{ github.repository }}-ci-env:py${{ matrix.python-version }}-ml-${{ needs.build-ci-env-ml.outputs.reqs-hash }}
+            image: ghcr.io/${{ github.repository }}-ci-env:py${{ matrix.python-version }}-ml-${{ needs.build-ci-env-ml.outputs.image-hash }}
             credentials:
                 username: ${{ github.actor }}
                 password: ${{ secrets.GITHUB_TOKEN }}
@@ -331,7 +338,7 @@ jobs:
         # path, so unlike the pytest step it can't be skipped the way testml/deptry skip installing the
         # package).
         container:
-            image: ghcr.io/${{ github.repository }}-ci-env:py${{ matrix.python-version }}-default-${{ needs.build-ci-env-default.outputs.reqs-hash }}
+            image: ghcr.io/${{ github.repository }}-ci-env:py${{ matrix.python-version }}-default-${{ needs.build-ci-env-default.outputs.image-hash }}
             credentials:
                 username: ${{ github.actor }}
                 password: ${{ secrets.GITHUB_TOKEN }}
@@ -461,7 +468,7 @@ jobs:
         # service dependency here, so no networking wrinkle - see notebooks, which does have one and isn't
         # containerized yet for that reason).
         container:
-            image: ghcr.io/${{ github.repository }}-ci-env:py${{ matrix.python-version }}-default-${{ needs.build-ci-env-default.outputs.reqs-hash }}
+            image: ghcr.io/${{ github.repository }}-ci-env:py${{ matrix.python-version }}-default-${{ needs.build-ci-env-default.outputs.image-hash }}
             credentials:
                 username: ${{ github.actor }}
                 password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -112,6 +112,13 @@ jobs:
                 uses: actions/setup-python@v6
                 with:
                     python-version: ${{ matrix.python-version }}
+                    # scipy/dm-tree build from source (see "Install ffmpeg" step above); cache pip's built
+                    # wheels so only a requirements bump triggers a recompile. Same file list as the
+                    # test/testml jobs below so the cache is shared across all three.
+                    cache: pip
+                    cache-dependency-path: |
+                        requirements-dev.txt
+                        requirements-ml.txt
             # https://adamj.eu/tech/2023/11/02/github-actions-faster-python-virtual-environments/ - skipped on
             # scheduled runs so the nightly cron always exercises a from-scratch install.
             -   name: Restore cached tox environments
@@ -186,6 +193,13 @@ jobs:
                 uses: actions/setup-python@v6
                 with:
                     python-version: ${{ matrix.python-version }}
+                    # scipy/dm-tree build from source (see "Install ffmpeg" step above); cache pip's built
+                    # wheels so only a requirements bump triggers a recompile. Same file list as the
+                    # deptry/test jobs so the cache is shared across all three.
+                    cache: pip
+                    cache-dependency-path: |
+                        requirements-dev.txt
+                        requirements-ml.txt
             -   name: Download episodes
                 run: |
                     wget "${{ env.flatland-benchmarks-episodes-url }}" -O FLATLAND_BENCHMARK_EPISODES_FOLDER.zip
@@ -251,6 +265,13 @@ jobs:
                 uses: actions/setup-python@v6
                 with:
                     python-version: ${{ matrix.python-version }}
+                    # scipy builds from source (see "Install ffmpeg" step above); cache pip's built wheels
+                    # so only a requirements bump triggers a recompile. Same file list as the deptry/testml
+                    # jobs (even though this job doesn't install requirements-ml.txt) so the cache is shared.
+                    cache: pip
+                    cache-dependency-path: |
+                        requirements-dev.txt
+                        requirements-ml.txt
             -   name: Download episodes
                 run: |
                     wget "${{ env.flatland-benchmarks-episodes-url }}" -O FLATLAND_BENCHMARK_EPISODES_FOLDER.zip

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -336,7 +336,14 @@ jobs:
                 username: ${{ github.actor }}
                 password: ${{ secrets.GITHUB_TOKEN }}
         steps:
+            # fetch-depth: 0 (full history, incl. tags) - the "Install flatland-rl and verify entry points"
+            # step below does `pip install .`, which needs setuptools_scm to run `git describe --tags` to
+            # infer a version; the default shallow (depth-1, no tags) checkout doesn't give it enough
+            # history for that and fails with "setuptools-scm was unable to detect version". Same reasoning
+            # as publish.yml's build-related checkout steps.
             -   uses: actions/checkout@v6
+                with:
+                    fetch-depth: 0
             # The archive is versioned in its URL (v5), so a plain URL-keyed cache is safe indefinitely -
             # no invalidation is needed until the workflow itself is updated to a new URL.
             -   name: Restore cached episodes

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -108,7 +108,6 @@ jobs:
                     sudo apt-get -y install libopenblas-dev
             -   uses: actions/checkout@v6
             -   name: Set up Python ${{ matrix.python-version }}
-                id: setup_python
                 uses: actions/setup-python@v6
                 with:
                     python-version: ${{ matrix.python-version }}
@@ -122,7 +121,7 @@ jobs:
                 uses: actions/cache/restore@v5
                 with:
                     path: ~/.cache/pip
-                    key: pip-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('requirements-dev.txt', 'requirements-ml.txt') }}
+                    key: pip-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('requirements-dev.txt', 'requirements-ml.txt') }}
             # https://adamj.eu/tech/2023/11/02/github-actions-faster-python-virtual-environments/ - skipped on
             # scheduled runs so the nightly cron always exercises a from-scratch install.
             -   name: Restore cached tox environments
@@ -130,7 +129,7 @@ jobs:
                 uses: actions/cache/restore@v5
                 with:
                     path: .tox
-                    key: tox-deptry-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('tox.ini', 'requirements-dev.txt', 'requirements-ml.txt') }}
+                    key: tox-deptry-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('tox.ini', 'requirements-dev.txt', 'requirements-ml.txt') }}
             -   name: Install tox
                 run: |
                     python -m pip install --upgrade pip
@@ -142,13 +141,13 @@ jobs:
                 uses: actions/cache/save@v5
                 with:
                     path: ~/.cache/pip
-                    key: pip-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('requirements-dev.txt', 'requirements-ml.txt') }}
+                    key: pip-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('requirements-dev.txt', 'requirements-ml.txt') }}
             -   name: Save cached tox environments
                 if: ${{ always() && github.event_name != 'schedule' }}
                 uses: actions/cache/save@v5
                 with:
                     path: .tox
-                    key: tox-deptry-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('tox.ini', 'requirements-dev.txt', 'requirements-ml.txt') }}
+                    key: tox-deptry-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('tox.ini', 'requirements-dev.txt', 'requirements-ml.txt') }}
 
     testml:
         runs-on: ubuntu-24.04
@@ -199,7 +198,6 @@ jobs:
                     sudo apt-get -y install libopenblas-dev
             -   uses: actions/checkout@v6
             -   name: Set up Python ${{ matrix.python-version }}
-                id: setup_python
                 uses: actions/setup-python@v6
                 with:
                     python-version: ${{ matrix.python-version }}
@@ -213,7 +211,7 @@ jobs:
                 uses: actions/cache/restore@v5
                 with:
                     path: ~/.cache/pip
-                    key: pip-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('requirements-dev.txt', 'requirements-ml.txt') }}
+                    key: pip-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('requirements-dev.txt', 'requirements-ml.txt') }}
             # The archive is versioned in its URL (v5), so a plain URL-keyed cache is safe indefinitely -
             # no invalidation is needed until the workflow itself is updated to a new URL.
             -   name: Restore cached episodes
@@ -241,7 +239,7 @@ jobs:
                 uses: actions/cache/restore@v5
                 with:
                     path: .tox
-                    key: tox-testml-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('tox.ini', 'requirements-dev.txt', 'requirements-ml.txt') }}
+                    key: tox-testml-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('tox.ini', 'requirements-dev.txt', 'requirements-ml.txt') }}
             -   name: Install tox
                 run: |
                     python -m pip install --upgrade pip
@@ -253,13 +251,13 @@ jobs:
                 uses: actions/cache/save@v5
                 with:
                     path: ~/.cache/pip
-                    key: pip-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('requirements-dev.txt', 'requirements-ml.txt') }}
+                    key: pip-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('requirements-dev.txt', 'requirements-ml.txt') }}
             -   name: Save cached tox environments
                 if: ${{ always() && github.event_name != 'schedule' }}
                 uses: actions/cache/save@v5
                 with:
                     path: .tox
-                    key: tox-testml-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('tox.ini', 'requirements-dev.txt', 'requirements-ml.txt') }}
+                    key: tox-testml-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('tox.ini', 'requirements-dev.txt', 'requirements-ml.txt') }}
             -   name: Check disk space
                 run: df . -h
 
@@ -296,7 +294,6 @@ jobs:
 
             -   uses: actions/checkout@v6
             -   name: Set up Python ${{ matrix.python-version }}
-                id: setup_python
                 uses: actions/setup-python@v6
                 with:
                     python-version: ${{ matrix.python-version }}
@@ -311,7 +308,7 @@ jobs:
                 uses: actions/cache/restore@v5
                 with:
                     path: ~/.cache/pip
-                    key: pip-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('requirements-dev.txt', 'requirements-ml.txt') }}
+                    key: pip-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('requirements-dev.txt', 'requirements-ml.txt') }}
             # The archive is versioned in its URL (v5), so a plain URL-keyed cache is safe indefinitely -
             # no invalidation is needed until the workflow itself is updated to a new URL.
             -   name: Restore cached episodes
@@ -339,7 +336,7 @@ jobs:
                 uses: actions/cache/restore@v5
                 with:
                     path: .tox
-                    key: tox-test-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('tox.ini', 'requirements-dev.txt') }}
+                    key: tox-test-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('tox.ini', 'requirements-dev.txt') }}
             -   name: Install tox
                 run: |
                     python -m pip install --upgrade pip
@@ -351,13 +348,13 @@ jobs:
                 uses: actions/cache/save@v5
                 with:
                     path: ~/.cache/pip
-                    key: pip-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('requirements-dev.txt', 'requirements-ml.txt') }}
+                    key: pip-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('requirements-dev.txt', 'requirements-ml.txt') }}
             -   name: Save cached tox environments
                 if: ${{ always() && github.event_name != 'schedule' }}
                 uses: actions/cache/save@v5
                 with:
                     path: .tox
-                    key: tox-test-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('tox.ini', 'requirements-dev.txt') }}
+                    key: tox-test-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('tox.ini', 'requirements-dev.txt') }}
             -   name: Check disk space
                 run: df . -h
 
@@ -379,7 +376,6 @@ jobs:
                     sudo apt-get update
                     sudo apt-get -y install ffmpeg
             -   name: Set up Python ${{ matrix.python-version }}
-                id: setup_python
                 uses: actions/setup-python@v6
                 with:
                     python-version: ${{ matrix.python-version }}
@@ -395,7 +391,7 @@ jobs:
                 uses: actions/cache/restore@v5
                 with:
                     path: .tox
-                    key: tox-notebooks-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('tox.ini', 'requirements-dev.txt') }}
+                    key: tox-notebooks-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('tox.ini', 'requirements-dev.txt') }}
             -   name: Install tox
                 run: |
                     python -m pip install --upgrade pip
@@ -409,7 +405,7 @@ jobs:
                 uses: actions/cache/save@v5
                 with:
                     path: .tox
-                    key: tox-notebooks-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('tox.ini', 'requirements-dev.txt') }}
+                    key: tox-notebooks-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('tox.ini', 'requirements-dev.txt') }}
 
     examples:
         runs-on: ubuntu-24.04
@@ -420,7 +416,6 @@ jobs:
         steps:
             -   uses: actions/checkout@v6
             -   name: Set up Python ${{ matrix.python-version }}
-                id: setup_python
                 uses: actions/setup-python@v6
                 with:
                     python-version: ${{ matrix.python-version }}
@@ -436,7 +431,7 @@ jobs:
                 uses: actions/cache/restore@v5
                 with:
                     path: .tox
-                    key: tox-examples-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('tox.ini', 'requirements-dev.txt') }}
+                    key: tox-examples-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('tox.ini', 'requirements-dev.txt') }}
             -   name: Install tox
                 run: |
                     python -m pip install --upgrade pip
@@ -448,7 +443,7 @@ jobs:
                 uses: actions/cache/save@v5
                 with:
                     path: .tox
-                    key: tox-examples-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('tox.ini', 'requirements-dev.txt') }}
+                    key: tox-examples-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('tox.ini', 'requirements-dev.txt') }}
 
     verify-cython-build:
         runs-on: ubuntu-24.04
@@ -581,7 +576,6 @@ jobs:
         steps:
             -   uses: actions/checkout@v6
             -   name: Set up Python ${{ matrix.python-version }}
-                id: setup_python
                 uses: actions/setup-python@v6
                 with:
                     python-version: ${{ matrix.python-version }}
@@ -597,7 +591,7 @@ jobs:
                 uses: actions/cache/restore@v5
                 with:
                     path: .tox
-                    key: tox-profiling-get-k-shortest-paths-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('tox.ini', 'requirements-dev.txt') }}
+                    key: tox-profiling-get-k-shortest-paths-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('tox.ini', 'requirements-dev.txt') }}
             -   name: Install tox
                 run: |
                     python -m pip install --upgrade pip
@@ -609,7 +603,7 @@ jobs:
                 uses: actions/cache/save@v5
                 with:
                     path: .tox
-                    key: tox-profiling-get-k-shortest-paths-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('tox.ini', 'requirements-dev.txt') }}
+                    key: tox-profiling-get-k-shortest-paths-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('tox.ini', 'requirements-dev.txt') }}
             -   uses: actions/upload-artifact@v6
                 with:
                     name: upload-profiling-get-k-shortest-paths-results-${{ matrix.python-version }}
@@ -642,7 +636,6 @@ jobs:
         steps:
             -   uses: actions/checkout@v6
             -   name: Set up Python ${{ matrix.python-version }}
-                id: setup_python
                 uses: actions/setup-python@v6
                 with:
                     python-version: ${{ matrix.python-version }}
@@ -677,7 +670,7 @@ jobs:
                 uses: actions/cache/restore@v5
                 with:
                     path: .tox
-                    key: tox-benchmarks-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('tox.ini', 'requirements-dev.txt') }}
+                    key: tox-benchmarks-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('tox.ini', 'requirements-dev.txt') }}
             -   name: Install tox
                 run: |
                     python -m pip install --upgrade pip
@@ -689,7 +682,7 @@ jobs:
                 uses: actions/cache/save@v5
                 with:
                     path: .tox
-                    key: tox-benchmarks-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('tox.ini', 'requirements-dev.txt') }}
+                    key: tox-benchmarks-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('tox.ini', 'requirements-dev.txt') }}
             -   uses: actions/upload-artifact@v6
                 with:
                     name: upload-benchmarks-results-${{ matrix.python-version }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -110,24 +110,12 @@ jobs:
                 password: ${{ secrets.GITHUB_TOKEN }}
         steps:
             -   uses: actions/checkout@v6
-            # Runs the deptry commands directly rather than `tox run -e py{version}-verify-requirements`:
-            # tox would create its own venv and reinstall requirements-dev.txt/requirements-ml.txt into it
-            # regardless of what the image's system Python already has. Mirrors tox.ini's
-            # [testenv:py{...}-verify-requirements] set_env/commands exactly; that env remains the source
-            # of truth for local/non-container runs.
+            # Runs tox.ini's own [testenv:py{...}-verify-requirements] against this image's already-installed
+            # packages: --current-env (tox-current-env, a requirements-dev.txt dependency) skips venv
+            # creation/dependency install, but still applies tox.ini's set_env and runs its exact commands -
+            # so the actual deptry invocation lives in exactly one place (tox.ini), not two.
             -   name: Run deptry
-                env:
-                    PINNED_AND_DYNAMICALLY_LOADED_MODULES: "cachetools|dm-tree|wandb|contourpy|scipy|rpds-py"
-                    DEV_MODULES: "coverage|deptry|flake8|flake8-eradicate|jupyter|jupyter-core|nbmake|notebook|pip-tools|pytest|pytest-retry|tox|testcontainers|pytest-xdist|cython"
-                    CMAKE_POLICY_VERSION_MINIMUM: "3.5"
-                run: |
-                    python --version
-                    python -m jupyter nbconvert --ExecutePreprocessor.timeout=1800 --to python benchmarks/*.ipynb
-                    python -m jupyter nbconvert --ExecutePreprocessor.timeout=1800 --to python notebooks/*.ipynb
-                    deptry . --verbose --ignore DEP003 --pep621-dev-dependency-groups dev,ml -ee flatland/ml -ee tests -ee benchmarks -ee notebooks -ee examples --per-rule-ignores "DEP002=${PINNED_AND_DYNAMICALLY_LOADED_MODULES}|${DEV_MODULES}"
-                    deptry . --ignore DEP003 --pep621-dev-dependency-groups dev -ee tests -ee benchmarks -ee notebooks -ee examples --per-rule-ignores "DEP002=${PINNED_AND_DYNAMICALLY_LOADED_MODULES}|${DEV_MODULES}"
-                    deptry . --ignore DEP003 --pep621-dev-dependency-groups ml -ee flatland/ml -ee tests/ml -ee "notebooks/rllib_demo.*" --per-rule-ignores "DEP002=${PINNED_AND_DYNAMICALLY_LOADED_MODULES}|${DEV_MODULES}"
-                    deptry . --ignore DEP003 --per-rule-ignores "DEP002=${PINNED_AND_DYNAMICALLY_LOADED_MODULES}|${DEV_MODULES}"
+                run: tox run -e py${{ matrix.python-version }}-verify-requirements --current-env
 
     testml:
         needs: [ build-ci-env-ml ]
@@ -173,18 +161,13 @@ jobs:
                 with:
                     path: episodes
                     key: episodes-${{ env.flatland-benchmarks-episodes-url }}
-            # Runs pytest directly rather than `tox run -e py{version}-ml`: tox would create its own venv
-            # and reinstall requirements-dev.txt/requirements-ml.txt into it regardless of what the image's
-            # system Python already has, rebuilding scipy/dm-tree from source again and defeating the point
-            # of this image. Mirrors tox.ini's [testenv:py{...}-ml] set_env/commands exactly; that env
-            # remains the source of truth for local/non-container runs.
+            # Runs tox.ini's own [testenv:py{...}-ml] against this image's already-installed packages:
+            # --current-env skips venv creation/dependency reinstall (which would rebuild scipy/dm-tree from
+            # source again, defeating the point of this image) but still applies tox.ini's set_env
+            # (including BENCHMARK_EPISODES_FOLDER/PYTHONPATH, both resolved portably via {tox_root}/
+            # {toxinidir}) and runs its exact commands.
             -   name: Run tests
-                env:
-                    PYTHONPATH: ${{ github.workspace }}
-                    BENCHMARK_EPISODES_FOLDER: ${{ github.workspace }}/episodes
-                    PYTHONDONTWRITEBYTECODE: "1"
-                    CMAKE_POLICY_VERSION_MINIMUM: "3.5"
-                run: python -m pytest -n auto --retries 2 --retry-delay 5 tests/ml
+                run: tox run -e py${{ matrix.python-version }}-ml --current-env
 
     # See run-ci-env-test.yml (shared with publish.yml's own pre-release test job) for the actual test
     # invocation.
@@ -308,21 +291,13 @@ jobs:
                     wget "${{ env.flatland-scenarios-olten-partially-closed-url }}" -O OLTEN_PARTIALLY_CLOSED_v2.zip
                     mkdir -p scenarios/scenario_olten/data
                     unzip OLTEN_PARTIALLY_CLOSED_v2 -d scenarios/scenario_olten/data
-            # Runs the script directly rather than `tox run -e py{version}-examples`: tox would create its
-            # own venv and reinstall requirements-dev.txt into it regardless of what the image's system
-            # Python already has, rebuilding scipy from source again and defeating the point of this image.
-            # Mirrors tox.ini's [testenv:py{...}-examples] set_env/commands exactly; that env remains the
-            # source of truth for local/non-container runs. Doesn't install flatland-rl itself even though
-            # tox's env technically does (default skip_install=false) - PYTHONPATH alone is enough (same
-            # reasoning as testml/test's main pytest run - see those jobs).
+            # Runs tox.ini's own [testenv:py{...}-examples] against this image's already-installed packages:
+            # --current-env skips venv creation/dependency reinstall (which would rebuild scipy from source
+            # again, defeating the point of this image) but still applies tox.ini's set_env (including
+            # SCENARIOS_FOLDER/PYTHONPATH, resolved portably via {tox_root}/{toxinidir}) and runs its exact
+            # commands.
             -   name: Run examples
-                env:
-                    PYTHONPATH: ${{ github.workspace }}
-                    SCENARIOS_FOLDER: ${{ github.workspace }}/scenarios
-                    CMAKE_POLICY_VERSION_MINIMUM: "3.5"
-                run: |
-                    python --version
-                    python benchmarks/run_all_examples.py
+                run: tox run -e py${{ matrix.python-version }}-examples --current-env
 
     verify-cython-build:
         runs-on: ubuntu-24.04

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -80,18 +80,9 @@ jobs:
         # ambiguity doesn't matter.
         outputs:
             image-hash: ${{ steps.image-hash.outputs.hash }}
-            # True if the image is confirmed available in GHCR right now, whether because it already existed
-            # or because we just pushed it successfully. False for any GHCR-availability problem (login,
-            # push, or the final verify step below all tolerate failure via continue-on-error) - deptry/
-            # testml below key off this to decide container: (fast, shared image) vs *-fallback (this job's
-            # -fallback sibling: local build, no registry involved at all). A genuine Dockerfile.ci-env bug
-            # isn't masked by this: the *-fallback jobs build the same Dockerfile themselves and fail loudly
-            # if it's actually broken, just via a different job than usual.
-            push-succeeded: ${{ steps.image-exists.outputs.exists == 'true' || steps.verify-push.outcome == 'success' }}
         steps:
             -   uses: actions/checkout@v6
             -   name: Log in to GHCR
-                continue-on-error: true
                 uses: docker/login-action@v4
                 with:
                     registry: ghcr.io
@@ -137,7 +128,6 @@ jobs:
                     curl -fsSL https://raw.githubusercontent.com/kou/arrow/e49d8ae15583ceff03237571569099a6ad62be32/ci/scripts/util_free_space.sh | bash
             -   name: Build and push CI-env image (ml variant)
                 if: steps.image-exists.outputs.exists != 'true'
-                continue-on-error: true
                 uses: docker/build-push-action@v7
                 with:
                     context: .
@@ -158,14 +148,6 @@ jobs:
                     # would "solve" the race too, but at the cost of a fresh image (and GHCR tag) on every
                     # commit even when nothing dependency-related changed, defeating the point of caching.
                     tags: ${{ steps.image-name.outputs.IMAGE_NAME }}:py${{ matrix.python-version }}-ml-${{ steps.image-hash.outputs.hash }}
-            # Re-checks existence rather than trusting the build/push step's own outcome: build-push-action
-            # can fail for reasons unrelated to GHCR (a genuine Dockerfile bug), and outcome alone can't tell
-            # the two apart - actually confirming the tag is pullable is the real signal deptry/testml need.
-            -   name: Verify image is available in GHCR
-                if: steps.image-exists.outputs.exists != 'true'
-                id: verify-push
-                continue-on-error: true
-                run: docker buildx imagetools inspect "${{ steps.image-name.outputs.IMAGE_NAME }}:py${{ matrix.python-version }}-ml-${{ steps.image-hash.outputs.hash }}" > /dev/null 2>&1
             -   name: Check disk space
                 run: df . -h
 
@@ -185,12 +167,9 @@ jobs:
         # matrix.python-version), so which leg "wins" the usual matrix-job-output ambiguity doesn't matter.
         outputs:
             image-hash: ${{ steps.image-hash.outputs.hash }}
-            # See build-ci-env-ml's equivalent output for the full rationale.
-            push-succeeded: ${{ steps.image-exists.outputs.exists == 'true' || steps.verify-push.outcome == 'success' }}
         steps:
             -   uses: actions/checkout@v6
             -   name: Log in to GHCR
-                continue-on-error: true
                 uses: docker/login-action@v4
                 with:
                     registry: ghcr.io
@@ -228,7 +207,6 @@ jobs:
                     curl -fsSL https://raw.githubusercontent.com/kou/arrow/e49d8ae15583ceff03237571569099a6ad62be32/ci/scripts/util_free_space.sh | bash
             -   name: Build and push CI-env image (default variant)
                 if: steps.image-exists.outputs.exists != 'true'
-                continue-on-error: true
                 uses: docker/build-push-action@v7
                 with:
                     context: .
@@ -241,19 +219,11 @@ jobs:
                     cache-to: type=registry,ref=${{ steps.image-name.outputs.IMAGE_NAME }}:cache-py${{ matrix.python-version }}-default,mode=max
                     push: true
                     tags: ${{ steps.image-name.outputs.IMAGE_NAME }}:py${{ matrix.python-version }}-default-${{ steps.image-hash.outputs.hash }}
-            # See build-ci-env-ml's equivalent step for why this re-checks rather than trusting outcome.
-            -   name: Verify image is available in GHCR
-                if: steps.image-exists.outputs.exists != 'true'
-                id: verify-push
-                continue-on-error: true
-                run: docker buildx imagetools inspect "${{ steps.image-name.outputs.IMAGE_NAME }}:py${{ matrix.python-version }}-default-${{ steps.image-hash.outputs.hash }}" > /dev/null 2>&1
             -   name: Check disk space
                 run: df . -h
 
     deptry:
         needs: [ build-ci-env-ml ]
-        # See deptry-fallback below for the GHCR-unavailable path.
-        if: needs.build-ci-env-ml.outputs.push-succeeded == 'true'
         runs-on: ubuntu-24.04
         permissions:
             contents: read
@@ -295,56 +265,8 @@ jobs:
                     deptry . --ignore DEP003 --pep621-dev-dependency-groups ml -ee flatland/ml -ee tests/ml -ee "notebooks/rllib_demo.*" --per-rule-ignores "DEP002=${PINNED_AND_DYNAMICALLY_LOADED_MODULES}|${DEV_MODULES}"
                     deptry . --ignore DEP003 --per-rule-ignores "DEP002=${PINNED_AND_DYNAMICALLY_LOADED_MODULES}|${DEV_MODULES}"
 
-    # GHCR-unavailable fallback for deptry above: instead of pulling a pre-built shared image, builds
-    # Dockerfile.ci-env locally in this same job (no push, no registry cache, no `container:` - `container:`
-    # would need a pull from the very registry we already know is unreachable) and runs the identical
-    # commands via `docker run`. Slower (rebuilds from scratch every time, no cross-run caching at all) but
-    # doesn't depend on GHCR in any way. Keep the "Run deptry" script in sync with deptry's own copy above.
-    deptry-fallback:
-        needs: [ build-ci-env-ml ]
-        if: needs.build-ci-env-ml.outputs.push-succeeded != 'true'
-        runs-on: ubuntu-24.04
-        permissions:
-            contents: read
-        strategy:
-            fail-fast: false
-            matrix:
-                python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
-        steps:
-            -   uses: actions/checkout@v6
-            -   name: Build CI-env image locally (ml variant, no push)
-                run: |
-                    docker build \
-                        -f Dockerfile.ci-env \
-                        --build-arg PYTHON_VERSION=${{ matrix.python-version }} \
-                        --build-arg WITH_ML=true \
-                        -t ci-env-local:py${{ matrix.python-version }}-ml \
-                        .
-            -   name: Run deptry
-                env:
-                    PINNED_AND_DYNAMICALLY_LOADED_MODULES: "cachetools|dm-tree|wandb|contourpy|scipy|rpds-py"
-                    DEV_MODULES: "coverage|deptry|flake8|flake8-eradicate|jupyter|jupyter-core|nbmake|notebook|pip-tools|pytest|pytest-retry|tox|testcontainers|pytest-xdist|cython"
-                    CMAKE_POLICY_VERSION_MINIMUM: "3.5"
-                run: |
-                    docker run --rm \
-                        -v "${{ github.workspace }}:${{ github.workspace }}" -w "${{ github.workspace }}" \
-                        -e PINNED_AND_DYNAMICALLY_LOADED_MODULES -e DEV_MODULES -e CMAKE_POLICY_VERSION_MINIMUM \
-                        ci-env-local:py${{ matrix.python-version }}-ml \
-                        bash -c '
-                            set -euo pipefail
-                            python --version
-                            python -m jupyter nbconvert --ExecutePreprocessor.timeout=1800 --to python benchmarks/*.ipynb
-                            python -m jupyter nbconvert --ExecutePreprocessor.timeout=1800 --to python notebooks/*.ipynb
-                            deptry . --verbose --ignore DEP003 --pep621-dev-dependency-groups dev,ml -ee flatland/ml -ee tests -ee benchmarks -ee notebooks -ee examples --per-rule-ignores "DEP002=${PINNED_AND_DYNAMICALLY_LOADED_MODULES}|${DEV_MODULES}"
-                            deptry . --ignore DEP003 --pep621-dev-dependency-groups dev -ee tests -ee benchmarks -ee notebooks -ee examples --per-rule-ignores "DEP002=${PINNED_AND_DYNAMICALLY_LOADED_MODULES}|${DEV_MODULES}"
-                            deptry . --ignore DEP003 --pep621-dev-dependency-groups ml -ee flatland/ml -ee tests/ml -ee "notebooks/rllib_demo.*" --per-rule-ignores "DEP002=${PINNED_AND_DYNAMICALLY_LOADED_MODULES}|${DEV_MODULES}"
-                            deptry . --ignore DEP003 --per-rule-ignores "DEP002=${PINNED_AND_DYNAMICALLY_LOADED_MODULES}|${DEV_MODULES}"
-                        '
-
     testml:
         needs: [ build-ci-env-ml ]
-        # See testml-fallback below for the GHCR-unavailable path.
-        if: needs.build-ci-env-ml.outputs.push-succeeded == 'true'
         runs-on: ubuntu-24.04
         permissions:
             contents: read
@@ -400,63 +322,8 @@ jobs:
                     CMAKE_POLICY_VERSION_MINIMUM: "3.5"
                 run: python -m pytest -n auto --retries 2 --retry-delay 5 tests/ml
 
-    # GHCR-unavailable fallback for testml above - see deptry-fallback's comment for the general rationale.
-    # Keep the "Run tests" script in sync with testml's own copy above.
-    testml-fallback:
-        needs: [ build-ci-env-ml ]
-        if: needs.build-ci-env-ml.outputs.push-succeeded != 'true'
-        runs-on: ubuntu-24.04
-        permissions:
-            contents: read
-        strategy:
-            fail-fast: false
-            matrix:
-                python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
-        steps:
-            -   uses: actions/checkout@v6
-            -   name: Restore cached episodes
-                id: cache-episodes
-                uses: actions/cache/restore@v5
-                with:
-                    path: episodes
-                    key: episodes-${{ env.flatland-benchmarks-episodes-url }}
-            -   name: Download episodes
-                if: steps.cache-episodes.outputs.cache-hit != 'true'
-                run: |
-                    wget "${{ env.flatland-benchmarks-episodes-url }}" -O FLATLAND_BENCHMARK_EPISODES_FOLDER.zip
-                    mkdir -p episodes
-                    unzip FLATLAND_BENCHMARK_EPISODES_FOLDER -d episodes
-            -   name: Save cached episodes
-                if: ${{ always() && steps.cache-episodes.outputs.cache-hit != 'true' }}
-                uses: actions/cache/save@v5
-                with:
-                    path: episodes
-                    key: episodes-${{ env.flatland-benchmarks-episodes-url }}
-            -   name: Build CI-env image locally (ml variant, no push)
-                run: |
-                    docker build \
-                        -f Dockerfile.ci-env \
-                        --build-arg PYTHON_VERSION=${{ matrix.python-version }} \
-                        --build-arg WITH_ML=true \
-                        -t ci-env-local:py${{ matrix.python-version }}-ml \
-                        .
-            -   name: Run tests
-                env:
-                    PYTHONPATH: ${{ github.workspace }}
-                    BENCHMARK_EPISODES_FOLDER: ${{ github.workspace }}/episodes
-                    PYTHONDONTWRITEBYTECODE: "1"
-                    CMAKE_POLICY_VERSION_MINIMUM: "3.5"
-                run: |
-                    docker run --rm \
-                        -v "${{ github.workspace }}:${{ github.workspace }}" -w "${{ github.workspace }}" \
-                        -e PYTHONPATH -e BENCHMARK_EPISODES_FOLDER -e PYTHONDONTWRITEBYTECODE -e CMAKE_POLICY_VERSION_MINIMUM \
-                        ci-env-local:py${{ matrix.python-version }}-ml \
-                        python -m pytest -n auto --retries 2 --retry-delay 5 tests/ml
-
     test:
         needs: [ build-ci-env-default ]
-        # See test-fallback below for the GHCR-unavailable path.
-        if: needs.build-ci-env-default.outputs.push-succeeded == 'true'
         runs-on: ubuntu-24.04
         permissions:
             contents: read
@@ -537,85 +404,6 @@ jobs:
                     flatland-trajectory-generate-from-metadata --help
                     flatland-trajectory-analysis --help
 
-    # GHCR-unavailable fallback for test above - see deptry-fallback's comment for the general rationale.
-    # Keep the "Run tests"/"Install flatland-rl and verify entry points" scripts in sync with test's own
-    # copies above.
-    test-fallback:
-        needs: [ build-ci-env-default ]
-        if: needs.build-ci-env-default.outputs.push-succeeded != 'true'
-        runs-on: ubuntu-24.04
-        permissions:
-            contents: read
-        strategy:
-            fail-fast: false
-            matrix:
-                python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
-        steps:
-            # Same fetch-depth/fetch-tags reasoning as test's checkout above: setuptools_scm needs it
-            # regardless of whether `pip install .` runs via container: or via docker run below - either way
-            # it's the same mounted .git from this checkout.
-            -   uses: actions/checkout@v6
-                with:
-                    fetch-depth: 0
-                    fetch-tags: true
-            -   name: Restore cached episodes
-                id: cache-episodes
-                uses: actions/cache/restore@v5
-                with:
-                    path: episodes
-                    key: episodes-${{ env.flatland-benchmarks-episodes-url }}
-            -   name: Download episodes
-                if: steps.cache-episodes.outputs.cache-hit != 'true'
-                run: |
-                    wget "${{ env.flatland-benchmarks-episodes-url }}" -O FLATLAND_BENCHMARK_EPISODES_FOLDER.zip
-                    mkdir -p episodes
-                    unzip FLATLAND_BENCHMARK_EPISODES_FOLDER -d episodes
-            -   name: Save cached episodes
-                if: ${{ always() && steps.cache-episodes.outputs.cache-hit != 'true' }}
-                uses: actions/cache/save@v5
-                with:
-                    path: episodes
-                    key: episodes-${{ env.flatland-benchmarks-episodes-url }}
-            -   name: Build CI-env image locally (default variant, no push)
-                run: |
-                    docker build \
-                        -f Dockerfile.ci-env \
-                        --build-arg PYTHON_VERSION=${{ matrix.python-version }} \
-                        --build-arg WITH_ML=false \
-                        -t ci-env-local:py${{ matrix.python-version }}-default \
-                        .
-            -   name: Run tests
-                env:
-                    PYTHONPATH: ${{ github.workspace }}
-                    BENCHMARK_EPISODES_FOLDER: ${{ github.workspace }}/episodes
-                    PYTHONDONTWRITEBYTECODE: "1"
-                    CMAKE_POLICY_VERSION_MINIMUM: "3.5"
-                run: |
-                    docker run --rm \
-                        -v "${{ github.workspace }}:${{ github.workspace }}" -w "${{ github.workspace }}" \
-                        -e PYTHONPATH -e BENCHMARK_EPISODES_FOLDER -e PYTHONDONTWRITEBYTECODE -e CMAKE_POLICY_VERSION_MINIMUM \
-                        ci-env-local:py${{ matrix.python-version }}-default \
-                        python -m pytest -n auto --ignore=tests/ml -m "not slow"
-            -   name: Install flatland-rl and verify entry points
-                run: |
-                    docker run --rm \
-                        -v "${{ github.workspace }}:${{ github.workspace }}" -w "${{ github.workspace }}" \
-                        ci-env-local:py${{ matrix.python-version }}-default \
-                        bash -c '
-                            set -euo pipefail
-                            python --version
-                            pip install --no-cache-dir .
-                            python -c "from flatland.evaluators.service import FlatlandRemoteEvaluationService"
-                            python -c "import flatland.integrations.interactiveai.interactiveai"
-                            evaluator --help
-                            flatland-demo --help
-                            flatland-evaluator --help
-                            flatland-trajectory-evaluate --help
-                            flatland-trajectory-generate-from-policy --help
-                            flatland-trajectory-generate-from-metadata --help
-                            flatland-trajectory-analysis --help
-                        '
-
     notebooks:
         runs-on: ubuntu-24.04
         strategy:
@@ -667,8 +455,6 @@ jobs:
 
     examples:
         needs: [ build-ci-env-default ]
-        # See examples-fallback below for the GHCR-unavailable path.
-        if: needs.build-ci-env-default.outputs.push-succeeded == 'true'
         runs-on: ubuntu-24.04
         permissions:
             contents: read
@@ -708,45 +494,6 @@ jobs:
                 run: |
                     python --version
                     python benchmarks/run_all_examples.py
-
-    # GHCR-unavailable fallback for examples above - see deptry-fallback's comment for the general
-    # rationale. Keep the "Run examples" script in sync with examples' own copy above.
-    examples-fallback:
-        needs: [ build-ci-env-default ]
-        if: needs.build-ci-env-default.outputs.push-succeeded != 'true'
-        runs-on: ubuntu-24.04
-        permissions:
-            contents: read
-        strategy:
-            fail-fast: false
-            matrix:
-                python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
-        steps:
-            -   uses: actions/checkout@v6
-            -   name: Download Olten scenario
-                run: |
-                    wget "${{ env.flatland-scenarios-olten-partially-closed-url }}" -O OLTEN_PARTIALLY_CLOSED_v2.zip
-                    mkdir -p scenarios/scenario_olten/data
-                    unzip OLTEN_PARTIALLY_CLOSED_v2 -d scenarios/scenario_olten/data
-            -   name: Build CI-env image locally (default variant, no push)
-                run: |
-                    docker build \
-                        -f Dockerfile.ci-env \
-                        --build-arg PYTHON_VERSION=${{ matrix.python-version }} \
-                        --build-arg WITH_ML=false \
-                        -t ci-env-local:py${{ matrix.python-version }}-default \
-                        .
-            -   name: Run examples
-                env:
-                    PYTHONPATH: ${{ github.workspace }}
-                    SCENARIOS_FOLDER: ${{ github.workspace }}/scenarios
-                    CMAKE_POLICY_VERSION_MINIMUM: "3.5"
-                run: |
-                    docker run --rm \
-                        -v "${{ github.workspace }}:${{ github.workspace }}" -w "${{ github.workspace }}" \
-                        -e PYTHONPATH -e SCENARIOS_FOLDER -e CMAKE_POLICY_VERSION_MINIMUM \
-                        ci-env-local:py${{ matrix.python-version }}-default \
-                        bash -c 'python --version && python benchmarks/run_all_examples.py'
 
     verify-cython-build:
         runs-on: ubuntu-24.04

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -80,9 +80,18 @@ jobs:
         # ambiguity doesn't matter.
         outputs:
             image-hash: ${{ steps.image-hash.outputs.hash }}
+            # True if the image is confirmed available in GHCR right now, whether because it already existed
+            # or because we just pushed it successfully. False for any GHCR-availability problem (login,
+            # push, or the final verify step below all tolerate failure via continue-on-error) - deptry/
+            # testml below key off this to decide container: (fast, shared image) vs *-fallback (this job's
+            # -fallback sibling: local build, no registry involved at all). A genuine Dockerfile.ci-env bug
+            # isn't masked by this: the *-fallback jobs build the same Dockerfile themselves and fail loudly
+            # if it's actually broken, just via a different job than usual.
+            push-succeeded: ${{ steps.image-exists.outputs.exists == 'true' || steps.verify-push.outcome == 'success' }}
         steps:
             -   uses: actions/checkout@v6
             -   name: Log in to GHCR
+                continue-on-error: true
                 uses: docker/login-action@v4
                 with:
                     registry: ghcr.io
@@ -128,6 +137,7 @@ jobs:
                     curl -fsSL https://raw.githubusercontent.com/kou/arrow/e49d8ae15583ceff03237571569099a6ad62be32/ci/scripts/util_free_space.sh | bash
             -   name: Build and push CI-env image (ml variant)
                 if: steps.image-exists.outputs.exists != 'true'
+                continue-on-error: true
                 uses: docker/build-push-action@v7
                 with:
                     context: .
@@ -148,6 +158,14 @@ jobs:
                     # would "solve" the race too, but at the cost of a fresh image (and GHCR tag) on every
                     # commit even when nothing dependency-related changed, defeating the point of caching.
                     tags: ${{ steps.image-name.outputs.IMAGE_NAME }}:py${{ matrix.python-version }}-ml-${{ steps.image-hash.outputs.hash }}
+            # Re-checks existence rather than trusting the build/push step's own outcome: build-push-action
+            # can fail for reasons unrelated to GHCR (a genuine Dockerfile bug), and outcome alone can't tell
+            # the two apart - actually confirming the tag is pullable is the real signal deptry/testml need.
+            -   name: Verify image is available in GHCR
+                if: steps.image-exists.outputs.exists != 'true'
+                id: verify-push
+                continue-on-error: true
+                run: docker buildx imagetools inspect "${{ steps.image-name.outputs.IMAGE_NAME }}:py${{ matrix.python-version }}-ml-${{ steps.image-hash.outputs.hash }}" > /dev/null 2>&1
             -   name: Check disk space
                 run: df . -h
 
@@ -167,9 +185,12 @@ jobs:
         # matrix.python-version), so which leg "wins" the usual matrix-job-output ambiguity doesn't matter.
         outputs:
             image-hash: ${{ steps.image-hash.outputs.hash }}
+            # See build-ci-env-ml's equivalent output for the full rationale.
+            push-succeeded: ${{ steps.image-exists.outputs.exists == 'true' || steps.verify-push.outcome == 'success' }}
         steps:
             -   uses: actions/checkout@v6
             -   name: Log in to GHCR
+                continue-on-error: true
                 uses: docker/login-action@v4
                 with:
                     registry: ghcr.io
@@ -207,6 +228,7 @@ jobs:
                     curl -fsSL https://raw.githubusercontent.com/kou/arrow/e49d8ae15583ceff03237571569099a6ad62be32/ci/scripts/util_free_space.sh | bash
             -   name: Build and push CI-env image (default variant)
                 if: steps.image-exists.outputs.exists != 'true'
+                continue-on-error: true
                 uses: docker/build-push-action@v7
                 with:
                     context: .
@@ -219,11 +241,19 @@ jobs:
                     cache-to: type=registry,ref=${{ steps.image-name.outputs.IMAGE_NAME }}:cache-py${{ matrix.python-version }}-default,mode=max
                     push: true
                     tags: ${{ steps.image-name.outputs.IMAGE_NAME }}:py${{ matrix.python-version }}-default-${{ steps.image-hash.outputs.hash }}
+            # See build-ci-env-ml's equivalent step for why this re-checks rather than trusting outcome.
+            -   name: Verify image is available in GHCR
+                if: steps.image-exists.outputs.exists != 'true'
+                id: verify-push
+                continue-on-error: true
+                run: docker buildx imagetools inspect "${{ steps.image-name.outputs.IMAGE_NAME }}:py${{ matrix.python-version }}-default-${{ steps.image-hash.outputs.hash }}" > /dev/null 2>&1
             -   name: Check disk space
                 run: df . -h
 
     deptry:
         needs: [ build-ci-env-ml ]
+        # See deptry-fallback below for the GHCR-unavailable path.
+        if: needs.build-ci-env-ml.outputs.push-succeeded == 'true'
         runs-on: ubuntu-24.04
         permissions:
             contents: read
@@ -265,8 +295,56 @@ jobs:
                     deptry . --ignore DEP003 --pep621-dev-dependency-groups ml -ee flatland/ml -ee tests/ml -ee "notebooks/rllib_demo.*" --per-rule-ignores "DEP002=${PINNED_AND_DYNAMICALLY_LOADED_MODULES}|${DEV_MODULES}"
                     deptry . --ignore DEP003 --per-rule-ignores "DEP002=${PINNED_AND_DYNAMICALLY_LOADED_MODULES}|${DEV_MODULES}"
 
+    # GHCR-unavailable fallback for deptry above: instead of pulling a pre-built shared image, builds
+    # Dockerfile.ci-env locally in this same job (no push, no registry cache, no `container:` - `container:`
+    # would need a pull from the very registry we already know is unreachable) and runs the identical
+    # commands via `docker run`. Slower (rebuilds from scratch every time, no cross-run caching at all) but
+    # doesn't depend on GHCR in any way. Keep the "Run deptry" script in sync with deptry's own copy above.
+    deptry-fallback:
+        needs: [ build-ci-env-ml ]
+        if: needs.build-ci-env-ml.outputs.push-succeeded != 'true'
+        runs-on: ubuntu-24.04
+        permissions:
+            contents: read
+        strategy:
+            fail-fast: false
+            matrix:
+                python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
+        steps:
+            -   uses: actions/checkout@v6
+            -   name: Build CI-env image locally (ml variant, no push)
+                run: |
+                    docker build \
+                        -f Dockerfile.ci-env \
+                        --build-arg PYTHON_VERSION=${{ matrix.python-version }} \
+                        --build-arg WITH_ML=true \
+                        -t ci-env-local:py${{ matrix.python-version }}-ml \
+                        .
+            -   name: Run deptry
+                env:
+                    PINNED_AND_DYNAMICALLY_LOADED_MODULES: "cachetools|dm-tree|wandb|contourpy|scipy|rpds-py"
+                    DEV_MODULES: "coverage|deptry|flake8|flake8-eradicate|jupyter|jupyter-core|nbmake|notebook|pip-tools|pytest|pytest-retry|tox|testcontainers|pytest-xdist|cython"
+                    CMAKE_POLICY_VERSION_MINIMUM: "3.5"
+                run: |
+                    docker run --rm \
+                        -v "${{ github.workspace }}:${{ github.workspace }}" -w "${{ github.workspace }}" \
+                        -e PINNED_AND_DYNAMICALLY_LOADED_MODULES -e DEV_MODULES -e CMAKE_POLICY_VERSION_MINIMUM \
+                        ci-env-local:py${{ matrix.python-version }}-ml \
+                        bash -c '
+                            set -euo pipefail
+                            python --version
+                            python -m jupyter nbconvert --ExecutePreprocessor.timeout=1800 --to python benchmarks/*.ipynb
+                            python -m jupyter nbconvert --ExecutePreprocessor.timeout=1800 --to python notebooks/*.ipynb
+                            deptry . --verbose --ignore DEP003 --pep621-dev-dependency-groups dev,ml -ee flatland/ml -ee tests -ee benchmarks -ee notebooks -ee examples --per-rule-ignores "DEP002=${PINNED_AND_DYNAMICALLY_LOADED_MODULES}|${DEV_MODULES}"
+                            deptry . --ignore DEP003 --pep621-dev-dependency-groups dev -ee tests -ee benchmarks -ee notebooks -ee examples --per-rule-ignores "DEP002=${PINNED_AND_DYNAMICALLY_LOADED_MODULES}|${DEV_MODULES}"
+                            deptry . --ignore DEP003 --pep621-dev-dependency-groups ml -ee flatland/ml -ee tests/ml -ee "notebooks/rllib_demo.*" --per-rule-ignores "DEP002=${PINNED_AND_DYNAMICALLY_LOADED_MODULES}|${DEV_MODULES}"
+                            deptry . --ignore DEP003 --per-rule-ignores "DEP002=${PINNED_AND_DYNAMICALLY_LOADED_MODULES}|${DEV_MODULES}"
+                        '
+
     testml:
         needs: [ build-ci-env-ml ]
+        # See testml-fallback below for the GHCR-unavailable path.
+        if: needs.build-ci-env-ml.outputs.push-succeeded == 'true'
         runs-on: ubuntu-24.04
         permissions:
             contents: read
@@ -322,8 +400,63 @@ jobs:
                     CMAKE_POLICY_VERSION_MINIMUM: "3.5"
                 run: python -m pytest -n auto --retries 2 --retry-delay 5 tests/ml
 
+    # GHCR-unavailable fallback for testml above - see deptry-fallback's comment for the general rationale.
+    # Keep the "Run tests" script in sync with testml's own copy above.
+    testml-fallback:
+        needs: [ build-ci-env-ml ]
+        if: needs.build-ci-env-ml.outputs.push-succeeded != 'true'
+        runs-on: ubuntu-24.04
+        permissions:
+            contents: read
+        strategy:
+            fail-fast: false
+            matrix:
+                python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
+        steps:
+            -   uses: actions/checkout@v6
+            -   name: Restore cached episodes
+                id: cache-episodes
+                uses: actions/cache/restore@v5
+                with:
+                    path: episodes
+                    key: episodes-${{ env.flatland-benchmarks-episodes-url }}
+            -   name: Download episodes
+                if: steps.cache-episodes.outputs.cache-hit != 'true'
+                run: |
+                    wget "${{ env.flatland-benchmarks-episodes-url }}" -O FLATLAND_BENCHMARK_EPISODES_FOLDER.zip
+                    mkdir -p episodes
+                    unzip FLATLAND_BENCHMARK_EPISODES_FOLDER -d episodes
+            -   name: Save cached episodes
+                if: ${{ always() && steps.cache-episodes.outputs.cache-hit != 'true' }}
+                uses: actions/cache/save@v5
+                with:
+                    path: episodes
+                    key: episodes-${{ env.flatland-benchmarks-episodes-url }}
+            -   name: Build CI-env image locally (ml variant, no push)
+                run: |
+                    docker build \
+                        -f Dockerfile.ci-env \
+                        --build-arg PYTHON_VERSION=${{ matrix.python-version }} \
+                        --build-arg WITH_ML=true \
+                        -t ci-env-local:py${{ matrix.python-version }}-ml \
+                        .
+            -   name: Run tests
+                env:
+                    PYTHONPATH: ${{ github.workspace }}
+                    BENCHMARK_EPISODES_FOLDER: ${{ github.workspace }}/episodes
+                    PYTHONDONTWRITEBYTECODE: "1"
+                    CMAKE_POLICY_VERSION_MINIMUM: "3.5"
+                run: |
+                    docker run --rm \
+                        -v "${{ github.workspace }}:${{ github.workspace }}" -w "${{ github.workspace }}" \
+                        -e PYTHONPATH -e BENCHMARK_EPISODES_FOLDER -e PYTHONDONTWRITEBYTECODE -e CMAKE_POLICY_VERSION_MINIMUM \
+                        ci-env-local:py${{ matrix.python-version }}-ml \
+                        python -m pytest -n auto --retries 2 --retry-delay 5 tests/ml
+
     test:
         needs: [ build-ci-env-default ]
+        # See test-fallback below for the GHCR-unavailable path.
+        if: needs.build-ci-env-default.outputs.push-succeeded == 'true'
         runs-on: ubuntu-24.04
         permissions:
             contents: read
@@ -404,6 +537,85 @@ jobs:
                     flatland-trajectory-generate-from-metadata --help
                     flatland-trajectory-analysis --help
 
+    # GHCR-unavailable fallback for test above - see deptry-fallback's comment for the general rationale.
+    # Keep the "Run tests"/"Install flatland-rl and verify entry points" scripts in sync with test's own
+    # copies above.
+    test-fallback:
+        needs: [ build-ci-env-default ]
+        if: needs.build-ci-env-default.outputs.push-succeeded != 'true'
+        runs-on: ubuntu-24.04
+        permissions:
+            contents: read
+        strategy:
+            fail-fast: false
+            matrix:
+                python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
+        steps:
+            # Same fetch-depth/fetch-tags reasoning as test's checkout above: setuptools_scm needs it
+            # regardless of whether `pip install .` runs via container: or via docker run below - either way
+            # it's the same mounted .git from this checkout.
+            -   uses: actions/checkout@v6
+                with:
+                    fetch-depth: 0
+                    fetch-tags: true
+            -   name: Restore cached episodes
+                id: cache-episodes
+                uses: actions/cache/restore@v5
+                with:
+                    path: episodes
+                    key: episodes-${{ env.flatland-benchmarks-episodes-url }}
+            -   name: Download episodes
+                if: steps.cache-episodes.outputs.cache-hit != 'true'
+                run: |
+                    wget "${{ env.flatland-benchmarks-episodes-url }}" -O FLATLAND_BENCHMARK_EPISODES_FOLDER.zip
+                    mkdir -p episodes
+                    unzip FLATLAND_BENCHMARK_EPISODES_FOLDER -d episodes
+            -   name: Save cached episodes
+                if: ${{ always() && steps.cache-episodes.outputs.cache-hit != 'true' }}
+                uses: actions/cache/save@v5
+                with:
+                    path: episodes
+                    key: episodes-${{ env.flatland-benchmarks-episodes-url }}
+            -   name: Build CI-env image locally (default variant, no push)
+                run: |
+                    docker build \
+                        -f Dockerfile.ci-env \
+                        --build-arg PYTHON_VERSION=${{ matrix.python-version }} \
+                        --build-arg WITH_ML=false \
+                        -t ci-env-local:py${{ matrix.python-version }}-default \
+                        .
+            -   name: Run tests
+                env:
+                    PYTHONPATH: ${{ github.workspace }}
+                    BENCHMARK_EPISODES_FOLDER: ${{ github.workspace }}/episodes
+                    PYTHONDONTWRITEBYTECODE: "1"
+                    CMAKE_POLICY_VERSION_MINIMUM: "3.5"
+                run: |
+                    docker run --rm \
+                        -v "${{ github.workspace }}:${{ github.workspace }}" -w "${{ github.workspace }}" \
+                        -e PYTHONPATH -e BENCHMARK_EPISODES_FOLDER -e PYTHONDONTWRITEBYTECODE -e CMAKE_POLICY_VERSION_MINIMUM \
+                        ci-env-local:py${{ matrix.python-version }}-default \
+                        python -m pytest -n auto --ignore=tests/ml -m "not slow"
+            -   name: Install flatland-rl and verify entry points
+                run: |
+                    docker run --rm \
+                        -v "${{ github.workspace }}:${{ github.workspace }}" -w "${{ github.workspace }}" \
+                        ci-env-local:py${{ matrix.python-version }}-default \
+                        bash -c '
+                            set -euo pipefail
+                            python --version
+                            pip install --no-cache-dir .
+                            python -c "from flatland.evaluators.service import FlatlandRemoteEvaluationService"
+                            python -c "import flatland.integrations.interactiveai.interactiveai"
+                            evaluator --help
+                            flatland-demo --help
+                            flatland-evaluator --help
+                            flatland-trajectory-evaluate --help
+                            flatland-trajectory-generate-from-policy --help
+                            flatland-trajectory-generate-from-metadata --help
+                            flatland-trajectory-analysis --help
+                        '
+
     notebooks:
         runs-on: ubuntu-24.04
         strategy:
@@ -455,6 +667,8 @@ jobs:
 
     examples:
         needs: [ build-ci-env-default ]
+        # See examples-fallback below for the GHCR-unavailable path.
+        if: needs.build-ci-env-default.outputs.push-succeeded == 'true'
         runs-on: ubuntu-24.04
         permissions:
             contents: read
@@ -494,6 +708,45 @@ jobs:
                 run: |
                     python --version
                     python benchmarks/run_all_examples.py
+
+    # GHCR-unavailable fallback for examples above - see deptry-fallback's comment for the general
+    # rationale. Keep the "Run examples" script in sync with examples' own copy above.
+    examples-fallback:
+        needs: [ build-ci-env-default ]
+        if: needs.build-ci-env-default.outputs.push-succeeded != 'true'
+        runs-on: ubuntu-24.04
+        permissions:
+            contents: read
+        strategy:
+            fail-fast: false
+            matrix:
+                python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
+        steps:
+            -   uses: actions/checkout@v6
+            -   name: Download Olten scenario
+                run: |
+                    wget "${{ env.flatland-scenarios-olten-partially-closed-url }}" -O OLTEN_PARTIALLY_CLOSED_v2.zip
+                    mkdir -p scenarios/scenario_olten/data
+                    unzip OLTEN_PARTIALLY_CLOSED_v2 -d scenarios/scenario_olten/data
+            -   name: Build CI-env image locally (default variant, no push)
+                run: |
+                    docker build \
+                        -f Dockerfile.ci-env \
+                        --build-arg PYTHON_VERSION=${{ matrix.python-version }} \
+                        --build-arg WITH_ML=false \
+                        -t ci-env-local:py${{ matrix.python-version }}-default \
+                        .
+            -   name: Run examples
+                env:
+                    PYTHONPATH: ${{ github.workspace }}
+                    SCENARIOS_FOLDER: ${{ github.workspace }}/scenarios
+                    CMAKE_POLICY_VERSION_MINIMUM: "3.5"
+                run: |
+                    docker run --rm \
+                        -v "${{ github.workspace }}:${{ github.workspace }}" -w "${{ github.workspace }}" \
+                        -e PYTHONPATH -e SCENARIOS_FOLDER -e CMAKE_POLICY_VERSION_MINIMUM \
+                        ci-env-local:py${{ matrix.python-version }}-default \
+                        bash -c 'python --version && python benchmarks/run_all_examples.py'
 
     verify-cython-build:
         runs-on: ubuntu-24.04

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -60,103 +60,13 @@ jobs:
                 run: ${{ steps.get_actionlint.outputs.executable }} -color
                 shell: bash
 
-    deptry:
-        runs-on: ubuntu-24.04
-        strategy:
-            fail-fast: false
-            matrix:
-                python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
-        # dm-tree's vendored abseil-cpp (20210324.2) fails to compile with GCC 13+ (the runner's default);
-        # gcc-12/g++-12 (installed below) build it fine. tox passes CC/CXX through by default.
-        env:
-            CC: gcc-12
-            CXX: g++-12
-        steps:
-            -   name: Inspect disk
-                run: |
-                    df -h
-                    docker system df
-            # https://stackoverflow.com/questions/30604846/docker-complains-about-no-space-left-on-device-how-to-clean-up
-            -   name: Prune docker system
-                run: |
-                    docker system prune --all --force
-            # https://www.dzombak.com/blog/2024/09/freeing-disk-space-on-github-actions-runners/
-            -   name: Free disk space
-                run: |
-                    curl -fsSL https://raw.githubusercontent.com/kou/arrow/e49d8ae15583ceff03237571569099a6ad62be32/ci/scripts/util_free_space.sh | bash
-            -   name: Inspect disk again
-                run: |
-                    df -h
-                    docker system df
-            -   name: Install ffmpeg
-                run: |
-                    set -euxo pipefail
-                    sudo sed -i 's/^Types: deb/Types: deb deb-src/' /etc/apt/sources.list.d/ubuntu.sources
-                    sudo apt-get update
-                    sudo apt-get -y install ffmpeg
-                    # TODO As long as scipy is pinned to < 1.16 (to ensure to support for Python 3.10), we need to install it from source
-                    # https://docs.scipy.org/doc/scipy/building/index.html
-                    sudo apt-get -y build-dep scipy
-                    # scipy's build-dep pulls in an old pybind11-dev that meson picks up via pkg-config ahead of
-                    # the newer pip-installed pybind11, breaking contourpy's from-source build on newer Pythons
-                    sudo apt-get -y remove pybind11-dev || true
-                    # dm-tree's vendored abseil-cpp (20210324.2) fails to compile with GCC 13+ (the runner's
-                    # default); gcc-12/g++-12 build it fine. CC/CXX are set at job level below (tox passes them through by default).
-                    sudo apt-get -y install gcc-12 g++-12
-                    # scipy's meson build looks for OpenBLAS specifically via pkg-config; the generic BLAS/LAPACK
-                    # virtual package satisfied by `build-dep scipy` doesn't necessarily provide openblas.pc.
-                    sudo apt-get -y install libopenblas-dev
-            -   uses: actions/checkout@v6
-            -   name: Set up Python ${{ matrix.python-version }}
-                uses: actions/setup-python@v6
-                with:
-                    python-version: ${{ matrix.python-version }}
-            # scipy/dm-tree build from source (see "Install ffmpeg" step above); cache pip's built wheels
-            # so only a requirements bump triggers a recompile. Same key as the test job below so the
-            # cache is shared between the two (testml gets its dependencies from a prebuilt Docker image
-            # instead - see build-ci-env-testml/testml above). Skipped (read-only) on scheduled runs, like
-            # the .tox cache below, so the nightly cron always exercises a from-scratch build - but
-            # nightly's freshly-built wheels are still saved (see the Save step below), so PR/push runs
-            # benefit.
-            -   name: Restore cached pip wheels
-                if: ${{ github.event_name != 'schedule' }}
-                uses: actions/cache/restore@v5
-                with:
-                    path: ~/.cache/pip
-                    key: pip-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('requirements-dev.txt', 'requirements-ml.txt') }}
-            # https://adamj.eu/tech/2023/11/02/github-actions-faster-python-virtual-environments/ - skipped on
-            # scheduled runs so the nightly cron always exercises a from-scratch install.
-            -   name: Restore cached tox environments
-                if: ${{ github.event_name != 'schedule' }}
-                uses: actions/cache/restore@v5
-                with:
-                    path: .tox
-                    key: tox-deptry-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('tox.ini', 'requirements-dev.txt', 'requirements-ml.txt') }}
-            -   name: Install tox
-                run: |
-                    python -m pip install --upgrade pip
-                    python -m pip install -U tox tox-gh-actions
-            -   name: Run deptry
-                run: tox -e py${{ matrix.python-version }}-verify-requirements
-            -   name: Save cached pip wheels
-                if: always()
-                uses: actions/cache/save@v5
-                with:
-                    path: ~/.cache/pip
-                    key: pip-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('requirements-dev.txt', 'requirements-ml.txt') }}
-            -   name: Save cached tox environments
-                if: ${{ always() && github.event_name != 'schedule' }}
-                uses: actions/cache/save@v5
-                with:
-                    path: .tox
-                    key: tox-deptry-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('tox.ini', 'requirements-dev.txt', 'requirements-ml.txt') }}
-
-    # Builds/pushes the CI-only dependency image consumed by the testml job below (see Dockerfile.ci-env,
-    # a separate, non-user-facing image from the ones docker.yml/publish.yml build and publish to end
-    # users). BuildKit's registry cache (cache-from/cache-to) makes this a near-instant no-op once
-    # requirements-dev.txt/requirements-ml.txt stop changing, since every RUN layer stays cache-hit -
-    # unlike actions/cache, multiple concurrent pushes to the same cache ref don't stomp each other.
-    build-ci-env-testml:
+    # Builds/pushes the CI-only dependency image consumed by the deptry/testml jobs below (see
+    # Dockerfile.ci-env, a separate, non-user-facing image from the ones docker.yml/publish.yml build and
+    # publish to end users). BuildKit's registry cache (cache-from/cache-to) makes this a near-instant
+    # no-op once requirements-dev.txt/requirements-ml.txt stop changing, since every RUN layer stays
+    # cache-hit - unlike actions/cache, multiple concurrent pushes to the same cache ref don't stomp each
+    # other.
+    build-ci-env-ml:
         runs-on: ubuntu-24.04
         permissions:
             contents: read
@@ -182,7 +92,7 @@ jobs:
                 id: image-name
                 run: echo "IMAGE_NAME=$(echo 'ghcr.io/${{ github.repository }}-ci-env' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
             # hashFiles() needs the checkout above to have already populated the workspace - it can't be
-            # computed directly in testml's own container: (see the tag comment below for why that matters).
+            # computed directly in deptry's/testml's own container: (see the tag comment below).
             -   name: Compute requirements hash
                 id: reqs-hash
                 run: echo "hash=${{ hashFiles('requirements-dev.txt', 'requirements-ml.txt') }}" >> "$GITHUB_OUTPUT"
@@ -212,7 +122,7 @@ jobs:
                 if: steps.image-exists.outputs.exists != 'true'
                 run: |
                     curl -fsSL https://raw.githubusercontent.com/kou/arrow/e49d8ae15583ceff03237571569099a6ad62be32/ci/scripts/util_free_space.sh | bash
-            -   name: Build and push testml CI-env image
+            -   name: Build and push CI-env image (ml variant)
                 if: steps.image-exists.outputs.exists != 'true'
                 uses: docker/build-push-action@v7
                 with:
@@ -221,6 +131,7 @@ jobs:
                     platforms: linux/amd64
                     build-args: |
                         PYTHON_VERSION=${{ matrix.python-version }}
+                        WITH_ML=true
                     cache-from: type=registry,ref=${{ steps.image-name.outputs.IMAGE_NAME }}:cache-py${{ matrix.python-version }}-ml
                     cache-to: type=registry,ref=${{ steps.image-name.outputs.IMAGE_NAME }}:cache-py${{ matrix.python-version }}-ml,mode=max
                     push: true
@@ -236,8 +147,76 @@ jobs:
             -   name: Check disk space
                 run: df . -h
 
-    testml:
-        needs: [ build-ci-env-testml ]
+    # Leaner counterpart to build-ci-env-ml, consumed by the test job below: no requirements-ml.txt, no
+    # dm-tree/cmake/git, since test only ever installs requirements-dev.txt.
+    build-ci-env-default:
+        runs-on: ubuntu-24.04
+        permissions:
+            contents: read
+            packages: write
+        strategy:
+            fail-fast: false
+            matrix:
+                python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
+        # Same value on every matrix leg (it only depends on requirements-dev.txt, not
+        # matrix.python-version), so which leg "wins" the usual matrix-job-output ambiguity doesn't matter.
+        outputs:
+            reqs-hash: ${{ steps.reqs-hash.outputs.hash }}
+        steps:
+            -   uses: actions/checkout@v6
+            -   name: Log in to GHCR
+                uses: docker/login-action@v4
+                with:
+                    registry: ghcr.io
+                    username: ${{ github.actor }}
+                    password: ${{ secrets.GITHUB_TOKEN }}
+            -   uses: docker/setup-buildx-action@v4
+            -   name: Build image name
+                id: image-name
+                run: echo "IMAGE_NAME=$(echo 'ghcr.io/${{ github.repository }}-ci-env' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+            -   name: Compute requirements hash
+                id: reqs-hash
+                run: echo "hash=${{ hashFiles('requirements-dev.txt') }}" >> "$GITHUB_OUTPUT"
+            -   name: Check if CI-env image already exists
+                id: image-exists
+                run: |
+                    if docker buildx imagetools inspect "${{ steps.image-name.outputs.IMAGE_NAME }}:py${{ matrix.python-version }}-default-${{ steps.reqs-hash.outputs.hash }}" > /dev/null 2>&1; then
+                        echo "exists=true" >> "$GITHUB_OUTPUT"
+                    else
+                        echo "exists=false" >> "$GITHUB_OUTPUT"
+                    fi
+            -   name: Inspect disk
+                if: steps.image-exists.outputs.exists != 'true'
+                run: |
+                    df -h
+                    docker system df
+            -   name: Prune docker system
+                if: steps.image-exists.outputs.exists != 'true'
+                run: |
+                    docker system prune --all --force
+            -   name: Free disk space
+                if: steps.image-exists.outputs.exists != 'true'
+                run: |
+                    curl -fsSL https://raw.githubusercontent.com/kou/arrow/e49d8ae15583ceff03237571569099a6ad62be32/ci/scripts/util_free_space.sh | bash
+            -   name: Build and push CI-env image (default variant)
+                if: steps.image-exists.outputs.exists != 'true'
+                uses: docker/build-push-action@v7
+                with:
+                    context: .
+                    file: Dockerfile.ci-env
+                    platforms: linux/amd64
+                    build-args: |
+                        PYTHON_VERSION=${{ matrix.python-version }}
+                        WITH_ML=false
+                    cache-from: type=registry,ref=${{ steps.image-name.outputs.IMAGE_NAME }}:cache-py${{ matrix.python-version }}-default
+                    cache-to: type=registry,ref=${{ steps.image-name.outputs.IMAGE_NAME }}:cache-py${{ matrix.python-version }}-default,mode=max
+                    push: true
+                    tags: ${{ steps.image-name.outputs.IMAGE_NAME }}:py${{ matrix.python-version }}-default-${{ steps.reqs-hash.outputs.hash }}
+            -   name: Check disk space
+                run: df . -h
+
+    deptry:
+        needs: [ build-ci-env-ml ]
         runs-on: ubuntu-24.04
         permissions:
             contents: read
@@ -247,14 +226,57 @@ jobs:
             matrix:
                 python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
         # All requirements-dev.txt/requirements-ml.txt deps (incl. scipy/dm-tree, already built from source)
-        # are baked into this image by build-ci-env-testml above - nothing left to install here.
+        # are baked into this image by build-ci-env-ml above - nothing left to install here.
         container:
-            # Matches build-ci-env-testml's tag exactly (see the comment there for why it's keyed on a
+            # Matches build-ci-env-ml's tag exactly (see the comment there for why it's keyed on a
             # requirements hash, not just Python-version). Read via needs.*.outputs rather than computing
             # hashFiles() here directly: container: is resolved before this job's own checkout runs, so
             # hashFiles() would see no files yet - needs.*.outputs works because it's just a stored value
-            # from the already-completed build-ci-env-testml job, not a live filesystem read.
-            image: ghcr.io/${{ github.repository }}-ci-env:py${{ matrix.python-version }}-ml-${{ needs.build-ci-env-testml.outputs.reqs-hash }}
+            # from the already-completed build-ci-env-ml job, not a live filesystem read.
+            image: ghcr.io/${{ github.repository }}-ci-env:py${{ matrix.python-version }}-ml-${{ needs.build-ci-env-ml.outputs.reqs-hash }}
+            credentials:
+                username: ${{ github.actor }}
+                password: ${{ secrets.GITHUB_TOKEN }}
+        steps:
+            -   uses: actions/checkout@v6
+            # Runs the deptry commands directly rather than `tox run -e py{version}-verify-requirements`:
+            # tox would create its own venv and reinstall requirements-dev.txt/requirements-ml.txt into it
+            # regardless of what the image's system Python already has. Mirrors tox.ini's
+            # [testenv:py{...}-verify-requirements] set_env/commands exactly; that env remains the source
+            # of truth for local/non-container runs.
+            -   name: Run deptry
+                env:
+                    PINNED_AND_DYNAMICALLY_LOADED_MODULES: "cachetools|dm-tree|wandb|contourpy|scipy|rpds-py"
+                    DEV_MODULES: "coverage|deptry|flake8|flake8-eradicate|jupyter|jupyter-core|nbmake|notebook|pip-tools|pytest|pytest-retry|tox|testcontainers|pytest-xdist|cython"
+                    CMAKE_POLICY_VERSION_MINIMUM: "3.5"
+                run: |
+                    python --version
+                    python -m jupyter nbconvert --ExecutePreprocessor.timeout=1800 --to python benchmarks/*.ipynb
+                    python -m jupyter nbconvert --ExecutePreprocessor.timeout=1800 --to python notebooks/*.ipynb
+                    deptry . --verbose --ignore DEP003 --pep621-dev-dependency-groups dev,ml -ee flatland/ml -ee tests -ee benchmarks -ee notebooks -ee examples --per-rule-ignores "DEP002=${PINNED_AND_DYNAMICALLY_LOADED_MODULES}|${DEV_MODULES}"
+                    deptry . --ignore DEP003 --pep621-dev-dependency-groups dev -ee tests -ee benchmarks -ee notebooks -ee examples --per-rule-ignores "DEP002=${PINNED_AND_DYNAMICALLY_LOADED_MODULES}|${DEV_MODULES}"
+                    deptry . --ignore DEP003 --pep621-dev-dependency-groups ml -ee flatland/ml -ee tests/ml -ee "notebooks/rllib_demo.*" --per-rule-ignores "DEP002=${PINNED_AND_DYNAMICALLY_LOADED_MODULES}|${DEV_MODULES}"
+                    deptry . --ignore DEP003 --per-rule-ignores "DEP002=${PINNED_AND_DYNAMICALLY_LOADED_MODULES}|${DEV_MODULES}"
+
+    testml:
+        needs: [ build-ci-env-ml ]
+        runs-on: ubuntu-24.04
+        permissions:
+            contents: read
+            packages: read
+        strategy:
+            fail-fast: false
+            matrix:
+                python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
+        # All requirements-dev.txt/requirements-ml.txt deps (incl. scipy/dm-tree, already built from source)
+        # are baked into this image by build-ci-env-ml above - nothing left to install here.
+        container:
+            # Matches build-ci-env-ml's tag exactly (see the comment there for why it's keyed on a
+            # requirements hash, not just Python-version). Read via needs.*.outputs rather than computing
+            # hashFiles() here directly: container: is resolved before this job's own checkout runs, so
+            # hashFiles() would see no files yet - needs.*.outputs works because it's just a stored value
+            # from the already-completed build-ci-env-ml job, not a live filesystem read.
+            image: ghcr.io/${{ github.repository }}-ci-env:py${{ matrix.python-version }}-ml-${{ needs.build-ci-env-ml.outputs.reqs-hash }}
             credentials:
                 username: ${{ github.actor }}
                 password: ${{ secrets.GITHUB_TOKEN }}
@@ -294,57 +316,27 @@ jobs:
                 run: python -m pytest -n auto --retries 2 --retry-delay 5 tests/ml
 
     test:
+        needs: [ build-ci-env-default ]
         runs-on: ubuntu-24.04
+        permissions:
+            contents: read
+            packages: read
         strategy:
             fail-fast: false
             matrix:
                 python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
+        # requirements-dev.txt (incl. scipy, already built from source) is baked into this image by
+        # build-ci-env-default above - nothing left to install here except flatland-rl itself, for the
+        # "Install flatland-rl and verify entry points" step below (its whole point is to test that install
+        # path, so unlike the pytest step it can't be skipped the way testml/deptry skip installing the
+        # package).
+        container:
+            image: ghcr.io/${{ github.repository }}-ci-env:py${{ matrix.python-version }}-default-${{ needs.build-ci-env-default.outputs.reqs-hash }}
+            credentials:
+                username: ${{ github.actor }}
+                password: ${{ secrets.GITHUB_TOKEN }}
         steps:
-            -   name: Inspect disk
-                run: |
-                    df -h
-                    docker system df
-            # https://stackoverflow.com/questions/30604846/docker-complains-about-no-space-left-on-device-how-to-clean-up
-            -   name: Prune docker system
-                run: |
-                    docker system prune --all --force
-            # https://www.dzombak.com/blog/2024/09/freeing-disk-space-on-github-actions-runners/
-            -   name: Free disk space
-                run: |
-                    curl -fsSL https://raw.githubusercontent.com/kou/arrow/e49d8ae15583ceff03237571569099a6ad62be32/ci/scripts/util_free_space.sh | bash
-            -   name: Inspect disk again
-                run: |
-                    df -h
-                    docker system df
-            -   name: Install ffmpeg
-                run: |
-                    set -euxo pipefail
-                    # https://askubuntu.com/questions/1512042/ubuntu-24-04-getting-error-you-must-put-some-deb-src-uris-in-your-sources-list
-                    sudo sed -i 's/^Types: deb/Types: deb deb-src/' /etc/apt/sources.list.d/ubuntu.sources
-                    sudo apt-get update
-                    sudo apt-get -y install ffmpeg
-
             -   uses: actions/checkout@v6
-            -   name: Set up Python ${{ matrix.python-version }}
-                uses: actions/setup-python@v6
-                with:
-                    python-version: ${{ matrix.python-version }}
-            # scipy builds from source (see "Install ffmpeg" step above); cache pip's built wheels so only
-            # a requirements bump triggers a recompile. Same key as the deptry job so the cache is shared -
-            # restore-only here, deliberately: this job only installs requirements-dev.txt, a strict subset
-            # of what deptry installs (requirements-dev.txt + requirements-ml.txt), so it's the faster of
-            # the two and would tend to win the cache-save race on a cold key. actions/cache keys are
-            # immutable (a save to an existing key is silently skipped), so whichever job's save "wins"
-            # locks in its content until the key changes - if that were this job, the shared cache would
-            # end up missing the dm-tree/torch/ray wheels deptry needs. Leaving the save to deptry (which
-            # installs the full superset) avoids that. (testml gets its dependencies from a prebuilt Docker
-            # image instead - see build-ci-env-testml/testml above - so it no longer participates here.)
-            -   name: Restore cached pip wheels
-                if: ${{ github.event_name != 'schedule' }}
-                uses: actions/cache/restore@v5
-                with:
-                    path: ~/.cache/pip
-                    key: pip-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('requirements-dev.txt', 'requirements-ml.txt') }}
             # The archive is versioned in its URL (v5), so a plain URL-keyed cache is safe indefinitely -
             # no invalidation is needed until the workflow itself is updated to a new URL.
             -   name: Restore cached episodes
@@ -365,30 +357,37 @@ jobs:
                 with:
                     path: episodes
                     key: episodes-${{ env.flatland-benchmarks-episodes-url }}
-            # https://adamj.eu/tech/2023/11/02/github-actions-faster-python-virtual-environments/ - skipped on
-            # scheduled runs so the nightly cron always exercises a from-scratch install.
-            -   name: Restore cached tox environments
-                if: ${{ github.event_name != 'schedule' }}
-                uses: actions/cache/restore@v5
-                with:
-                    path: .tox
-                    key: tox-test-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('tox.ini', 'requirements-dev.txt') }}
-            -   name: Install tox
-                run: |
-                    python -m pip install --upgrade pip
-                    python -m pip install -U tox tox-gh-actions
+            # Runs pytest directly rather than `tox run -e py{version}`: tox would create its own venv and
+            # reinstall requirements-dev.txt into it regardless of what the image's system Python already
+            # has, rebuilding scipy from source again and defeating the point of this image. Mirrors
+            # tox.ini's [testenv:py{...}] set_env/commands exactly; that env remains the source of truth
+            # for local/non-container runs. Doesn't install flatland-rl itself even though tox's env
+            # technically does (default skip_install=false) - PYTHONPATH alone is enough for tests to
+            # import it (confirmed empirically: testml's equivalent tox env has the identical default, and
+            # its container-based run already passes without installing the package).
             -   name: Run tests
-                run: tox -e py${{ matrix.python-version }},py${{ matrix.python-version }}-verify-install
-            # No "Save cached pip wheels" step here - see the comment on "Restore cached pip wheels" above:
-            # this job never writes to the shared pip-wheel cache, only reads from it.
-            -   name: Save cached tox environments
-                if: ${{ always() && github.event_name != 'schedule' }}
-                uses: actions/cache/save@v5
-                with:
-                    path: .tox
-                    key: tox-test-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('tox.ini', 'requirements-dev.txt') }}
-            -   name: Check disk space
-                run: df . -h
+                env:
+                    PYTHONPATH: ${{ github.workspace }}
+                    BENCHMARK_EPISODES_FOLDER: ${{ github.workspace }}/episodes
+                    PYTHONDONTWRITEBYTECODE: "1"
+                    CMAKE_POLICY_VERSION_MINIMUM: "3.5"
+                run: python -m pytest -n auto --ignore=tests/ml -m "not slow"
+            # Mirrors tox.ini's [testenv:py{...}-verify-install] - unlike the step above, this one's whole
+            # point is to test the installed-package/entry-points path, so it genuinely needs `pip install
+            # .` rather than relying on PYTHONPATH.
+            -   name: Install flatland-rl and verify entry points
+                run: |
+                    python --version
+                    pip install --no-cache-dir .
+                    python -c 'from flatland.evaluators.service import FlatlandRemoteEvaluationService'
+                    python -c 'import flatland.integrations.interactiveai.interactiveai'
+                    evaluator --help
+                    flatland-demo --help
+                    flatland-evaluator --help
+                    flatland-trajectory-evaluate --help
+                    flatland-trajectory-generate-from-policy --help
+                    flatland-trajectory-generate-from-metadata --help
+                    flatland-trajectory-analysis --help
 
     notebooks:
         runs-on: ubuntu-24.04

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -407,6 +407,29 @@ jobs:
                     flatland-trajectory-generate-from-metadata --help
                     flatland-trajectory-analysis --help
 
+    # Not containerized (unlike deptry/testml/test/examples above) despite using the same requirements-dev.txt
+    # - blocked on this job's "Start Redis" services: container below, for two compounding reasons:
+    #
+    # 1. The simple fix - add `container: {image: ...}` and keep everything else as-is - doesn't work,
+    #    because a containerized job's `container:` can't be given `--network host` to make it share the
+    #    runner's own network namespace: GH's docs for `container:`/`services:` `options:` state plainly
+    #    "The --network and --entrypoint options are not supported."
+    #    https://docs.github.com/en/actions/using-jobs/running-jobs-in-a-container
+    #
+    # 2. Without --network host, GH Actions' actual supported mechanism for a containerized job to reach a
+    #    services: container is different, not absent: it auto-joins the job's container and the service
+    #    container to a shared Docker bridge network, reachable via the service's label as a hostname (e.g.
+    #    `redis`), not via localhost/127.0.0.1 - see "About service containers":
+    #    https://docs.github.com/en/actions/using-containerized-services/about-service-containers
+    #    That's exactly the opposite of how it works today: this job runs directly on the runner (no
+    #    container:), so Redis's port is published straight onto the runner's own localhost, which is
+    #    exactly what notebooks/test_service.ipynb and notebooks/test-service-timeouts.ipynb hardcode
+    #    (localhost/127.0.0.1). Containerizing without also editing those notebook cells to use the `redis`
+    #    hostname would just trade one failure (no --network host) for another (wrong hostname).
+    #
+    # So this needs an actual code change (parameterize the Redis host in the two notebooks, then add
+    # `container:` + keep `services:` here), not just a workflow tweak - see S6 in the ongoing CI cache/
+    # containerization cleanup plan.
     notebooks:
         runs-on: ubuntu-24.04
         strategy:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -219,8 +219,20 @@ jobs:
     #    (localhost/127.0.0.1). Containerizing without also editing those notebook cells to use the `redis`
     #    hostname would just trade one failure (no --network host) for another (wrong hostname).
     #
-    # So this needs an actual code change (parameterize the Redis host in the two notebooks, then add
-    # `container:` + keep `services:` here), not just a workflow tweak.
+    # A fix does exist (parameterize the Redis host in the two notebooks, then add `container:` + keep
+    # `services:` here), but this job deliberately keeps its current tox+actions/cache setup instead of
+    # pursuing it:
+    # - Unlike deptry/testml/test/examples, this job's slowness isn't dominated by rebuilding scipy/dm-tree
+    #   from source - that's what the GHCR image caching elsewhere in this file targets - so containerizing
+    #   it wouldn't recover anywhere near the same payoff for the added complexity (a new/adapted CI-env
+    #   image variant, plus wiring notebooks into build-ci-env.yml/run-ci-env-test.yml).
+    # - notebooks/test_service.ipynb and notebooks/test-service-timeouts.ipynb are read and run
+    #   interactively by humans, not just executed by CI - hardcoding a `redis` hostname instead of
+    #   localhost/127.0.0.1 to satisfy the containerized-job networking model would be a behavior change for
+    #   that interactive use too, not a CI-only config tweak, which is out of scope for a CI-time-reduction
+    #   effort.
+    # - This job already carves out python-version 3.10 as "failing too often" (see the matrix below) - it's
+    #   an already-accepted soft spot in this workflow, not the main bottleneck this effort was aimed at.
     notebooks:
         runs-on: ubuntu-24.04
         strategy:

--- a/.github/workflows/ci-env-cleanup.yml
+++ b/.github/workflows/ci-env-cleanup.yml
@@ -1,0 +1,46 @@
+name: Clean up CI-env GHCR package
+
+# Prunes old flatland-rl-ci-env versions (see Dockerfile.ci-env, and checks.yml's build-ci-env-ml/
+# build-ci-env-default jobs that produce them). Unlike actions/cache's automatic 7-day eviction, GHCR has no
+# built-in expiry: every requirements-dev.txt/requirements-ml.txt/Dockerfile.ci-env change mints a brand-new
+# py{version}-{ml,default}-{hash} tag, and once no branch still needs that exact content, nothing else ever
+# reclaims it - this is the scheduled fallback for that.
+on:
+    workflow_dispatch:
+    schedule:
+        # Weekly, not tied to checks.yml's own triggers - cleanup doesn't need to run on every push/PR.
+        -   cron: '0 4 * * 0'
+
+jobs:
+    cleanup:
+        runs-on: ubuntu-24.04
+        permissions:
+            packages: write
+        steps:
+            # Untagged versions are always safe to remove here: build-ci-env-ml/-default never re-push an
+            # already-existing runnable tag (their "Check if CI-env image already exists" step skips the
+            # build entirely in that case), so a given tag is pushed exactly once. The only way a version
+            # becomes untagged is BuildKit's cache-to (mode=max) overwriting cache-py{version}-{ml,default}
+            # in place, leaving its previous manifest dangling. Dockerfile.ci-env only ever builds
+            # linux/amd64 (no multi-arch manifest lists), so there's no risk of this deleting a still-
+            # referenced per-platform child of a tagged multi-arch image.
+            -   name: Delete untagged versions
+                uses: actions/delete-package-versions@v5
+                with:
+                    package-name: flatland-rl-ci-env
+                    package-type: container
+                    delete-only-untagged-versions: true
+                    token: ${{ secrets.GITHUB_TOKEN }}
+            # Flat count across the whole package, not grouped per (python-version, variant): the action
+            # doesn't support grouping, and since a single requirements/Dockerfile change tends to bump most
+            # of build-ci-env-ml/-default's 10 (5 versions x 2 variants) tags at once, 30 is roughly 3
+            # "generations" of headroom. cache-* refs are excluded since they're mutable pointers BuildKit
+            # already overwrites in place - they don't need (and shouldn't get) count-based pruning.
+            -   name: Delete old tagged versions
+                uses: actions/delete-package-versions@v5
+                with:
+                    package-name: flatland-rl-ci-env
+                    package-type: container
+                    min-versions-to-keep: 30
+                    ignore-versions: "^cache-.*"
+                    token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,9 +8,6 @@ on:
     schedule:
         -   cron: '0 3 * * *'
 
-env:
-    REGISTRY: ghcr.io
-
 jobs:
     actionlint:
         # Static analysis of .github/workflows/*.yml itself - catches invalid expressions/`if:` typos and
@@ -27,47 +24,28 @@ jobs:
                 run: ${{ steps.get_actionlint.outputs.executable }} -color
                 shell: bash
 
+    # See build-docker-image.yml (shared with publish.yml's own docker-publish job) for the actual
+    # build/skip-if-unchanged/retag logic.
     docker-publish:
-        runs-on: ubuntu-24.04
-        permissions:
-            contents: read
-            packages: write
         strategy:
             fail-fast: false
             matrix:
                 python-version: [ "3.12" ]
                 variant:
                     -   name: default
-                        with-ml: "false"
+                        with-ml: false
                         tag-suffix: ""
                     -   name: ml
-                        with-ml: "true"
+                        with-ml: true
                         tag-suffix: "-ml"
-        steps:
-            -   name: Checkout
-                uses: actions/checkout@v6
-            -   name: Log in to GHCR
-                if: ${{ github.event_name != 'pull_request' }}
-                uses: docker/login-action@v4
-                with:
-                    registry: ${{ env.REGISTRY }}
-                    username: ${{ github.actor }}
-                    password: ${{ secrets.GITHUB_TOKEN }}
-            -   name: Set up QEMU
-                uses: docker/setup-qemu-action@v4
-            -   name: Set up Docker Buildx
-                uses: docker/setup-buildx-action@v4
-            -   name: Build image name
-                id: image-name
-                run: echo "IMAGE_NAME=$(echo '${{ env.REGISTRY }}/${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
-            -   name: Build and push image
-                uses: docker/build-push-action@v7
-                with:
-                    context: .
-                    platforms: linux/amd64,linux/arm64
-                    build-args: |
-                        PYTHON_VERSION=${{ matrix.python-version }}
-                        WITH_ML=${{ matrix.variant.with-ml }}
-                    no-cache: true
-                    push: ${{ github.event_name != 'pull_request' }}
-                    tags: ${{ steps.image-name.outputs.IMAGE_NAME }}:latest-py${{ matrix.python-version }}${{ matrix.variant.tag-suffix }}
+        uses: ./.github/workflows/build-docker-image.yml
+        with:
+            python-version: ${{ matrix.python-version }}
+            with-ml: ${{ matrix.variant.with-ml }}
+            flatland-rl-ref: main
+            human-facing-tag: latest-py${{ matrix.python-version }}${{ matrix.variant.tag-suffix }}
+            # Nightly always rebuilds from scratch even if nothing we control changed, so it keeps
+            # exercising a fresh build (catching e.g. base-image/upstream drift) rather than just re-tagging
+            # a possibly-stale cached image indefinitely.
+            force-rebuild: ${{ github.event_name == 'schedule' }}
+            push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -48,20 +48,20 @@ jobs:
                 uses: actions/checkout@v6
             -   name: Log in to GHCR
                 if: ${{ github.event_name != 'pull_request' }}
-                uses: docker/login-action@v3
+                uses: docker/login-action@v4
                 with:
                     registry: ${{ env.REGISTRY }}
                     username: ${{ github.actor }}
                     password: ${{ secrets.GITHUB_TOKEN }}
             -   name: Set up QEMU
-                uses: docker/setup-qemu-action@v3
+                uses: docker/setup-qemu-action@v4
             -   name: Set up Docker Buildx
-                uses: docker/setup-buildx-action@v3
+                uses: docker/setup-buildx-action@v4
             -   name: Build image name
                 id: image-name
                 run: echo "IMAGE_NAME=$(echo '${{ env.REGISTRY }}/${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
             -   name: Build and push image
-                uses: docker/build-push-action@v6
+                uses: docker/build-push-action@v7
                 with:
                     context: .
                     platforms: linux/amd64,linux/arm64

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -189,31 +189,17 @@ jobs:
                     name: python-package
                     path: dist/
 
-    docker-publish:
-        # Runs after whichever publish flow ran - the other is always skipped, so the default
-        # needs-implies-success() condition would otherwise block this job.
+    # Resolves what docker-publish below needs before it can call build-docker-image.yml (a `uses:` job
+    # can't have its own preceding steps). Runs after whichever publish flow ran - the other is always
+    # skipped, so the default needs-implies-success() condition would otherwise block this job.
+    resolve-docker-publish-ref:
         if: ${{ !cancelled() && (needs.publish-pypi.result == 'success' || needs.publish-test-pypi.result == 'success') }}
         needs: [ publish-pypi, publish-test-pypi ]
         runs-on: ubuntu-24.04
-        permissions:
-            contents: read
-            packages: write
-        env:
-            REGISTRY: ghcr.io
-        strategy:
-            fail-fast: false
-            matrix:
-                python-version: [ "3.12" ]
-                variant:
-                    -   name: default
-                        with-ml: "false"
-                        tag-suffix: ""
-                    -   name: ml
-                        with-ml: "true"
-                        tag-suffix: "-ml"
+        outputs:
+            version_tag: ${{ steps.version.outputs.VERSION_TAG }}
+            flatland_rl_ref: ${{ steps.version.outputs.FLATLAND_RL_REF }}
         steps:
-            -   name: Checkout
-                uses: actions/checkout@v6
             -   name: Resolve version tag and flatland-rl ref
                 id: version
                 run: |
@@ -224,28 +210,26 @@ jobs:
                         echo "VERSION_TAG=${{ needs.publish-test-pypi.outputs.version_tag }}" >> "$GITHUB_OUTPUT"
                         echo "FLATLAND_RL_REF=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
                     fi
-            -   name: Log in to GHCR
-                uses: docker/login-action@v4
-                with:
-                    registry: ${{ env.REGISTRY }}
-                    username: ${{ github.actor }}
-                    password: ${{ secrets.GITHUB_TOKEN }}
-            -   name: Set up QEMU
-                uses: docker/setup-qemu-action@v4
-            -   name: Set up Docker Buildx
-                uses: docker/setup-buildx-action@v4
-            -   name: Build image name
-                id: image-name
-                run: echo "IMAGE_NAME=$(echo '${{ env.REGISTRY }}/${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
-            -   name: Build and push image
-                uses: docker/build-push-action@v7
-                with:
-                    context: .
-                    platforms: linux/amd64,linux/arm64
-                    build-args: |
-                        PYTHON_VERSION=${{ matrix.python-version }}
-                        WITH_ML=${{ matrix.variant.with-ml }}
-                        FLATLAND_RL_REF=${{ steps.version.outputs.FLATLAND_RL_REF }}
-                    no-cache: true
-                    push: true
-                    tags: ${{ steps.image-name.outputs.IMAGE_NAME }}:${{ steps.version.outputs.VERSION_TAG }}-py${{ matrix.python-version }}${{ matrix.variant.tag-suffix }}
+
+    # See build-docker-image.yml (shared with docker.yml's own docker-publish job) for the actual
+    # build/skip-if-unchanged/retag logic. No explicit `if:` needed here - resolve-docker-publish-ref being
+    # skipped already propagates via the default needs-implies-success() condition.
+    docker-publish:
+        needs: [ resolve-docker-publish-ref ]
+        strategy:
+            fail-fast: false
+            matrix:
+                python-version: [ "3.12" ]
+                variant:
+                    -   name: default
+                        with-ml: false
+                        tag-suffix: ""
+                    -   name: ml
+                        with-ml: true
+                        tag-suffix: "-ml"
+        uses: ./.github/workflows/build-docker-image.yml
+        with:
+            python-version: ${{ matrix.python-version }}
+            with-ml: ${{ matrix.variant.with-ml }}
+            flatland-rl-ref: ${{ needs.resolve-docker-publish-ref.outputs.flatland_rl_ref }}
+            human-facing-tag: ${{ needs.resolve-docker-publish-ref.outputs.version_tag }}-py${{ matrix.python-version }}${{ matrix.variant.tag-suffix }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,5 @@
 name: Publish package
 
-env:
-    flatland-benchmarks-episodes-url: "https://github.com/flatland-association/flatland-scenarios/raw/refs/heads/main/trajectories/FLATLAND_BENCHMARK_EPISODES_FOLDER_v5.zip"
-
 on:
     push:
         branches: [ "main" ]
@@ -42,8 +39,29 @@ jobs:
             -   uses: googleapis/release-please-action@v4
                 id: release
 
+    # Builds the same CI-env image checks.yml uses (see build-ci-env.yml) rather than reinstalling
+    # requirements-dev.txt from scratch on a bare runner every release - shares GHCR's warm cache with
+    # checks.yml's own runs instead of redoing that work here.
+    build-ci-env-default:
+        # See test's identical condition below for why !failure() && !cancelled() is needed here too.
+        if: >-
+            ${{ !failure() && !cancelled() &&
+            ((github.event_name == 'push' && needs.release-please.outputs.release_created) ||
+            (github.event_name == 'workflow_dispatch' && inputs.version != '')) }}
+        needs: [ release-please ]
+        strategy:
+            fail-fast: false
+            matrix:
+                python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
+        uses: ./.github/workflows/build-ci-env.yml
+        with:
+            python-version: ${{ matrix.python-version }}
+            with-ml: false
+            ref: ${{ needs.release-please.outputs.tag_name || github.ref }}
+
     # Runs the full test matrix before either publish flow below: for a real release (gated on
-    # release-please having just created one) or a manual Test PyPI publish (gated on a version being given).
+    # release-please having just created one) or a manual Test PyPI publish (gated on a version being
+    # given). See run-ci-env-test.yml (shared with checks.yml's own test job) for the actual test invocation.
     test:
         # N.B. needs !failure() && !cancelled() because release-please is skipped (not run) on workflow_dispatch,
         # and a skipped dependency makes the implicit needs-success() check fail, which would otherwise skip this job too.
@@ -52,62 +70,16 @@ jobs:
             ${{ !failure() && !cancelled() &&
             ((github.event_name == 'push' && needs.release-please.outputs.release_created) ||
             (github.event_name == 'workflow_dispatch' && inputs.version != '')) }}
-        needs: [ release-please ]
-        runs-on: ubuntu-24.04
+        needs: [ release-please, build-ci-env-default ]
         strategy:
             fail-fast: false
             matrix:
                 python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
-        steps:
-            -   name: Inspect disk
-                run: |
-                    df -h
-                    docker system df
-            # https://stackoverflow.com/questions/30604846/docker-complains-about-no-space-left-on-device-how-to-clean-up
-            -   name: Prune docker system
-                run: |
-                    docker system prune --all --force
-            # https://www.dzombak.com/blog/2024/09/freeing-disk-space-on-github-actions-runners/
-            -   name: Free disk space
-                run: |
-                    curl -fsSL https://raw.githubusercontent.com/kou/arrow/e49d8ae15583ceff03237571569099a6ad62be32/ci/scripts/util_free_space.sh | bash
-            -   name: Inspect disk again
-                run: |
-                    df -h
-                    docker system df
-            -   name: Install ffmpeg
-                run: |
-                    set -euxo pipefail
-                    # https://askubuntu.com/questions/1512042/ubuntu-24-04-getting-error-you-must-put-some-deb-src-uris-in-your-sources-list
-                    sudo sed -i 's/^Types: deb/Types: deb deb-src/' /etc/apt/sources.list.d/ubuntu.sources
-                    sudo apt-get update
-                    sudo apt-get -y install ffmpeg
-                    # TODO As long as scipy is pinned to < 1.16 (to ensure to support for Python 3.10), we need to install it from source
-                    # https://docs.scipy.org/doc/scipy/building/index.html
-                    sudo apt-get -y build-dep scipy
-                    # scipy's build-dep pulls in an old pybind11-dev that meson picks up via pkg-config ahead of
-                    # the newer pip-installed pybind11, breaking contourpy's from-source build on newer Pythons
-                    sudo apt-get -y remove pybind11-dev || true
-            -   uses: actions/checkout@v6
-                with:
-                    ref: ${{ needs.release-please.outputs.tag_name || github.ref }}
-            -   name: Set up Python ${{ matrix.python-version }}
-                uses: actions/setup-python@v6
-                with:
-                    python-version: ${{ matrix.python-version }}
-            -   name: Download episodes
-                run: |
-                    wget "${{ env.flatland-benchmarks-episodes-url }}" -O FLATLAND_BENCHMARK_EPISODES_FOLDER.zip
-                    mkdir -p episodes
-                    unzip FLATLAND_BENCHMARK_EPISODES_FOLDER -d episodes
-            -   name: Install tox
-                run: |
-                    python -m pip install --upgrade pip
-                    python -m pip install tox tox-gh-actions
-            -   name: Run tests
-                run: tox -e py${{ matrix.python-version }},py${{ matrix.python-version }}-verify-install
-            -   name: Check disk space
-                run: df . -h
+        uses: ./.github/workflows/run-ci-env-test.yml
+        with:
+            python-version: ${{ matrix.python-version }}
+            image-hash: ${{ needs.build-ci-env-default.outputs.image-hash }}
+            ref: ${{ needs.release-please.outputs.tag_name || github.ref }}
 
     publish-pypi:
         if: ${{ github.event_name == 'push' && needs.release-please.outputs.release_created }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -253,20 +253,20 @@ jobs:
                         echo "FLATLAND_RL_REF=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
                     fi
             -   name: Log in to GHCR
-                uses: docker/login-action@v3
+                uses: docker/login-action@v4
                 with:
                     registry: ${{ env.REGISTRY }}
                     username: ${{ github.actor }}
                     password: ${{ secrets.GITHUB_TOKEN }}
             -   name: Set up QEMU
-                uses: docker/setup-qemu-action@v3
+                uses: docker/setup-qemu-action@v4
             -   name: Set up Docker Buildx
-                uses: docker/setup-buildx-action@v3
+                uses: docker/setup-buildx-action@v4
             -   name: Build image name
                 id: image-name
                 run: echo "IMAGE_NAME=$(echo '${{ env.REGISTRY }}/${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
             -   name: Build and push image
-                uses: docker/build-push-action@v6
+                uses: docker/build-push-action@v7
                 with:
                     context: .
                     platforms: linux/amd64,linux/arm64

--- a/.github/workflows/run-ci-env-test.yml
+++ b/.github/workflows/run-ci-env-test.yml
@@ -69,34 +69,20 @@ jobs:
                 with:
                     path: episodes
                     key: episodes-${{ env.flatland-benchmarks-episodes-url }}
-            # Runs pytest directly rather than `tox run -e py{version}`: tox would create its own venv and
-            # reinstall requirements-dev.txt into it regardless of what the image's system Python already
-            # has, rebuilding scipy from source again and defeating the point of this image. Mirrors
-            # tox.ini's [testenv:py{...}] set_env/commands exactly; that env remains the source of truth for
-            # local/non-container runs. Doesn't install flatland-rl itself even though tox's env technically
-            # does (default skip_install=false) - PYTHONPATH alone is enough for tests to import it
-            # (confirmed empirically: testml's equivalent tox env has the identical default, and its
-            # container-based run already passes without installing the package).
+            # Runs tox.ini's own [testenv:py{...}] against this image's already-installed packages:
+            # --current-env skips venv creation/dependency reinstall (which would rebuild scipy from source
+            # again, defeating the point of this image) but still applies tox.ini's set_env (including
+            # BENCHMARK_EPISODES_FOLDER/PYTHONPATH, resolved portably via {tox_root}/{toxinidir}) and runs
+            # its exact commands. Doesn't install flatland-rl itself - --current-env unconditionally forces
+            # no_package=True regardless of a testenv's own skip_install setting, which happens to match
+            # what this step already wanted (PYTHONPATH alone is enough for tests to import it).
             -   name: Run tests
-                env:
-                    PYTHONPATH: ${{ github.workspace }}
-                    BENCHMARK_EPISODES_FOLDER: ${{ github.workspace }}/episodes
-                    PYTHONDONTWRITEBYTECODE: "1"
-                    CMAKE_POLICY_VERSION_MINIMUM: "3.5"
-                run: python -m pytest -n auto --ignore=tests/ml -m "not slow"
-            # Mirrors tox.ini's [testenv:py{...}-verify-install] - unlike the step above, this one's whole
-            # point is to test the installed-package/entry-points path, so it genuinely needs `pip install
-            # .` rather than relying on PYTHONPATH.
-            -   name: Install flatland-rl and verify entry points
-                run: |
-                    python --version
-                    pip install --no-cache-dir .
-                    python -c 'from flatland.evaluators.service import FlatlandRemoteEvaluationService'
-                    python -c 'import flatland.integrations.interactiveai.interactiveai'
-                    evaluator --help
-                    flatland-demo --help
-                    flatland-evaluator --help
-                    flatland-trajectory-evaluate --help
-                    flatland-trajectory-generate-from-policy --help
-                    flatland-trajectory-generate-from-metadata --help
-                    flatland-trajectory-analysis --help
+                run: tox run -e py${{ inputs.python-version }} --current-env
+            # Unlike the step above, --current-env's forced no_package=True is NOT what we want here: this
+            # env's whole point is testing the installed-package/entry-points path, so it needs a real `pip
+            # install .` first; only the verification commands themselves are tox-sourced (see tox.ini's
+            # [testenv:py{...}-verify-install]).
+            -   name: Install flatland-rl
+                run: pip install --no-cache-dir .
+            -   name: Verify entry points
+                run: tox run -e py${{ inputs.python-version }}-verify-install --current-env

--- a/.github/workflows/run-ci-env-test.yml
+++ b/.github/workflows/run-ci-env-test.yml
@@ -1,0 +1,102 @@
+name: Run tests against a CI-env image
+
+# Reusable workflow: runs flatland-rl's main test suite, plus the installed-package/entry-points check,
+# inside an already-built CI-env image (see build-ci-env.yml, called separately by whichever workflow calls
+# this one - this workflow only consumes its image-hash output, it doesn't build anything itself). Used by
+# both checks.yml's test job and publish.yml's pre-release test job, so the actual test invocation only has
+# to exist in one place.
+on:
+    workflow_call:
+        inputs:
+            python-version:
+                required: true
+                type: string
+            image-hash:
+                description: "image-hash output from a prior build-ci-env.yml (with-ml: false) call."
+                required: true
+                type: string
+            ref:
+                description: "Git ref to check out and test - defaults to whatever ref triggered the calling workflow."
+                required: false
+                type: string
+                default: ""
+
+env:
+    flatland-benchmarks-episodes-url: "https://github.com/flatland-association/flatland-scenarios/raw/refs/heads/main/trajectories/FLATLAND_BENCHMARK_EPISODES_FOLDER_v5.zip"
+
+jobs:
+    # requirements-dev.txt (incl. scipy, already built from source) is baked into the image by build-ci-env.yml
+    # - nothing left to install here except flatland-rl itself, for the "Install flatland-rl and verify
+    # entry points" step below (its whole point is to test that install path, so unlike the pytest step it
+    # can't be skipped).
+    test:
+        runs-on: ubuntu-24.04
+        permissions:
+            contents: read
+            packages: read
+        container:
+            image: ghcr.io/${{ github.repository }}-ci-env:py${{ inputs.python-version }}-default-${{ inputs.image-hash }}
+            credentials:
+                username: ${{ github.actor }}
+                password: ${{ secrets.GITHUB_TOKEN }}
+        steps:
+            # The "Install flatland-rl and verify entry points" step below does `pip install .`, which needs
+            # setuptools_scm to run `git describe --tags` to infer a version. fetch-depth: 0 alone isn't
+            # enough for that - it gives full commit history but actions/checkout still doesn't fetch tags
+            # unless fetch-tags is explicitly set too, so both are needed together.
+            -   uses: actions/checkout@v6
+                with:
+                    ref: ${{ inputs.ref || github.ref }}
+                    fetch-depth: 0
+                    fetch-tags: true
+            # The archive is versioned in its URL (v5), so a plain URL-keyed cache is safe indefinitely - no
+            # invalidation is needed until this workflow itself is updated to a new URL.
+            -   name: Restore cached episodes
+                id: cache-episodes
+                uses: actions/cache/restore@v5
+                with:
+                    path: episodes
+                    key: episodes-${{ env.flatland-benchmarks-episodes-url }}
+            -   name: Download episodes
+                if: steps.cache-episodes.outputs.cache-hit != 'true'
+                run: |
+                    wget "${{ env.flatland-benchmarks-episodes-url }}" -O FLATLAND_BENCHMARK_EPISODES_FOLDER.zip
+                    mkdir -p episodes
+                    unzip FLATLAND_BENCHMARK_EPISODES_FOLDER -d episodes
+            -   name: Save cached episodes
+                if: ${{ always() && steps.cache-episodes.outputs.cache-hit != 'true' }}
+                uses: actions/cache/save@v5
+                with:
+                    path: episodes
+                    key: episodes-${{ env.flatland-benchmarks-episodes-url }}
+            # Runs pytest directly rather than `tox run -e py{version}`: tox would create its own venv and
+            # reinstall requirements-dev.txt into it regardless of what the image's system Python already
+            # has, rebuilding scipy from source again and defeating the point of this image. Mirrors
+            # tox.ini's [testenv:py{...}] set_env/commands exactly; that env remains the source of truth for
+            # local/non-container runs. Doesn't install flatland-rl itself even though tox's env technically
+            # does (default skip_install=false) - PYTHONPATH alone is enough for tests to import it
+            # (confirmed empirically: testml's equivalent tox env has the identical default, and its
+            # container-based run already passes without installing the package).
+            -   name: Run tests
+                env:
+                    PYTHONPATH: ${{ github.workspace }}
+                    BENCHMARK_EPISODES_FOLDER: ${{ github.workspace }}/episodes
+                    PYTHONDONTWRITEBYTECODE: "1"
+                    CMAKE_POLICY_VERSION_MINIMUM: "3.5"
+                run: python -m pytest -n auto --ignore=tests/ml -m "not slow"
+            # Mirrors tox.ini's [testenv:py{...}-verify-install] - unlike the step above, this one's whole
+            # point is to test the installed-package/entry-points path, so it genuinely needs `pip install
+            # .` rather than relying on PYTHONPATH.
+            -   name: Install flatland-rl and verify entry points
+                run: |
+                    python --version
+                    pip install --no-cache-dir .
+                    python -c 'from flatland.evaluators.service import FlatlandRemoteEvaluationService'
+                    python -c 'import flatland.integrations.interactiveai.interactiveai'
+                    evaluator --help
+                    flatland-demo --help
+                    flatland-evaluator --help
+                    flatland-trajectory-evaluate --help
+                    flatland-trajectory-generate-from-policy --help
+                    flatland-trajectory-generate-from-metadata --help
+                    flatland-trajectory-analysis --help

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,16 @@ policies, rendering, trajectory recording/replay, and evaluation services for th
 
 All commands assume dependencies from `requirements-dev.txt` (+ `requirements-ml.txt` for `flatland/ml`/`tests/ml`)
 are installed, and are run from the repo root. `tox` wraps most of these into reproducible environments (see
-`tox.ini`) — CI (`.github/workflows/checks.yml`) invokes tox directly, e.g. `tox -e py3.12,py3.12-verify-install`.
+`tox.ini`) — CI (`.github/workflows/checks.yml`)'s containerized jobs run tox's own testenvs directly via
+`tox run -e <env> --current-env` (the `tox-current-env` plugin: skips venv creation/dependency reinstall against
+an image's already-installed deps, but still applies the testenv's `set_env`/`commands` verbatim), so `tox.ini`
+is the single source of truth for both local and CI runs — editing it changes CI behavior without touching
+`checks.yml`. Two gotchas this implies: (1) a `[testenv:...]` section that declares its own `set_env` *replaces*
+rather than merges with the base `[testenv]` section's `set_env` (tox does not merge these) — any testenv needing
+extra env vars must start its `set_env` with `{[testenv]set_env}` or it silently loses `PYTHONPATH`/
+`CMAKE_POLICY_VERSION_MINIMUM`; (2) a dev dependency that's only invoked via CLI and never `import`ed (e.g. `tox`,
+`tox-current-env`) must be added to the `verify-requirements` testenv's `DEV_MODULES` list or `deptry` (`DEP002`)
+flags it as unused.
 
 - **Run the core test suite** (matches CI's `test` job): `benchmarks/benchmark_episodes.py`'s regression tests need
   a `BENCHMARK_EPISODES_FOLDER` populated from the `FLATLAND_BENCHMARK_EPISODES_FOLDER` archive (see

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,11 +8,13 @@ ARG FLATLAND_RL_REF
 
 WORKDIR /app
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends curl gcc build-essential wget zip ffmpeg git && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* && \
-    ffmpeg --help
+# See docker/install-build-toolchain.sh for what's installed and why - shared with Dockerfile.ci-env so a
+# toolchain fix needed by one doesn't silently stay missing from the other. Notably this is what supplies
+# gfortran/libopenblas-dev/pkg-config for numpy==1.26.4's from-source build on Pythons without a wheel -
+# previously missing here entirely (masked so far by docker.yml only building python-version 3.12, which
+# does have a numpy wheel).
+COPY docker/install-build-toolchain.sh /tmp/install-build-toolchain.sh
+RUN bash /tmp/install-build-toolchain.sh && rm /tmp/install-build-toolchain.sh && ffmpeg --help
 
 RUN curl -fsSL "https://raw.githubusercontent.com/flatland-association/flatland-rl/${FLATLAND_RL_REF}/requirements.txt" -o requirements.txt \
     && pip install --no-cache-dir -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,20 @@
+# This is the published, user-facing runtime image (built/pushed by docker.yml/publish.yml) - not to be
+# confused with the sibling Dockerfile.ci-env (checks.yml's throwaway test-dependency cache). Deliberately
+# does NOT `FROM` or otherwise inherit from a Dockerfile.ci-env-built image, even though they share the
+# apt toolchain layer (docker/install-build-toolchain.sh):
+# - Content: Dockerfile.ci-env bakes in requirements-dev.txt (pytest, deptry, flake8, tox, ...) - dev/test
+#   tooling with no business in a published runtime image.
+# - Architecture: Dockerfile.ci-env images are linux/amd64-only (checks.yml's build-ci-env.yml never builds
+#   arm64, since none of its consumers need it); this image is genuinely multi-arch
+#   (linux/amd64,linux/arm64), so inheriting would either break arm64 outright or force checks.yml to build
+#   arm64 on every PR/push - far more often than this image is actually published - for no benefit to
+#   checks.yml itself.
+# - Version binding: this image installs flatland-rl from an arbitrary FLATLAND_RL_REF (a git ref, often a
+#   past release tag, decoupled from whatever's currently checked out); Dockerfile.ci-env's image is tagged
+#   by a hash of the *currently checked out* requirements-dev.txt/requirements-ml.txt, i.e. tied to HEAD, not
+#   to an arbitrary historical ref. Reconciling the two would mean re-fetching/rebuilding per-ref anyway,
+#   which is exactly the "no cross-run cache" situation this image's own no-cache build already accepts (see
+#   docker.yml) - little caching benefit to gain from sharing.
 ARG PYTHON_VERSION=3.12
 ARG WITH_ML=false
 ARG FLATLAND_RL_REF=main

--- a/Dockerfile.ci-env
+++ b/Dockerfile.ci-env
@@ -1,25 +1,23 @@
-# CI-only dependency cache for flatland-rl's test matrix (checks.yml's testml job) - NOT a runtime image,
-# see the sibling Dockerfile for that (installs flatland-rl itself from a released ref, multi-arch, published
-# to end users). This image only bakes in requirements-dev.txt/requirements-ml.txt so CI's `pip install` can
-# hit BuildKit's registry layer cache instead of recompiling scipy/dm-tree from source on every run.
+# CI-only dependency cache for flatland-rl's test matrix (checks.yml's deptry/testml/test jobs) - NOT a
+# runtime image, see the sibling Dockerfile for that (installs flatland-rl itself from a released ref,
+# multi-arch, published to end users). This image only bakes in requirements-dev.txt (and, for the "ml"
+# variant, requirements-ml.txt too) so CI's `pip install` can hit BuildKit's registry layer cache instead
+# of recompiling scipy/dm-tree from source on every run.
 ARG PYTHON_VERSION=3.12
+ARG WITH_ML=true
 
 # Pinned to a known Debian codename (not the floating "slim" alias) so the default gcc version is
 # predictable - bookworm ships gcc-12 by default, avoiding the GCC13+/dm-tree incompatibility that
 # checks.yml's "Install ffmpeg" step otherwise has to work around explicitly on the Ubuntu 24.04 runner.
-FROM python:${PYTHON_VERSION}-slim-bookworm
+FROM python:${PYTHON_VERSION}-slim-bookworm AS base
 
 # ffmpeg: used by rendering tests. build-essential/gfortran/libopenblas-dev/pkg-config: scipy<1.16 has no
 # wheels for newer Pythons and builds from source (see pyproject.toml's scipy pin comment) - gfortran +
 # libopenblas-dev + pkg-config are scipy's meson build requirements (Fortran + BLAS/LAPACK backend + config
 # lookup); meson/ninja/pybind11 themselves come from scipy's own PEP 517 build-requires via pip's build
-# isolation, so they don't need to be installed here. cmake: dm-tree's setup.py does its own `cmake
-# --version` prerequisite check before building (unlike scipy, it doesn't rely on pip's build-isolation
-# cmake package for this). git: dm-tree's CMakeLists.txt fetches pybind11 via `FetchContent_Populate`/
-# `ExternalProject_Add`, which shells out to `git clone` at build time. wget/unzip: checks.yml's testml
-# job downloads and extracts the benchmark episodes archive, now running inside this image's steps rather
-# than directly on the CI runner. The Ubuntu CI runner has all of these preinstalled by default, masking
-# these requirements; this Debian slim base has none of them.
+# isolation, so they don't need to be installed here. wget/unzip: the episodes-download step (test/testml)
+# runs inside this image's steps rather than directly on the CI runner. The Ubuntu CI runner has all of
+# these preinstalled by default, masking these requirements; this Debian slim base has none of them.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         ffmpeg \
@@ -27,20 +25,33 @@ RUN apt-get update && \
         gfortran \
         libopenblas-dev \
         pkg-config \
-        cmake \
-        git \
         wget \
         unzip && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# dm-tree's vendored abseil-cpp (20210324.2) bundles very old CMakeLists.txt files that recent cmake (>=4.0,
-# pulled in via pip's build isolation) hard-errors on unless told to allow them - same setting tox.ini passes
-# for the equivalent (non-containerized) CI job.
-ENV CMAKE_POLICY_VERSION_MINIMUM=3.5
-
 WORKDIR /deps
 
+FROM base AS ml-true
+# cmake: dm-tree's setup.py does its own `cmake --version` prerequisite check before building (unlike
+# scipy, it doesn't rely on pip's build-isolation cmake package for this). git: dm-tree's CMakeLists.txt
+# fetches pybind11 via `FetchContent_Populate`/`ExternalProject_Add`, which shells out to `git clone` at
+# build time. Same "Ubuntu runner has it preinstalled, this Debian slim base doesn't" story as above.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends cmake git && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+# dm-tree's vendored abseil-cpp (20210324.2) bundles very old CMakeLists.txt files that recent cmake
+# (>=4.0, pulled in via pip's build isolation) hard-errors on unless told to allow them - same setting
+# tox.ini passes for the equivalent (non-containerized) CI job.
+ENV CMAKE_POLICY_VERSION_MINIMUM=3.5
 COPY requirements-dev.txt requirements-ml.txt ./
 RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir -r requirements-dev.txt -r requirements-ml.txt
+
+FROM base AS ml-false
+COPY requirements-dev.txt ./
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir -r requirements-dev.txt
+
+FROM ml-${WITH_ML} AS final

--- a/Dockerfile.ci-env
+++ b/Dockerfile.ci-env
@@ -15,8 +15,9 @@ FROM python:${PYTHON_VERSION}-slim-bookworm
 # lookup); meson/ninja/pybind11 themselves come from scipy's own PEP 517 build-requires via pip's build
 # isolation, so they don't need to be installed here. cmake: dm-tree's setup.py does its own `cmake
 # --version` prerequisite check before building (unlike scipy, it doesn't rely on pip's build-isolation
-# cmake package for this) - the Ubuntu CI runner has cmake preinstalled by default, but this Debian slim
-# base doesn't, so it has to be installed explicitly here.
+# cmake package for this). git: dm-tree's CMakeLists.txt fetches pybind11 via `FetchContent_Populate`/
+# `ExternalProject_Add`, which shells out to `git clone` at build time. The Ubuntu CI runner has both
+# cmake and git preinstalled by default, masking these requirements; this Debian slim base has neither.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         ffmpeg \
@@ -24,7 +25,8 @@ RUN apt-get update && \
         gfortran \
         libopenblas-dev \
         pkg-config \
-        cmake && \
+        cmake \
+        git && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile.ci-env
+++ b/Dockerfile.ci-env
@@ -16,8 +16,12 @@ FROM python:${PYTHON_VERSION}-slim-bookworm AS base
 # libopenblas-dev + pkg-config are scipy's meson build requirements (Fortran + BLAS/LAPACK backend + config
 # lookup); meson/ninja/pybind11 themselves come from scipy's own PEP 517 build-requires via pip's build
 # isolation, so they don't need to be installed here. wget/unzip: the episodes-download step (test/testml)
-# runs inside this image's steps rather than directly on the CI runner. The Ubuntu CI runner has all of
-# these preinstalled by default, masking these requirements; this Debian slim base has none of them.
+# runs inside this image's steps rather than directly on the CI runner. git: needed in both variants -
+# setuptools_scm shells out to `git describe --tags` during `pip install .` (checks.yml's test job does
+# this even on the non-ml image) to infer the package version; without it, the subprocess failure is
+# swallowed and surfaces as the misleading "setuptools-scm was unable to detect version" instead of a
+# "git: command not found". The Ubuntu CI runner has all of these preinstalled by default, masking these
+# requirements; this Debian slim base has none of them.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         ffmpeg \
@@ -26,7 +30,8 @@ RUN apt-get update && \
         libopenblas-dev \
         pkg-config \
         wget \
-        unzip && \
+        unzip \
+        git && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -34,11 +39,11 @@ WORKDIR /deps
 
 FROM base AS ml-true
 # cmake: dm-tree's setup.py does its own `cmake --version` prerequisite check before building (unlike
-# scipy, it doesn't rely on pip's build-isolation cmake package for this). git: dm-tree's CMakeLists.txt
-# fetches pybind11 via `FetchContent_Populate`/`ExternalProject_Add`, which shells out to `git clone` at
-# build time. Same "Ubuntu runner has it preinstalled, this Debian slim base doesn't" story as above.
+# scipy, it doesn't rely on pip's build-isolation cmake package for this). git is already installed in the
+# base stage above (also needed there for setuptools_scm); dm-tree's CMakeLists.txt additionally shells out
+# to it via `FetchContent_Populate`/`ExternalProject_Add` to fetch pybind11 at build time.
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends cmake git && \
+    apt-get install -y --no-install-recommends cmake && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 # dm-tree's vendored abseil-cpp (20210324.2) bundles very old CMakeLists.txt files that recent cmake

--- a/Dockerfile.ci-env
+++ b/Dockerfile.ci-env
@@ -1,0 +1,36 @@
+# CI-only dependency cache for flatland-rl's test matrix (checks.yml's testml job) - NOT a runtime image,
+# see the sibling Dockerfile for that (installs flatland-rl itself from a released ref, multi-arch, published
+# to end users). This image only bakes in requirements-dev.txt/requirements-ml.txt so CI's `pip install` can
+# hit BuildKit's registry layer cache instead of recompiling scipy/dm-tree from source on every run.
+ARG PYTHON_VERSION=3.12
+
+# Pinned to a known Debian codename (not the floating "slim" alias) so the default gcc version is
+# predictable - bookworm ships gcc-12 by default, avoiding the GCC13+/dm-tree incompatibility that
+# checks.yml's "Install ffmpeg" step otherwise has to work around explicitly on the Ubuntu 24.04 runner.
+FROM python:${PYTHON_VERSION}-slim-bookworm
+
+# ffmpeg: used by rendering tests. build-essential/gfortran/libopenblas-dev/pkg-config: scipy<1.16 has no
+# wheels for newer Pythons and builds from source (see pyproject.toml's scipy pin comment) - gfortran +
+# libopenblas-dev + pkg-config are scipy's meson build requirements (Fortran + BLAS/LAPACK backend + config
+# lookup); meson/ninja/pybind11 themselves come from scipy's own PEP 517 build-requires via pip's build
+# isolation, so they don't need to be installed here.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        ffmpeg \
+        build-essential \
+        gfortran \
+        libopenblas-dev \
+        pkg-config && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# dm-tree's vendored abseil-cpp (20210324.2) bundles very old CMakeLists.txt files that recent cmake (>=4.0,
+# pulled in via pip's build isolation) hard-errors on unless told to allow them - same setting tox.ini passes
+# for the equivalent (non-containerized) CI job.
+ENV CMAKE_POLICY_VERSION_MINIMUM=3.5
+
+WORKDIR /deps
+
+COPY requirements-dev.txt requirements-ml.txt ./
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir -r requirements-dev.txt -r requirements-ml.txt

--- a/Dockerfile.ci-env
+++ b/Dockerfile.ci-env
@@ -16,8 +16,10 @@ FROM python:${PYTHON_VERSION}-slim-bookworm
 # isolation, so they don't need to be installed here. cmake: dm-tree's setup.py does its own `cmake
 # --version` prerequisite check before building (unlike scipy, it doesn't rely on pip's build-isolation
 # cmake package for this). git: dm-tree's CMakeLists.txt fetches pybind11 via `FetchContent_Populate`/
-# `ExternalProject_Add`, which shells out to `git clone` at build time. The Ubuntu CI runner has both
-# cmake and git preinstalled by default, masking these requirements; this Debian slim base has neither.
+# `ExternalProject_Add`, which shells out to `git clone` at build time. wget/unzip: checks.yml's testml
+# job downloads and extracts the benchmark episodes archive, now running inside this image's steps rather
+# than directly on the CI runner. The Ubuntu CI runner has all of these preinstalled by default, masking
+# these requirements; this Debian slim base has none of them.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         ffmpeg \
@@ -26,7 +28,9 @@ RUN apt-get update && \
         libopenblas-dev \
         pkg-config \
         cmake \
-        git && \
+        git \
+        wget \
+        unzip && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile.ci-env
+++ b/Dockerfile.ci-env
@@ -13,14 +13,18 @@ FROM python:${PYTHON_VERSION}-slim-bookworm
 # wheels for newer Pythons and builds from source (see pyproject.toml's scipy pin comment) - gfortran +
 # libopenblas-dev + pkg-config are scipy's meson build requirements (Fortran + BLAS/LAPACK backend + config
 # lookup); meson/ninja/pybind11 themselves come from scipy's own PEP 517 build-requires via pip's build
-# isolation, so they don't need to be installed here.
+# isolation, so they don't need to be installed here. cmake: dm-tree's setup.py does its own `cmake
+# --version` prerequisite check before building (unlike scipy, it doesn't rely on pip's build-isolation
+# cmake package for this) - the Ubuntu CI runner has cmake preinstalled by default, but this Debian slim
+# base doesn't, so it has to be installed explicitly here.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         ffmpeg \
         build-essential \
         gfortran \
         libopenblas-dev \
-        pkg-config && \
+        pkg-config \
+        cmake && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile.ci-env
+++ b/Dockerfile.ci-env
@@ -11,11 +11,14 @@ ARG WITH_ML=true
 # checks.yml's "Install ffmpeg" step otherwise has to work around explicitly on the Ubuntu 24.04 runner.
 FROM python:${PYTHON_VERSION}-slim-bookworm AS base
 
-# ffmpeg: used by rendering tests. build-essential/gfortran/libopenblas-dev/pkg-config: scipy<1.16 has no
-# wheels for newer Pythons and builds from source (see pyproject.toml's scipy pin comment) - gfortran +
-# libopenblas-dev + pkg-config are scipy's meson build requirements (Fortran + BLAS/LAPACK backend + config
-# lookup); meson/ninja/pybind11 themselves come from scipy's own PEP 517 build-requires via pip's build
-# isolation, so they don't need to be installed here. wget/unzip: the episodes-download step (test/testml)
+# ffmpeg: used by rendering tests. build-essential/gfortran/libopenblas-dev/pkg-config: numpy==1.26.4 (see
+# pyproject.toml's "numpy<2" pin - requirements-dev.txt/requirements-ml.txt both lock it to 1.26.4) has no
+# wheels for newer Pythons and builds from source - gfortran + libopenblas-dev + pkg-config are its meson
+# build requirements (Fortran + BLAS/LAPACK backend + config lookup); meson/ninja/pybind11 themselves come
+# from numpy's own PEP 517 build-requires via pip's build isolation, so they don't need to be installed
+# here. This applies to both variants since numpy is a requirements-dev.txt dependency, not just an ml one
+# (scipy, requirements-ml.txt-only, has the same "no wheel, builds from source" story and reuses these same
+# tools in the ml-true stage below). wget/unzip: the episodes-download step (test/testml)
 # runs inside this image's steps rather than directly on the CI runner. git: needed in both variants -
 # setuptools_scm shells out to `git describe --tags` during `pip install .` (checks.yml's test job does
 # this even on the non-ml image) to infer the package version; without it, the subprocess failure is

--- a/Dockerfile.ci-env
+++ b/Dockerfile.ci-env
@@ -11,32 +11,11 @@ ARG WITH_ML=true
 # checks.yml's "Install ffmpeg" step otherwise has to work around explicitly on the Ubuntu 24.04 runner.
 FROM python:${PYTHON_VERSION}-slim-bookworm AS base
 
-# ffmpeg: used by rendering tests. build-essential/gfortran/libopenblas-dev/pkg-config: numpy==1.26.4 (see
-# pyproject.toml's "numpy<2" pin - requirements-dev.txt/requirements-ml.txt both lock it to 1.26.4) has no
-# wheels for newer Pythons and builds from source - gfortran + libopenblas-dev + pkg-config are its meson
-# build requirements (Fortran + BLAS/LAPACK backend + config lookup); meson/ninja/pybind11 themselves come
-# from numpy's own PEP 517 build-requires via pip's build isolation, so they don't need to be installed
-# here. This applies to both variants since numpy is a requirements-dev.txt dependency, not just an ml one
-# (scipy, requirements-ml.txt-only, has the same "no wheel, builds from source" story and reuses these same
-# tools in the ml-true stage below). wget/unzip: the episodes-download step (test/testml)
-# runs inside this image's steps rather than directly on the CI runner. git: needed in both variants -
-# setuptools_scm shells out to `git describe --tags` during `pip install .` (checks.yml's test job does
-# this even on the non-ml image) to infer the package version; without it, the subprocess failure is
-# swallowed and surfaces as the misleading "setuptools-scm was unable to detect version" instead of a
-# "git: command not found". The Ubuntu CI runner has all of these preinstalled by default, masking these
-# requirements; this Debian slim base has none of them.
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-        ffmpeg \
-        build-essential \
-        gfortran \
-        libopenblas-dev \
-        pkg-config \
-        wget \
-        unzip \
-        git && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+# See docker/install-build-toolchain.sh for what's installed and why - shared with the sibling Dockerfile
+# so a toolchain fix needed by one doesn't silently stay missing from the other (this is literally how the
+# numpy build-toolchain packages in that script got added here first).
+COPY docker/install-build-toolchain.sh /tmp/install-build-toolchain.sh
+RUN bash /tmp/install-build-toolchain.sh && rm /tmp/install-build-toolchain.sh
 
 WORKDIR /deps
 

--- a/benchmarks/benchmark_k_shortest_paths_profiling.ipynb
+++ b/benchmarks/benchmark_k_shortest_paths_profiling.ipynb
@@ -1,11 +1,10 @@
 {
  "cells": [
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "182cc8bf-ead7-e866-91b2-305770304ccd",
    "metadata": {},
+   "cell_type": "code",
    "outputs": [],
+   "execution_count": null,
    "source": [
     "import os\n",
     "import pstats\n",
@@ -15,52 +14,44 @@
     "import pandas as pd\n",
     "import seaborn as sns\n",
     "from matplotlib import pyplot as plt"
-   ]
+   ],
+   "id": "23ed773862ecab67"
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "349716a0-5008-307c-5959-2167497cd66b",
    "metadata": {},
+   "cell_type": "code",
    "outputs": [],
-   "source": [
-    "%load_ext snakeviz"
-   ]
+   "execution_count": null,
+   "source": "%load_ext snakeviz",
+   "id": "16eb29a3efd4df96"
   },
   {
+   "metadata": {},
    "cell_type": "markdown",
-   "id": "80fce8d8-dd95-e4ce-b8a9-16bcef2d8405",
-   "metadata": {},
-   "source": [
-    "## Configuration"
-   ]
+   "source": "## Configuration",
+   "id": "bbdf32a791e577a5"
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f0eb22f5-e80b-a1ed-d49a-811bc02da457",
    "metadata": {},
+   "cell_type": "code",
    "outputs": [],
-   "source": [
-    "NUM_RUNS = int(os.getenv(\"NUM_RUNS\", default=1))"
-   ]
+   "execution_count": null,
+   "source": "NUM_RUNS = int(os.getenv(\"NUM_RUNS\", default=1))",
+   "id": "7460f04b56604dd2"
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "6429ae38-fbea-506a-8afd-b54b95710c49",
    "metadata": {},
+   "cell_type": "code",
    "outputs": [],
-   "source": [
-    "ECML2026_PKL = Path(os.getenv(\"ECML2026_PKL\"))"
-   ]
+   "execution_count": null,
+   "source": "ECML2026_PKL = Path(os.getenv(\"ECML2026_PKL\"))",
+   "id": "c593db3792cad12e"
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "0a0b0c8e-75b3-834f-d687-5ce2b661aa90",
    "metadata": {},
+   "cell_type": "code",
    "outputs": [],
+   "execution_count": null,
    "source": [
     "# download the ECML 2026 scenario used by benchmark_k_shortest_paths.py if not already present\n",
     "if not ECML2026_PKL.exists():\n",
@@ -70,114 +61,213 @@
     "STATIONS_PKL = Path(os.getenv(\"ECML2026_STATIONS_PKL\"))\n",
     "if not STATIONS_PKL.exists():\n",
     "    !wget \"https://github.com/flatland-association/ecml2026-starterkit/raw/refs/heads/main/reinforcement_learning/sampling/stations.pkl\" -O {STATIONS_PKL}"
-   ]
+   ],
+   "id": "82eba4fd59937ae5"
   },
   {
+   "metadata": {},
    "cell_type": "code",
-   "execution_count": null,
-   "id": "b3b0814c-0f7a-788b-294b-954610fef5da",
-   "metadata": {},
    "outputs": [],
-   "source": "loop = [\n    {\n        \"sha\": \"5a97ccb6aec2e7c6227aba8a3b33de54f567ee3a\",\n        \"date\": \"Tue Apr 23 15:17:36 2024 +0200\",\n        \"name\": \"v4.0.2\"\n    },\n    {\n        \"sha\": \"9115580bf7c602ca3c524ad392489bd712f355da\",\n        \"date\": \"Tue Feb 18 17:03:18 2025 +0100\",\n        \"name\": \"v4.0.4\"\n    },\n    {\n        \"sha\": \"01d4c7ae8179c7a716059552eb31865772e5a549\",\n        \"date\": \"Tue Feb 18 17:11:28 2025 +0100\",\n        \"name\": \"118-fix-lru-cache-in-env-loading\"\n    },\n    {\n        \"sha\": \"3f905a2bc37a0cd69047513d43df1576e7ba7634\",\n        \"date\": \"Mon Mar 31 11:22:49 2025 +0200\",\n        \"name\": \"179-simplify-step\"\n    },\n    {\n        \"sha\": \"4fecd60e49dfb144b452f100ce916af2ed2a58fd\",\n        \"date\": \"Mon Mar 31 18:16:23 2025 +0200\",\n        \"name\": \"v4.1.0\"\n    },\n    {\n        \"sha\": \"04911f88f50e30188b7d671291e0c2bbe1ee5ad1\",\n        \"date\": \"Fri May 16 16:57:14 2025 +0200\",\n        \"name\": \"v4.1.1\"\n    },\n    {\n        \"sha\": \"8f607149e29590a5baa5211d0efd32d1858091a3\",\n        \"date\": \"Fri May 16 16:57:14 2025 +0200\",\n        \"name\": \"v4.2.0\"\n    },\n    {\n        \"sha\": \"79c1031f4cb80e671fc6e58e9a590fd78865a4af\",\n        \"date\": \"Fri May 16 16:57:14 2025 +0200\",\n        \"name\": \"v4.2.1\"\n    },\n    {\n        \"sha\": \"d6a69ca00bde635f78b6b45032bdcfe6d2e480aa\",\n        \"date\": \"Fri May 16 16:57:14 2025 +0200\",\n        \"name\": \"v4.2.2\"\n    },\n    {\n        \"sha\": \"189c259a8fe19266329a6826a137e1db29a12996\",\n        \"date\": \"Fri May 16 16:57:14 2025 +0200\",\n        \"name\": \"v4.2.3\"\n    },\n    {\n        \"sha\": \"dfcea58bfed32c9b549fba04a86e57a532280dc2\",\n        \"date\": \"Fri May 16 16:57:14 2025 +0200\",\n        \"name\": \"v4.2.4\"\n    },\n    {\n        \"sha\": \"2156f46ffd8c707c8737fe00da89376f9cc5c4e4\",\n        \"date\": \"Fri May 16 16:57:14 2025 +0200\",\n        \"name\": \"pr-402\"\n    },\n    {\n        \"sha\": \"6de179e336d6d7fe40a385a90ca9d1ac328fc786\",\n        \"date\": \"Fri May 16 16:57:14 2025 +0200\",\n        \"name\": \"v4.2.5\"\n    },\n    {\n        \"sha\": \"71e5faa53fae3a67b4dc35e504018701e1d3fe83\",\n        \"date\": \"Tue Jun 2 09:23:04 2026 +0200\",\n        \"name\": \"v4.2.6\"\n    },\n    {\n        \"sha\": \"LOCAL\",\n        \"date\": \"--\",\n        \"name\": \"LOCAL\"\n    },\n    {\n        \"sha\": \"LOCAL_Cython\",\n        \"date\": \"--\",\n        \"name\": \"LOCAL_Cython\"\n    }\n]"
-  },
-  {
-   "cell_type": "markdown",
-   "id": "483ee89e-0c59-0494-104e-759e51c7501a",
-   "metadata": {},
+   "execution_count": null,
    "source": [
-    "## Run Benchmarks with Profiler"
-   ]
+    "loop = [\n",
+    "    {\n",
+    "        \"sha\": \"5a97ccb6aec2e7c6227aba8a3b33de54f567ee3a\",\n",
+    "        \"date\": \"Tue Apr 23 15:17:36 2024 +0200\",\n",
+    "        \"name\": \"v4.0.2\"\n",
+    "    },\n",
+    "    {\n",
+    "        \"sha\": \"4fecd60e49dfb144b452f100ce916af2ed2a58fd\",\n",
+    "        \"date\": \"Mon Mar 31 18:16:23 2025 +0200\",\n",
+    "        \"name\": \"v4.1.0\"\n",
+    "    },\n",
+    "    {\n",
+    "        \"sha\": \"04911f88f50e30188b7d671291e0c2bbe1ee5ad1\",\n",
+    "        \"date\": \"Fri May 16 16:57:14 2025 +0200\",\n",
+    "        \"name\": \"v4.1.1\"\n",
+    "    },\n",
+    "    {\n",
+    "        \"sha\": \"189c259a8fe19266329a6826a137e1db29a12996\",\n",
+    "        \"date\": \"Fri May 16 16:57:14 2025 +0200\",\n",
+    "        \"name\": \"v4.2.3\"\n",
+    "    },\n",
+    "    {\n",
+    "        \"sha\": \"dfcea58bfed32c9b549fba04a86e57a532280dc2\",\n",
+    "        \"date\": \"Fri May 16 16:57:14 2025 +0200\",\n",
+    "        \"name\": \"v4.2.4\"\n",
+    "    },\n",
+    "    {\n",
+    "        \"sha\": \"6de179e336d6d7fe40a385a90ca9d1ac328fc786\",\n",
+    "        \"date\": \"Fri May 16 16:57:14 2025 +0200\",\n",
+    "        \"name\": \"v4.2.5\"\n",
+    "    },\n",
+    "    {\n",
+    "        \"sha\": \"71e5faa53fae3a67b4dc35e504018701e1d3fe83\",\n",
+    "        \"date\": \"Tue Jun 2 09:23:04 2026 +0200\",\n",
+    "        \"name\": \"v4.2.6\"\n",
+    "    },\n",
+    "    {\n",
+    "        \"sha\": \"LOCAL\",\n",
+    "        \"date\": \"--\",\n",
+    "        \"name\": \"LOCAL\"\n",
+    "    },\n",
+    "    {\n",
+    "        \"sha\": \"LOCAL_Cython\",\n",
+    "        \"date\": \"--\",\n",
+    "        \"name\": \"LOCAL_Cython\"\n",
+    "    }\n",
+    "]"
+   ],
+   "id": "7e0bd48c2584af4d"
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "84528bf5-bd01-f9ae-3d2c-689a4d8fcecd",
    "metadata": {},
+   "cell_type": "markdown",
+   "source": "## Run Benchmarks with Profiler",
+   "id": "febba23b902a63d7"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
    "outputs": [],
-   "source": "# use separate location where we checkout the code version to profile\n# hence we can control the configuration of the env in the cli in the current code relative to this notebook\n# CAVEAT: we run the checked out code in the current env (as we run it from the notebook) - this could lead to inconsistencies in the future (discarded or updated requirements or backwards-incompatibilities of the benchmarking cli)\n!git clone https://github.com/flatland-association/flatland-rl.git /tmp/flatland-rl\n!cd /tmp/flatland-rl && git clean -fdx && git reset --hard"
+   "execution_count": null,
+   "source": [
+    "# use separate location where we checkout the code version to profile\n",
+    "# hence we can control the configuration of the env in the cli in the current code relative to this notebook\n",
+    "# CAVEAT: we run the checked out code in the current env (as we run it from the notebook) - this could lead to inconsistencies in the future (discarded or updated requirements or backwards-incompatibilities of the benchmarking cli)\n",
+    "!git clone https://github.com/flatland-association/flatland-rl.git /tmp/flatland-rl\n",
+    "!cd /tmp/flatland-rl && git clean -fdx && git reset --hard"
+   ],
+   "id": "391f2ce65819420e"
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "62c33213-3ba5-2320-2b70-b7275165294e",
    "metadata": {},
+   "cell_type": "code",
    "outputs": [],
-   "source": "for i in range(NUM_RUNS):\n    for l in loop:\n        if l[\"name\"] in (\"LOCAL\", \"LOCAL_Cython\"):\n            continue\n        print(\"===================================================================\")\n        print(f'{l[\"name\"]} - {l[\"sha\"]} - {i}')\n        print(\"===================================================================\")\n        !cd /tmp/flatland-rl && git checkout {l[\"sha\"]} && git log -1\n        !export PYTHONPATH=/tmp/flatland-rl && export ECML2026_PKL={ECML2026_PKL} && python -m cProfile -o benchmark_k_shortest_paths.py_{l[\"name\"]}_{i}.prof -m pytest benchmark_k_shortest_paths.py\n        time.sleep(2)"
+   "execution_count": null,
+   "source": [
+    "for i in range(NUM_RUNS):\n",
+    "    for l in loop:\n",
+    "        if l[\"name\"] in (\"LOCAL\", \"LOCAL_Cython\"):\n",
+    "            continue\n",
+    "        print(\"===================================================================\")\n",
+    "        print(f'{l[\"name\"]} - {l[\"sha\"]} - {i}')\n",
+    "        print(\"===================================================================\")\n",
+    "        !cd /tmp/flatland-rl && git checkout {l[\"sha\"]} && git log -1\n",
+    "        !export PYTHONPATH=/tmp/flatland-rl && export ECML2026_PKL={ECML2026_PKL} && python -m cProfile -o benchmark_k_shortest_paths.py_{l[\"name\"]}_{i}.prof -m pytest benchmark_k_shortest_paths.py\n",
+    "        time.sleep(2)"
+   ],
+   "id": "475006a1e5f37368"
   },
   {
-   "cell_type": "code",
-   "id": "b61f1a42",
-   "source": "# ensure no compiled Cython artifacts remain so LOCAL (and all other non-Cython loop configs) reflect pure-Python performance\nrepo_root = Path.cwd().parent\n!rm -rf {repo_root}/build && find {repo_root}/flatland \\( -name '*.c' -o -name '*.so' \\) -print0 | xargs -0 rm -f",
    "metadata": {},
-   "execution_count": null,
-   "outputs": []
-  },
-  {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "63c6c638-1d6a-3612-40cb-c98706637bf2",
-   "metadata": {},
    "outputs": [],
+   "execution_count": null,
+   "source": [
+    "# ensure no compiled Cython artifacts remain so LOCAL (and all other non-Cython loop configs) reflect pure-Python performance\n",
+    "repo_root = Path.cwd().parent\n",
+    "!rm -rf {repo_root}/build && find {repo_root}/flatland \\( -name '*.c' -o -name '*.so' \\) -print0 | xargs -0 rm -f"
+   ],
+   "id": "a8cee71fad4a0317"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
    "source": [
     "for i in range(NUM_RUNS):\n",
     "    print(\"===================================================================\")\n",
     "    print(f'LOCAL - {i}')\n",
     "    print(\"===================================================================\")\n",
     "    !export PYTHONPATH={Path.cwd().parent} && export ECML2026_PKL={ECML2026_PKL} && python -m cProfile -o benchmark_k_shortest_paths.py_LOCAL_{i}.prof -m pytest benchmark_k_shortest_paths.py"
-   ]
+   ],
+   "id": "e9080c2e0eea7d5d"
   },
   {
+   "metadata": {},
    "cell_type": "markdown",
-   "id": "4d9714b3",
    "source": "### Cythonize `ext_modules` and run LOCAL_Cython",
-   "metadata": {}
+   "id": "278f51d88b51b9ef"
   },
   {
+   "metadata": {},
    "cell_type": "code",
-   "id": "7c024acd",
-   "source": "# cythonize + compile the ext_modules declared in pyproject.toml's [tool.setuptools] ext-modules (in-place,\n# so the .so lands next to the .py it shadows) - there is no setup.py anymore, so invoke setup() directly\n!python -m pip install \"cython>=3.3.0a1\" \"setuptools_scm>=8\"\n!cd {repo_root} && python -c \"from setuptools import setup; setup()\" build_ext --inplace",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "id": "d8554527",
-   "source": "import subprocess\n\n# verify the ext-modules actually compiled under the same PYTHONPATH used for the LOCAL_Cython runs below —\n# pyproject.toml declares them `optional = true` (silent pure-Python fallback on missing Cython/compiler),\n# and the `!shell` build cell above doesn't raise on failure, so this is the only thing that would catch that.\n# rail_env_shortest_paths is included since it's the module this notebook actually profiles - without it, a\n# failed cythonization of just that module would go unnoticed and LOCAL_Cython would silently benchmark\n# pure-Python performance for get_k_shortest_paths under a misleading label.\nfor ext_module in (\"flatland.envs.step_utils.state_machine\", \"flatland.envs.step_utils.states\", \"flatland.envs.rail_env_shortest_paths\"):\n    result = subprocess.run(\n        [\"python\", \"-c\", f\"import {ext_module} as m; assert m.__file__.endswith(('.so', '.pyd')), m.__file__; print(m.__file__)\"],\n        env={**os.environ, \"PYTHONPATH\": str(repo_root)},\n        capture_output=True, text=True,\n    )\n    assert result.returncode == 0, (\n        f\"{ext_module} is not compiled (build_ext failed or fell back to pure Python):\\n\"\n        f\"{result.stdout}{result.stderr}\"\n    )\n    print(f\"verified compiled: {result.stdout.strip()}\")",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "id": "f29bbfd7",
-   "source": "for i in range(NUM_RUNS):\n    print(\"===================================================================\")\n    print(f'LOCAL_Cython - {i}')\n    print(\"===================================================================\")\n    !export PYTHONPATH={repo_root} && export ECML2026_PKL={ECML2026_PKL} && python -m cProfile -o benchmark_k_shortest_paths.py_LOCAL_Cython_{i}.prof -m pytest benchmark_k_shortest_paths.py",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "id": "cafcee5d",
-   "source": "# restore the working tree to a pure-Python state so no other loop config or downstream test picks up the compiled extension\n!rm -rf {repo_root}/build && find {repo_root}/flatland \\( -name '*.c' -o -name '*.so' \\) -print0 | xargs -0 rm -f",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "markdown",
-   "id": "b69814b1-742c-d3c4-84dc-7e42fdba7e7a",
-   "metadata": {},
-   "source": [
-    "## Analyse Profiling"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b1b49f62-ed26-a8f6-f443-2e9ea9cacc5d",
-   "metadata": {},
    "outputs": [],
+   "execution_count": null,
+   "source": [
+    "# cythonize + compile the ext_modules declared in pyproject.toml's [tool.setuptools] ext-modules (in-place,\n",
+    "# so the .so lands next to the .py it shadows) - there is no setup.py anymore, so invoke setup() directly\n",
+    "!python -m pip install \"cython>=3.3.0a1\" \"setuptools_scm>=8\"\n",
+    "!cd {repo_root} && python -c \"from setuptools import setup; setup()\" build_ext --inplace"
+   ],
+   "id": "cefeaa0f69d20380"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": [
+    "import subprocess\n",
+    "\n",
+    "# verify the ext-modules actually compiled under the same PYTHONPATH used for the LOCAL_Cython runs below —\n",
+    "# pyproject.toml declares them `optional = true` (silent pure-Python fallback on missing Cython/compiler),\n",
+    "# and the `!shell` build cell above doesn't raise on failure, so this is the only thing that would catch that.\n",
+    "# rail_env_shortest_paths is included since it's the module this notebook actually profiles - without it, a\n",
+    "# failed cythonization of just that module would go unnoticed and LOCAL_Cython would silently benchmark\n",
+    "# pure-Python performance for get_k_shortest_paths under a misleading label.\n",
+    "for ext_module in (\"flatland.envs.step_utils.state_machine\", \"flatland.envs.step_utils.states\", \"flatland.envs.rail_env_shortest_paths\"):\n",
+    "    result = subprocess.run(\n",
+    "        [\"python\", \"-c\", f\"import {ext_module} as m; assert m.__file__.endswith(('.so', '.pyd')), m.__file__; print(m.__file__)\"],\n",
+    "        env={**os.environ, \"PYTHONPATH\": str(repo_root)},\n",
+    "        capture_output=True, text=True,\n",
+    "    )\n",
+    "    assert result.returncode == 0, (\n",
+    "        f\"{ext_module} is not compiled (build_ext failed or fell back to pure Python):\\n\"\n",
+    "        f\"{result.stdout}{result.stderr}\"\n",
+    "    )\n",
+    "    print(f\"verified compiled: {result.stdout.strip()}\")"
+   ],
+   "id": "bb131d001ae2aa5b"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": [
+    "for i in range(NUM_RUNS):\n",
+    "    print(\"===================================================================\")\n",
+    "    print(f'LOCAL_Cython - {i}')\n",
+    "    print(\"===================================================================\")\n",
+    "    !export PYTHONPATH={repo_root} && export ECML2026_PKL={ECML2026_PKL} && python -m cProfile -o benchmark_k_shortest_paths.py_LOCAL_Cython_{i}.prof -m pytest benchmark_k_shortest_paths.py"
+   ],
+   "id": "bfce6976d718baba"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": [
+    "# restore the working tree to a pure-Python state so no other loop config or downstream test picks up the compiled extension\n",
+    "!rm -rf {repo_root}/build && find {repo_root}/flatland \\( -name '*.c' -o -name '*.so' \\) -print0 | xargs -0 rm -f"
+   ],
+   "id": "78af54d7321f461a"
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "## Analyse Profiling",
+   "id": "1b09d8d33e1a0adf"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
    "source": [
     "# https://stackoverflow.com/questions/44302726/pandas-how-to-store-cprofile-output-in-a-pandas-dataframe\n",
     "def prof_to_df(st):\n",
@@ -194,24 +284,22 @@
     "        for i, kk in enumerate(keys_from_v):\n",
     "            data[kk].append(s[k][i])\n",
     "    return pd.DataFrame(data)"
-   ]
+   ],
+   "id": "dc01f8af33f2c50f"
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "a6256921-a306-397f-8e96-d35e13edf5b4",
    "metadata": {},
+   "cell_type": "code",
    "outputs": [],
-   "source": [
-    "agg = {\"fn\": [\"first\"], \"sha\": [\"first\"], \"cumtime\": ['mean', 'median', 'min', 'max', 'std'], \"tottime\": ['mean', 'median', 'min', 'max', 'std']}"
-   ]
+   "execution_count": null,
+   "source": "agg = {\"fn\": [\"first\"], \"sha\": [\"first\"], \"cumtime\": ['mean', 'median', 'min', 'max', 'std'], \"tottime\": ['mean', 'median', 'min', 'max', 'std']}",
+   "id": "c9b39ccd00c7d7d"
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "4c718dd2-460a-1480-dec1-45d6fe7637f2",
    "metadata": {},
+   "cell_type": "code",
    "outputs": [],
+   "execution_count": null,
    "source": [
     "def aggregate(example):\n",
     "    dfs = []\n",
@@ -227,39 +315,39 @@
     "            dfs.append(df)\n",
     "    df = pd.concat(dfs)\n",
     "    return df"
-   ]
+   ],
+   "id": "ae1f656a1514a1cd"
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "8c81a2d4-4d65-f92b-168b-41cbac7be54f",
    "metadata": {},
+   "cell_type": "code",
    "outputs": [],
+   "execution_count": null,
    "source": [
     "# tottime is the total time spent in the function alone.\n",
     "# cumtime is the total time spent in the function plus all functions that this function called."
-   ]
+   ],
+   "id": "f29f23ee1576995d"
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f0782951-f774-0c6e-cf61-e5e94ed1a6c8",
    "metadata": {},
+   "cell_type": "code",
    "outputs": [],
+   "execution_count": null,
    "source": [
     "def filter_df(df, conditions):\n",
     "    cond = False\n",
     "    for fn, file in conditions:\n",
     "        cond = cond | (df[\"fn\"] == fn) & (df[\"file\"].str.contains(file))\n",
     "    return df[cond]"
-   ]
+   ],
+   "id": "49a00a005d9079f3"
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "ca1cbb2a-fb3a-07bd-9e4e-a0451a2a360f",
    "metadata": {},
+   "cell_type": "code",
    "outputs": [],
+   "execution_count": null,
    "source": [
     "def analyse_df(df, fn, file, sort_by=\"cumtime\"):\n",
     "    df_ = df[(df[\"fn\"] == fn) & (df[\"file\"].str.contains(file))].groupby(\"name\").agg(agg).sort_values((sort_by, \"median\"), ascending=True)\n",
@@ -268,33 +356,31 @@
     "    df_[\"diff_mean\"] = df_[(sort_by, \"mean\")].diff().cumsum()\n",
     "    df_[\"diff%_mean\"] = df_[\"diff_mean\"] / (df_[(\"cumtime\", \"mean\")] + df_[\"diff_mean\"]) * 100\n",
     "    return df_"
-   ]
+   ],
+   "id": "ff3336f6c526cf30"
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "7805889e-1122-8b68-a612-4367a2a5179b",
    "metadata": {},
+   "cell_type": "code",
    "outputs": [],
+   "execution_count": null,
    "source": [
     "df_benchmark_k_shortest_paths = aggregate(\"benchmark_k_shortest_paths.py\")\n",
     "df_benchmark_k_shortest_paths"
-   ]
+   ],
+   "id": "e63c8c08441beafc"
   },
   {
+   "metadata": {},
    "cell_type": "markdown",
-   "id": "25682593-f877-8c96-971a-fbb39646a339",
-   "metadata": {},
-   "source": [
-    "### Look into overall performance"
-   ]
+   "source": "### Look into overall performance",
+   "id": "108bcb1eb54d0256"
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "d47a695d-7b3c-f826-ec07-c75ccd3a2e01",
    "metadata": {},
+   "cell_type": "code",
    "outputs": [],
+   "execution_count": null,
    "source": [
     "plt.figure(figsize=(15, 8))\n",
     "ax = sns.barplot(filter_df(df_benchmark_k_shortest_paths, [\n",
@@ -302,65 +388,42 @@
     "]), x=\"name\", y=\"cumtime\", hue=\"fn\", legend=True, estimator=\"median\")\n",
     "ax.bar_label(ax.containers[0], fontsize=10);\n",
     "plt.savefig(\"performance_get_k_shortest_paths.png\")"
-   ]
+   ],
+   "id": "bbcbb2291c6ec42f"
   },
   {
-   "cell_type": "markdown",
-   "id": "e661217a-8c58-536c-55d0-ec9c4eb88b5c",
    "metadata": {},
-   "source": [
-    "The same data in tabular form:"
-   ]
+   "cell_type": "markdown",
+   "source": "The same data in tabular form:",
+   "id": "b111ae843ad6c66a"
   },
   {
+   "metadata": {},
    "cell_type": "code",
-   "execution_count": null,
-   "id": "23e653e7-a8e8-8c05-4de5-553837157bc7",
-   "metadata": {},
    "outputs": [],
-   "source": [
-    "analyse_df(df_benchmark_k_shortest_paths, \"get_k_shortest_paths\", \"rail_env_shortest_paths.py\")"
-   ]
+   "execution_count": null,
+   "source": "analyse_df(df_benchmark_k_shortest_paths, \"get_k_shortest_paths\", \"rail_env_shortest_paths.py\")",
+   "id": "659632b5c5d46266"
   },
   {
-   "cell_type": "markdown",
-   "id": "4f529481-cf16-eb5a-1ff1-a752cc2af881",
    "metadata": {},
+   "cell_type": "markdown",
    "source": [
     "### Snakeviz of individual profiles\n",
     "Use the following line to start a snakeviz server and open a new browser window:"
-   ]
+   ],
+   "id": "b98b7d488161bd88"
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "62142dd3-dacb-748e-1bd0-8e2b5b374d05",
    "metadata": {},
+   "cell_type": "code",
    "outputs": [],
-   "source": [
-    "#!snakeviz \"benchmark_k_shortest_paths.py_LOCAL_3.prof\""
-   ]
+   "execution_count": null,
+   "source": "#!snakeviz \"benchmark_k_shortest_paths.py_LOCAL_3.prof\"",
+   "id": "10d9c1cb2bcf8b57"
   }
  ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.12.9"
-  }
- },
+ "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 5
 }

--- a/benchmarks/benchmark_k_shortest_paths_profiling.ipynb
+++ b/benchmarks/benchmark_k_shortest_paths_profiling.ipynb
@@ -15,7 +15,7 @@
     "import seaborn as sns\n",
     "from matplotlib import pyplot as plt"
    ],
-   "id": "23ed773862ecab67"
+   "id": "ccbb9f505c194125"
   },
   {
    "metadata": {},
@@ -23,13 +23,13 @@
    "outputs": [],
    "execution_count": null,
    "source": "%load_ext snakeviz",
-   "id": "16eb29a3efd4df96"
+   "id": "42eadaa76a09e332"
   },
   {
    "metadata": {},
    "cell_type": "markdown",
    "source": "## Configuration",
-   "id": "bbdf32a791e577a5"
+   "id": "4d7553c117db6d6a"
   },
   {
    "metadata": {},
@@ -37,7 +37,7 @@
    "outputs": [],
    "execution_count": null,
    "source": "NUM_RUNS = int(os.getenv(\"NUM_RUNS\", default=1))",
-   "id": "7460f04b56604dd2"
+   "id": "191ecea65ce0d9b6"
   },
   {
    "metadata": {},
@@ -45,7 +45,7 @@
    "outputs": [],
    "execution_count": null,
    "source": "ECML2026_PKL = Path(os.getenv(\"ECML2026_PKL\"))",
-   "id": "c593db3792cad12e"
+   "id": "d55644c51e0d42bc"
   },
   {
    "metadata": {},
@@ -62,7 +62,7 @@
     "if not STATIONS_PKL.exists():\n",
     "    !wget \"https://github.com/flatland-association/ecml2026-starterkit/raw/refs/heads/main/reinforcement_learning/sampling/stations.pkl\" -O {STATIONS_PKL}"
    ],
-   "id": "82eba4fd59937ae5"
+   "id": "61d06ffef41fe8e2"
   },
   {
    "metadata": {},
@@ -76,6 +76,21 @@
     "        \"date\": \"Tue Apr 23 15:17:36 2024 +0200\",\n",
     "        \"name\": \"v4.0.2\"\n",
     "    },\n",
+    "    # {\n",
+    "    #     \"sha\": \"9115580bf7c602ca3c524ad392489bd712f355da\",\n",
+    "    #     \"date\": \"Tue Feb 18 17:03:18 2025 +0100\",\n",
+    "    #     \"name\": \"v4.0.4\"\n",
+    "    # },\n",
+    "    # {\n",
+    "    #     \"sha\": \"01d4c7ae8179c7a716059552eb31865772e5a549\",\n",
+    "    #     \"date\": \"Tue Feb 18 17:11:28 2025 +0100\",\n",
+    "    #     \"name\": \"118-fix-lru-cache-in-env-loading\"\n",
+    "    # },\n",
+    "    # {\n",
+    "    #     \"sha\": \"3f905a2bc37a0cd69047513d43df1576e7ba7634\",\n",
+    "    #     \"date\": \"Mon Mar 31 11:22:49 2025 +0200\",\n",
+    "    #     \"name\": \"179-simplify-step\"\n",
+    "    # },\n",
     "    {\n",
     "        \"sha\": \"4fecd60e49dfb144b452f100ce916af2ed2a58fd\",\n",
     "        \"date\": \"Mon Mar 31 18:16:23 2025 +0200\",\n",
@@ -86,6 +101,21 @@
     "        \"date\": \"Fri May 16 16:57:14 2025 +0200\",\n",
     "        \"name\": \"v4.1.1\"\n",
     "    },\n",
+    "    # {\n",
+    "    #     \"sha\": \"8f607149e29590a5baa5211d0efd32d1858091a3\",\n",
+    "    #     \"date\": \"Fri May 16 16:57:14 2025 +0200\",\n",
+    "    #     \"name\": \"v4.2.0\"\n",
+    "    # },\n",
+    "    # {\n",
+    "    #     \"sha\": \"79c1031f4cb80e671fc6e58e9a590fd78865a4af\",\n",
+    "    #     \"date\": \"Fri May 16 16:57:14 2025 +0200\",\n",
+    "    #     \"name\": \"v4.2.1\"\n",
+    "    # },\n",
+    "    # {\n",
+    "    #     \"sha\": \"d6a69ca00bde635f78b6b45032bdcfe6d2e480aa\",\n",
+    "    #     \"date\": \"Fri May 16 16:57:14 2025 +0200\",\n",
+    "    #     \"name\": \"v4.2.2\"\n",
+    "    # },\n",
     "    {\n",
     "        \"sha\": \"189c259a8fe19266329a6826a137e1db29a12996\",\n",
     "        \"date\": \"Fri May 16 16:57:14 2025 +0200\",\n",
@@ -96,6 +126,11 @@
     "        \"date\": \"Fri May 16 16:57:14 2025 +0200\",\n",
     "        \"name\": \"v4.2.4\"\n",
     "    },\n",
+    "    # {\n",
+    "    #     \"sha\": \"2156f46ffd8c707c8737fe00da89376f9cc5c4e4\",\n",
+    "    #     \"date\": \"Fri May 16 16:57:14 2025 +0200\",\n",
+    "    #     \"name\": \"pr-402\"\n",
+    "    # },\n",
     "    {\n",
     "        \"sha\": \"6de179e336d6d7fe40a385a90ca9d1ac328fc786\",\n",
     "        \"date\": \"Fri May 16 16:57:14 2025 +0200\",\n",
@@ -118,13 +153,13 @@
     "    }\n",
     "]"
    ],
-   "id": "7e0bd48c2584af4d"
+   "id": "1ac4a0f6ef435b52"
   },
   {
    "metadata": {},
    "cell_type": "markdown",
    "source": "## Run Benchmarks with Profiler",
-   "id": "febba23b902a63d7"
+   "id": "a4e337a4e35373d0"
   },
   {
    "metadata": {},
@@ -138,7 +173,7 @@
     "!git clone https://github.com/flatland-association/flatland-rl.git /tmp/flatland-rl\n",
     "!cd /tmp/flatland-rl && git clean -fdx && git reset --hard"
    ],
-   "id": "391f2ce65819420e"
+   "id": "c365767d50bf68a7"
   },
   {
    "metadata": {},
@@ -157,7 +192,7 @@
     "        !export PYTHONPATH=/tmp/flatland-rl && export ECML2026_PKL={ECML2026_PKL} && python -m cProfile -o benchmark_k_shortest_paths.py_{l[\"name\"]}_{i}.prof -m pytest benchmark_k_shortest_paths.py\n",
     "        time.sleep(2)"
    ],
-   "id": "475006a1e5f37368"
+   "id": "a7e6cb00c008e9cc"
   },
   {
    "metadata": {},
@@ -169,7 +204,7 @@
     "repo_root = Path.cwd().parent\n",
     "!rm -rf {repo_root}/build && find {repo_root}/flatland \\( -name '*.c' -o -name '*.so' \\) -print0 | xargs -0 rm -f"
    ],
-   "id": "a8cee71fad4a0317"
+   "id": "b92dda0efb9a145e"
   },
   {
    "metadata": {},
@@ -183,13 +218,13 @@
     "    print(\"===================================================================\")\n",
     "    !export PYTHONPATH={Path.cwd().parent} && export ECML2026_PKL={ECML2026_PKL} && python -m cProfile -o benchmark_k_shortest_paths.py_LOCAL_{i}.prof -m pytest benchmark_k_shortest_paths.py"
    ],
-   "id": "e9080c2e0eea7d5d"
+   "id": "54cfd738dc8b2c37"
   },
   {
    "metadata": {},
    "cell_type": "markdown",
    "source": "### Cythonize `ext_modules` and run LOCAL_Cython",
-   "id": "278f51d88b51b9ef"
+   "id": "de49d50e2f1dd8fd"
   },
   {
    "metadata": {},
@@ -202,7 +237,7 @@
     "!python -m pip install \"cython>=3.3.0a1\" \"setuptools_scm>=8\"\n",
     "!cd {repo_root} && python -c \"from setuptools import setup; setup()\" build_ext --inplace"
    ],
-   "id": "cefeaa0f69d20380"
+   "id": "b1816f46fc72e701"
   },
   {
    "metadata": {},
@@ -230,7 +265,7 @@
     "    )\n",
     "    print(f\"verified compiled: {result.stdout.strip()}\")"
    ],
-   "id": "bb131d001ae2aa5b"
+   "id": "2b4b97995f148ad2"
   },
   {
    "metadata": {},
@@ -244,7 +279,7 @@
     "    print(\"===================================================================\")\n",
     "    !export PYTHONPATH={repo_root} && export ECML2026_PKL={ECML2026_PKL} && python -m cProfile -o benchmark_k_shortest_paths.py_LOCAL_Cython_{i}.prof -m pytest benchmark_k_shortest_paths.py"
    ],
-   "id": "bfce6976d718baba"
+   "id": "12dc992f2623ca93"
   },
   {
    "metadata": {},
@@ -255,13 +290,13 @@
     "# restore the working tree to a pure-Python state so no other loop config or downstream test picks up the compiled extension\n",
     "!rm -rf {repo_root}/build && find {repo_root}/flatland \\( -name '*.c' -o -name '*.so' \\) -print0 | xargs -0 rm -f"
    ],
-   "id": "78af54d7321f461a"
+   "id": "d68eb3bd2c88467f"
   },
   {
    "metadata": {},
    "cell_type": "markdown",
    "source": "## Analyse Profiling",
-   "id": "1b09d8d33e1a0adf"
+   "id": "dce9b23a4ab8fbad"
   },
   {
    "metadata": {},
@@ -285,7 +320,7 @@
     "            data[kk].append(s[k][i])\n",
     "    return pd.DataFrame(data)"
    ],
-   "id": "dc01f8af33f2c50f"
+   "id": "2942cc44fa211d18"
   },
   {
    "metadata": {},
@@ -293,7 +328,7 @@
    "outputs": [],
    "execution_count": null,
    "source": "agg = {\"fn\": [\"first\"], \"sha\": [\"first\"], \"cumtime\": ['mean', 'median', 'min', 'max', 'std'], \"tottime\": ['mean', 'median', 'min', 'max', 'std']}",
-   "id": "c9b39ccd00c7d7d"
+   "id": "45bb54d6abe468d3"
   },
   {
    "metadata": {},
@@ -316,7 +351,7 @@
     "    df = pd.concat(dfs)\n",
     "    return df"
    ],
-   "id": "ae1f656a1514a1cd"
+   "id": "8481f57e14fabdd"
   },
   {
    "metadata": {},
@@ -327,7 +362,7 @@
     "# tottime is the total time spent in the function alone.\n",
     "# cumtime is the total time spent in the function plus all functions that this function called."
    ],
-   "id": "f29f23ee1576995d"
+   "id": "2a4f0720f069cb5d"
   },
   {
    "metadata": {},
@@ -341,7 +376,7 @@
     "        cond = cond | (df[\"fn\"] == fn) & (df[\"file\"].str.contains(file))\n",
     "    return df[cond]"
    ],
-   "id": "49a00a005d9079f3"
+   "id": "b11b38a5a4077c8f"
   },
   {
    "metadata": {},
@@ -357,7 +392,7 @@
     "    df_[\"diff%_mean\"] = df_[\"diff_mean\"] / (df_[(\"cumtime\", \"mean\")] + df_[\"diff_mean\"]) * 100\n",
     "    return df_"
    ],
-   "id": "ff3336f6c526cf30"
+   "id": "dd1505dd86cf0324"
   },
   {
    "metadata": {},
@@ -368,13 +403,13 @@
     "df_benchmark_k_shortest_paths = aggregate(\"benchmark_k_shortest_paths.py\")\n",
     "df_benchmark_k_shortest_paths"
    ],
-   "id": "e63c8c08441beafc"
+   "id": "bbc99c62f24758c9"
   },
   {
    "metadata": {},
    "cell_type": "markdown",
    "source": "### Look into overall performance",
-   "id": "108bcb1eb54d0256"
+   "id": "417ac007fb7bb9d2"
   },
   {
    "metadata": {},
@@ -389,13 +424,13 @@
     "ax.bar_label(ax.containers[0], fontsize=10);\n",
     "plt.savefig(\"performance_get_k_shortest_paths.png\")"
    ],
-   "id": "bbcbb2291c6ec42f"
+   "id": "4b8e26edd9537561"
   },
   {
    "metadata": {},
    "cell_type": "markdown",
    "source": "The same data in tabular form:",
-   "id": "b111ae843ad6c66a"
+   "id": "a3c00f4efed3c414"
   },
   {
    "metadata": {},
@@ -403,7 +438,7 @@
    "outputs": [],
    "execution_count": null,
    "source": "analyse_df(df_benchmark_k_shortest_paths, \"get_k_shortest_paths\", \"rail_env_shortest_paths.py\")",
-   "id": "659632b5c5d46266"
+   "id": "44f34dc1e2cb1571"
   },
   {
    "metadata": {},
@@ -412,7 +447,7 @@
     "### Snakeviz of individual profiles\n",
     "Use the following line to start a snakeviz server and open a new browser window:"
    ],
-   "id": "b98b7d488161bd88"
+   "id": "ba0b83499935beb4"
   },
   {
    "metadata": {},
@@ -420,7 +455,7 @@
    "outputs": [],
    "execution_count": null,
    "source": "#!snakeviz \"benchmark_k_shortest_paths.py_LOCAL_3.prof\"",
-   "id": "10d9c1cb2bcf8b57"
+   "id": "cf8fd578833d5d9c"
   }
  ],
  "metadata": {},

--- a/benchmarks/flatland_performance_profiling.ipynb
+++ b/benchmarks/flatland_performance_profiling.ipynb
@@ -15,7 +15,7 @@
     "import seaborn as sns\n",
     "from matplotlib import pyplot as plt"
    ],
-   "id": "dfc9cd269f567457"
+   "id": "4287106a1bb50b77"
   },
   {
    "metadata": {},
@@ -23,13 +23,13 @@
    "outputs": [],
    "execution_count": null,
    "source": "%load_ext snakeviz",
-   "id": "f3fd54400872c9dd"
+   "id": "c0e1567a45019f03"
   },
   {
    "metadata": {},
    "cell_type": "markdown",
    "source": "## Configuration",
-   "id": "2f914bb87e422e06"
+   "id": "e123b4e8674348a3"
   },
   {
    "metadata": {},
@@ -37,7 +37,7 @@
    "outputs": [],
    "execution_count": null,
    "source": "NUM_RUNS = int(os.getenv(\"NUM_RUNS\", default=25))",
-   "id": "6b372f73165d6c2d"
+   "id": "b94bc5abca6c8ce8"
   },
   {
    "metadata": {},
@@ -63,6 +63,21 @@
     "        \"date\": \"Tue Apr 23 15:17:36 2024 +0200\",\n",
     "        \"name\": \"v4.0.2\"\n",
     "    },\n",
+    "    # {\n",
+    "    #     \"sha\": \"9115580bf7c602ca3c524ad392489bd712f355da\",\n",
+    "    #     \"date\": \"Tue Feb 18 17:03:18 2025 +0100\",\n",
+    "    #     \"name\": \"v4.0.4\"\n",
+    "    # },\n",
+    "    # {\n",
+    "    #     \"sha\": \"01d4c7ae8179c7a716059552eb31865772e5a549\",\n",
+    "    #     \"date\": \"Tue Feb 18 17:11:28 2025 +0100\",\n",
+    "    #     \"name\": \"118-fix-lru-cache-in-env-loading\"\n",
+    "    # },\n",
+    "    # {\n",
+    "    #     \"sha\": \"3f905a2bc37a0cd69047513d43df1576e7ba7634\",\n",
+    "    #     \"date\": \"Mon Mar 31 11:22:49 2025 +0200\",\n",
+    "    #     \"name\": \"179-simplify-step\"\n",
+    "    # },\n",
     "    {\n",
     "        \"sha\": \"4fecd60e49dfb144b452f100ce916af2ed2a58fd\",\n",
     "        \"date\": \"Mon Mar 31 18:16:23 2025 +0200\",\n",
@@ -73,6 +88,21 @@
     "        \"date\": \"Fri May 16 16:57:14 2025 +0200\",\n",
     "        \"name\": \"v4.1.1\"\n",
     "    },\n",
+    "    # {\n",
+    "    #     \"sha\": \"8f607149e29590a5baa5211d0efd32d1858091a3\",\n",
+    "    #     \"date\": \"Fri May 16 16:57:14 2025 +0200\",\n",
+    "    #     \"name\": \"v4.2.0\"\n",
+    "    # },\n",
+    "    # {\n",
+    "    #     \"sha\": \"79c1031f4cb80e671fc6e58e9a590fd78865a4af\",\n",
+    "    #     \"date\": \"Fri May 16 16:57:14 2025 +0200\",\n",
+    "    #     \"name\": \"v4.2.1\"\n",
+    "    # },\n",
+    "    # {\n",
+    "    #     \"sha\": \"d6a69ca00bde635f78b6b45032bdcfe6d2e480aa\",\n",
+    "    #     \"date\": \"Fri May 16 16:57:14 2025 +0200\",\n",
+    "    #     \"name\": \"v4.2.2\"\n",
+    "    # },\n",
     "    {\n",
     "        \"sha\": \"189c259a8fe19266329a6826a137e1db29a12996\",\n",
     "        \"date\": \"Fri May 16 16:57:14 2025 +0200\",\n",
@@ -105,13 +135,13 @@
     "    }\n",
     "]"
    ],
-   "id": "c4daec762f3a8290"
+   "id": "dfb89da1814f5be8"
   },
   {
    "metadata": {},
    "cell_type": "markdown",
    "source": "## Run Benchmarks with Profiler",
-   "id": "bd5130f88fbb52d5"
+   "id": "6b2e7f111a99b3db"
   },
   {
    "metadata": {},
@@ -125,7 +155,7 @@
     "!git clone https://github.com/flatland-association/flatland-rl.git /tmp/flatland-rl\n",
     "!cd /tmp/flatland-rl && git clean -fdx && git reset --hard"
    ],
-   "id": "2f0333b8ed9363a5"
+   "id": "b189854fa6774382"
   },
   {
    "metadata": {},
@@ -145,7 +175,7 @@
     "        #> /tmp/out.txt && head -n 10 /tmp/out.txt\n",
     "        time.sleep(2)"
    ],
-   "id": "1b26b0a30f2c8a45"
+   "id": "a0e470530c587758"
   },
   {
    "metadata": {},
@@ -157,7 +187,7 @@
     "repo_root = os.path.dirname(os.getcwd())\n",
     "!rm -rf {repo_root}/build && find {repo_root}/flatland \\( -name '*.c' -o -name '*.so' \\) -print0 | xargs -0 rm -f"
    ],
-   "id": "392ebc36fe53dbcc"
+   "id": "4943def2c08c9224"
   },
   {
    "metadata": {},
@@ -171,13 +201,13 @@
     "    print(\"===================================================================\")\n",
     "    !export PYTHONPATH={os.path.dirname(os.getcwd())} && python ../examples/flatland_performance_profiling.py -o flatland_performance_profiling.py_LOCAL_{i}.prof"
    ],
-   "id": "c84d991606d67ab0"
+   "id": "3a16b4dcb9c9d1e6"
   },
   {
    "metadata": {},
    "cell_type": "markdown",
    "source": "### Cythonize `ext_modules` and run LOCAL_Cython",
-   "id": "679d8afe76f5f72e"
+   "id": "bcac072e6f8c31ae"
   },
   {
    "metadata": {},
@@ -190,7 +220,7 @@
     "!python -m pip install \"cython>=3.3.0a1\" \"setuptools_scm>=8\"\n",
     "!cd {repo_root} && python -c \"from setuptools import setup; setup()\" build_ext --inplace"
    ],
-   "id": "d7dc07a0cc1d79ae"
+   "id": "ff95eabfced9f3ef"
   },
   {
    "metadata": {},
@@ -215,7 +245,7 @@
     "    )\n",
     "    print(f\"verified compiled: {result.stdout.strip()}\")"
    ],
-   "id": "b7679e5c2e400ec5"
+   "id": "964b35f8b2a055b"
   },
   {
    "metadata": {},
@@ -229,7 +259,7 @@
     "    print(\"===================================================================\")\n",
     "    !export PYTHONPATH={repo_root} && python ../examples/flatland_performance_profiling.py -o flatland_performance_profiling.py_LOCAL_Cython_{i}.prof"
    ],
-   "id": "41d6e4ae6864b398"
+   "id": "4b02921f8811d0fd"
   },
   {
    "metadata": {},
@@ -240,13 +270,13 @@
     "# restore the working tree to a pure-Python state so no other loop config or downstream test picks up the compiled extension\n",
     "!rm -rf {repo_root}/build && find {repo_root}/flatland \\( -name '*.c' -o -name '*.so' \\) -print0 | xargs -0 rm -f"
    ],
-   "id": "8321a76031dd3b80"
+   "id": "cf1078b0a86a283a"
   },
   {
    "metadata": {},
    "cell_type": "markdown",
    "source": "## Analyse Profiling",
-   "id": "bab15ea3c54b77e6"
+   "id": "5819eaf582939dc5"
   },
   {
    "metadata": {},
@@ -270,7 +300,7 @@
     "            data[kk].append(s[k][i])\n",
     "    return pd.DataFrame(data)"
    ],
-   "id": "6e1ef678c38e2706"
+   "id": "dbc8fa654a7e1870"
   },
   {
    "metadata": {},
@@ -278,7 +308,7 @@
    "outputs": [],
    "execution_count": null,
    "source": "agg = {\"fn\": [\"first\"], \"sha\": [\"first\"], \"cumtime\": ['mean', 'median', 'min', 'max', 'std'], \"tottime\": ['mean', 'median', 'min', 'max', 'std']}",
-   "id": "dc2aefb1a62527f6"
+   "id": "4d4cececcc88dad4"
   },
   {
    "metadata": {},
@@ -301,7 +331,7 @@
     "    df = pd.concat(dfs)\n",
     "    return df"
    ],
-   "id": "7e87ec7358d34a8a"
+   "id": "d0053e53c8f594e1"
   },
   {
    "metadata": {},
@@ -312,7 +342,7 @@
     "# tottime is the total time spent in the function alone.\n",
     "# cumtime is the total time spent in the function plus all functions that this function called."
    ],
-   "id": "91869c01a0ef88ba"
+   "id": "219ed1ec98986613"
   },
   {
    "metadata": {},
@@ -326,7 +356,7 @@
     "        cond = cond | (df[\"fn\"] == fn) & (df[\"file\"].str.contains(file))\n",
     "    return df[cond]"
    ],
-   "id": "54d4abd646691155"
+   "id": "3b91ea545d74efbc"
   },
   {
    "metadata": {},
@@ -342,7 +372,7 @@
     "    df_[\"diff%_mean\"] = df_[\"diff_mean\"] / (df_[(\"cumtime\", \"mean\")] + df_[\"diff_mean\"]) * 100\n",
     "    return df_"
    ],
-   "id": "8ddef60ee00c4da8"
+   "id": "96751372c07c43e1"
   },
   {
    "metadata": {},
@@ -353,13 +383,13 @@
     "df_flatland_performance_profiling = aggregate(\"flatland_performance_profiling.py\")\n",
     "df_flatland_performance_profiling"
    ],
-   "id": "736203d1a574071"
+   "id": "8be1455d5bed71ae"
   },
   {
    "metadata": {},
    "cell_type": "markdown",
    "source": "### Look into overall performance",
-   "id": "ac06577cf6814496"
+   "id": "9e27013f3f9f5e76"
   },
   {
    "metadata": {},
@@ -378,13 +408,13 @@
     "ax.bar_label(ax.containers[2], fontsize=10);\n",
     "plt.savefig(\"performance_overall.png\")"
    ],
-   "id": "f78a62ab225fd165"
+   "id": "4968dd38b8b83991"
   },
   {
    "metadata": {},
    "cell_type": "markdown",
    "source": "The same data in tabular form:",
-   "id": "cce30172856fbe52"
+   "id": "b2de144a4bf79e91"
   },
   {
    "metadata": {},
@@ -392,7 +422,7 @@
    "outputs": [],
    "execution_count": null,
    "source": "analyse_df(df_flatland_performance_profiling, \"run_simulation\", \"flatland_performance_profiling.py\")",
-   "id": "40a8244056cc5a9f"
+   "id": "3d88ebd61f17a786"
   },
   {
    "metadata": {},
@@ -410,7 +440,7 @@
     "        ][\"cumtime\"].median()\n",
     "    assert median_step_local <= 1.65, f\"step() median cumtime for LOCAL regressed: {median_step_local:.3f}s > 1.65s\""
    ],
-   "id": "d9adb377d4801818"
+   "id": "8e14732748b6153c"
   },
   {
    "metadata": {},
@@ -420,7 +450,7 @@
     "- improvement of a star: https://github.com/flatland-association/flatland-rl/pull/68 (come in with v4.0.2)\n",
     "- improvement of motion check: https://github.com/flatland-association/flatland-rl/issues/6 (forthcoming)"
    ],
-   "id": "cedbb95ab9726e8c"
+   "id": "92932add15cae77e"
   },
   {
    "metadata": {},
@@ -439,7 +469,7 @@
     "#ax.bar_label(ax.containers[1], fontsize=10);\n",
     "plt.savefig(\"performance_a_star_motion_check.png\")"
    ],
-   "id": "6f85d21c0d5b5e66"
+   "id": "f45f15be55af058e"
   },
   {
    "metadata": {},
@@ -448,7 +478,7 @@
     "### Look into LRU caching speed-up\n",
     "- improvement of lru caching (came in with v4.0.0)"
    ],
-   "id": "9a034063bdd20f8"
+   "id": "f7a0981051e7c1a1"
   },
   {
    "metadata": {},
@@ -464,7 +494,7 @@
     "ax.bar_label(ax.containers[0], fontsize=10);\n",
     "plt.savefig(\"performance_lru.png\")"
    ],
-   "id": "b26d2ab6ceb6ea84"
+   "id": "48e07bc8a7689273"
   },
   {
    "metadata": {},
@@ -473,7 +503,7 @@
     "### Snakeviz of individual profiles\n",
     "Use the following line to start a snakeviz server and open a new browser window:"
    ],
-   "id": "f168e025ec133820"
+   "id": "e01d350d008f0f66"
   },
   {
    "metadata": {},
@@ -481,7 +511,7 @@
    "outputs": [],
    "execution_count": null,
    "source": "#!snakeviz \"flatland_performance_profiling.py_LOCAL_3.prof\"",
-   "id": "dfd9d3fb2d60ee6"
+   "id": "ddca0056c46cb3d9"
   },
   {
    "metadata": {},
@@ -489,7 +519,7 @@
    "outputs": [],
    "execution_count": null,
    "source": "# !snakeviz \"flatland_performance_profiling.py_4fecd60e49dfb144b452f100ce916af2ed2a58fd_3.prof\"",
-   "id": "bae951101d90d9a4"
+   "id": "fab9eb29bef22b4b"
   },
   {
    "metadata": {},
@@ -497,7 +527,7 @@
    "outputs": [],
    "execution_count": null,
    "source": "# !snakeviz \"flatland_performance_profiling.py_5a97ccb6aec2e7c6227aba8a3b33de54f567ee3a_3.prof\"",
-   "id": "7c00a324f8191b4"
+   "id": "5df0de8f55be9da6"
   }
  ],
  "metadata": {},

--- a/benchmarks/flatland_performance_profiling.ipynb
+++ b/benchmarks/flatland_performance_profiling.ipynb
@@ -1,11 +1,10 @@
 {
  "cells": [
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "39b8dd2f-247b-499c-8324-0b750a5be310",
    "metadata": {},
+   "cell_type": "code",
    "outputs": [],
+   "execution_count": null,
    "source": [
     "\n",
     "import os\n",
@@ -15,140 +14,245 @@
     "import pandas as pd\n",
     "import seaborn as sns\n",
     "from matplotlib import pyplot as plt"
-   ]
+   ],
+   "id": "dfc9cd269f567457"
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "a53a61d1-6d69-4e33-bc79-157006bd232e",
    "metadata": {},
+   "cell_type": "code",
    "outputs": [],
-   "source": [
-    "%load_ext snakeviz"
-   ]
+   "execution_count": null,
+   "source": "%load_ext snakeviz",
+   "id": "f3fd54400872c9dd"
   },
   {
+   "metadata": {},
    "cell_type": "markdown",
-   "id": "6ca1ce82-79c2-48b5-8d81-df869f6bea3c",
+   "source": "## Configuration",
+   "id": "2f914bb87e422e06"
+  },
+  {
    "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": "NUM_RUNS = int(os.getenv(\"NUM_RUNS\", default=25))",
+   "id": "6b372f73165d6c2d"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
    "source": [
-    "## Configuration"
-   ]
+    "loop = [\n",
+    "    # {\n",
+    "    #     \"sha\": \"f37c7f7947d823317651521994aaaf464e6e8dfa\",\n",
+    "    #     \"date\": \"Sat Nov 19 17:55:28 2022 +0000\",\n",
+    "    #     \"message\": \"introduce find_swaps2 - faster version of find_swaps\",\n",
+    "    #     \"name\": \"before lru\"\n",
+    "    # },\n",
+    "    # {\n",
+    "    #     \"sha\": \"45768358\",\n",
+    "    #     \"date\": \"Fri Oct 27 15:19:24 2023 +0200\",\n",
+    "    #     \"name\": \"v4.0.0\",\n",
+    "    #     \"message\": \"Release version 4.0.0\"\n",
+    "    # },\n",
+    "    {\n",
+    "        \"sha\": \"5a97ccb6aec2e7c6227aba8a3b33de54f567ee3a\",\n",
+    "        \"date\": \"Tue Apr 23 15:17:36 2024 +0200\",\n",
+    "        \"name\": \"v4.0.2\"\n",
+    "    },\n",
+    "    {\n",
+    "        \"sha\": \"4fecd60e49dfb144b452f100ce916af2ed2a58fd\",\n",
+    "        \"date\": \"Mon Mar 31 18:16:23 2025 +0200\",\n",
+    "        \"name\": \"v4.1.0\"\n",
+    "    },\n",
+    "    {\n",
+    "        \"sha\": \"04911f88f50e30188b7d671291e0c2bbe1ee5ad1\",\n",
+    "        \"date\": \"Fri May 16 16:57:14 2025 +0200\",\n",
+    "        \"name\": \"v4.1.1\"\n",
+    "    },\n",
+    "    {\n",
+    "        \"sha\": \"189c259a8fe19266329a6826a137e1db29a12996\",\n",
+    "        \"date\": \"Fri May 16 16:57:14 2025 +0200\",\n",
+    "        \"name\": \"v4.2.3\"\n",
+    "    },\n",
+    "    {\n",
+    "        \"sha\": \"dfcea58bfed32c9b549fba04a86e57a532280dc2\",\n",
+    "        \"date\": \"Fri May 16 16:57:14 2025 +0200\",\n",
+    "        \"name\": \"v4.2.4\"\n",
+    "    },\n",
+    "    {\n",
+    "        \"sha\": \"6de179e336d6d7fe40a385a90ca9d1ac328fc786\",\n",
+    "        \"date\": \"Fri May 16 16:57:14 2025 +0200\",\n",
+    "        \"name\": \"v4.2.5\"\n",
+    "    },\n",
+    "    {\n",
+    "        \"sha\": \"71e5faa53fae3a67b4dc35e504018701e1d3fe83\",\n",
+    "        \"date\": \"Tue Jun 2 09:23:04 2026 +0200\",\n",
+    "        \"name\": \"v4.2.6\"\n",
+    "    },\n",
+    "    {\n",
+    "        \"sha\": \"LOCAL\",\n",
+    "        \"date\": \"--\",\n",
+    "        \"name\": \"LOCAL\"\n",
+    "    },\n",
+    "    {\n",
+    "        \"sha\": \"LOCAL_Cython\",\n",
+    "        \"date\": \"--\",\n",
+    "        \"name\": \"LOCAL_Cython\"\n",
+    "    }\n",
+    "]"
+   ],
+   "id": "c4daec762f3a8290"
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f087ee77-cfa7-4837-aad7-aa7b545b23af",
    "metadata": {},
-   "outputs": [],
-   "source": "NUM_RUNS = int(os.getenv(\"NUM_RUNS\", default=25))"
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "953c47f0-0fe9-462f-b487-18ff68fb0cc1",
-   "metadata": {},
-   "outputs": [],
-   "source": "loop = [\n    # {\n    #     \"sha\": \"f37c7f7947d823317651521994aaaf464e6e8dfa\",\n    #     \"date\": \"Sat Nov 19 17:55:28 2022 +0000\",\n    #     \"message\": \"introduce find_swaps2 - faster version of find_swaps\",\n    #     \"name\": \"before lru\"\n    # },\n    # {\n    #     \"sha\": \"45768358\",\n    #     \"date\": \"Fri Oct 27 15:19:24 2023 +0200\",\n    #     \"name\": \"v4.0.0\",\n    #     \"message\": \"Release version 4.0.0\"\n    # },\n    {\n        \"sha\": \"5a97ccb6aec2e7c6227aba8a3b33de54f567ee3a\",\n        \"date\": \"Tue Apr 23 15:17:36 2024 +0200\",\n        \"name\": \"v4.0.2\"\n    },\n    {\n        \"sha\": \"9115580bf7c602ca3c524ad392489bd712f355da\",\n        \"date\": \"Tue Feb 18 17:03:18 2025 +0100\",\n        \"name\": \"v4.0.4\"\n    },\n    {\n        \"sha\": \"01d4c7ae8179c7a716059552eb31865772e5a549\",\n        \"date\": \"Tue Feb 18 17:11:28 2025 +0100\",\n        \"name\": \"118-fix-lru-cache-in-env-loading\"\n    },\n    {\n        \"sha\": \"3f905a2bc37a0cd69047513d43df1576e7ba7634\",\n        \"date\": \"Mon Mar 31 11:22:49 2025 +0200\",\n        \"name\": \"179-simplify-step\"\n    },\n    {\n        \"sha\": \"4fecd60e49dfb144b452f100ce916af2ed2a58fd\",\n        \"date\": \"Mon Mar 31 18:16:23 2025 +0200\",\n        \"name\": \"v4.1.0\"\n    },\n    {\n        \"sha\": \"04911f88f50e30188b7d671291e0c2bbe1ee5ad1\",\n        \"date\": \"Fri May 16 16:57:14 2025 +0200\",\n        \"name\": \"v4.1.1\"\n    },\n    {\n        \"sha\": \"8f607149e29590a5baa5211d0efd32d1858091a3\",\n        \"date\": \"Fri May 16 16:57:14 2025 +0200\",\n        \"name\": \"v4.2.0\"\n    },\n    {\n        \"sha\": \"79c1031f4cb80e671fc6e58e9a590fd78865a4af\",\n        \"date\": \"Fri May 16 16:57:14 2025 +0200\",\n        \"name\": \"v4.2.1\"\n    },\n    {\n        \"sha\": \"d6a69ca00bde635f78b6b45032bdcfe6d2e480aa\",\n        \"date\": \"Fri May 16 16:57:14 2025 +0200\",\n        \"name\": \"v4.2.2\"\n    },\n    {\n        \"sha\": \"189c259a8fe19266329a6826a137e1db29a12996\",\n        \"date\": \"Fri May 16 16:57:14 2025 +0200\",\n        \"name\": \"v4.2.3\"\n    },\n    {\n        \"sha\": \"dfcea58bfed32c9b549fba04a86e57a532280dc2\",\n        \"date\": \"Fri May 16 16:57:14 2025 +0200\",\n        \"name\": \"v4.2.4\"\n    },\n    {\n        \"sha\": \"6de179e336d6d7fe40a385a90ca9d1ac328fc786\",\n        \"date\": \"Fri May 16 16:57:14 2025 +0200\",\n        \"name\": \"v4.2.5\"\n    },\n    {\n        \"sha\": \"71e5faa53fae3a67b4dc35e504018701e1d3fe83\",\n        \"date\": \"Tue Jun 2 09:23:04 2026 +0200\",\n        \"name\": \"v4.2.6\"\n    },\n    {\n        \"sha\": \"LOCAL\",\n        \"date\": \"--\",\n        \"name\": \"LOCAL\"\n    },\n    {\n        \"sha\": \"LOCAL_Cython\",\n        \"date\": \"--\",\n        \"name\": \"LOCAL_Cython\"\n    }\n]"
-  },
-  {
    "cell_type": "markdown",
-   "id": "8af7a915-16fd-4288-8e3a-16ae820654af",
+   "source": "## Run Benchmarks with Profiler",
+   "id": "bd5130f88fbb52d5"
+  },
+  {
    "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
    "source": [
-    "## Run Benchmarks with Profiler"
-   ]
+    "# use separate location where we checkout the code version to profile\n",
+    "# hence we can control the configuration of the env in the cli in the current code relative to this notebook\n",
+    "# CAVEAT: we run the checked out code in the current env (as we run it from the notebook) - this could lead to inconsistencies in the future (discarded or updated requirements or backwards-incompatibilities of the benchmarking cli)\n",
+    "!git clone https://github.com/flatland-association/flatland-rl.git /tmp/flatland-rl\n",
+    "!cd /tmp/flatland-rl && git clean -fdx && git reset --hard"
+   ],
+   "id": "2f0333b8ed9363a5"
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "217aaf8f-371d-4d0f-9d92-edcb3a52fbf6",
    "metadata": {},
+   "cell_type": "code",
    "outputs": [],
-   "source": "# use separate location where we checkout the code version to profile\n# hence we can control the configuration of the env in the cli in the current code relative to this notebook\n# CAVEAT: we run the checked out code in the current env (as we run it from the notebook) - this could lead to inconsistencies in the future (discarded or updated requirements or backwards-incompatibilities of the benchmarking cli)\n!git clone https://github.com/flatland-association/flatland-rl.git /tmp/flatland-rl\n!cd /tmp/flatland-rl && git clean -fdx && git reset --hard"
+   "execution_count": null,
+   "source": [
+    "for i in range(NUM_RUNS):\n",
+    "    for l in loop:\n",
+    "        if l[\"name\"] in (\"LOCAL\", \"LOCAL_Cython\"):\n",
+    "            continue\n",
+    "        print(\"===================================================================\")\n",
+    "        print(f'{l[\"name\"]} - {l[\"sha\"]} - {i}')\n",
+    "        print(\"===================================================================\")\n",
+    "        !cd /tmp/flatland-rl && git checkout {l[\"sha\"]} && git log -1\n",
+    "        !export PYTHONPATH=/tmp/flatland-rl && python ../examples/flatland_performance_profiling.py -o flatland_performance_profiling.py_{l[\"name\"]}_{i}.prof\n",
+    "        #> /tmp/out.txt && head -n 10 /tmp/out.txt\n",
+    "        time.sleep(2)"
+   ],
+   "id": "1b26b0a30f2c8a45"
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "39f0ab30-e4d1-44f1-93d5-7b6ef00cb713",
    "metadata": {},
+   "cell_type": "code",
    "outputs": [],
-   "source": "for i in range(NUM_RUNS):\n    for l in loop:\n        if l[\"name\"] in (\"LOCAL\", \"LOCAL_Cython\"):\n            continue\n        print(\"===================================================================\")\n        print(f'{l[\"name\"]} - {l[\"sha\"]} - {i}')\n        print(\"===================================================================\")\n        !cd /tmp/flatland-rl && git checkout {l[\"sha\"]} && git log -1\n        !export PYTHONPATH=/tmp/flatland-rl && python ../examples/flatland_performance_profiling.py -o flatland_performance_profiling.py_{l[\"name\"]}_{i}.prof\n        #> /tmp/out.txt && head -n 10 /tmp/out.txt\n        time.sleep(2)"
+   "execution_count": null,
+   "source": [
+    "# ensure no compiled Cython artifacts remain so LOCAL (and all other non-Cython loop configs) reflect pure-Python performance\n",
+    "repo_root = os.path.dirname(os.getcwd())\n",
+    "!rm -rf {repo_root}/build && find {repo_root}/flatland \\( -name '*.c' -o -name '*.so' \\) -print0 | xargs -0 rm -f"
+   ],
+   "id": "392ebc36fe53dbcc"
   },
   {
-   "cell_type": "code",
-   "id": "ee806b56",
-   "source": "# ensure no compiled Cython artifacts remain so LOCAL (and all other non-Cython loop configs) reflect pure-Python performance\nrepo_root = os.path.dirname(os.getcwd())\n!rm -rf {repo_root}/build && find {repo_root}/flatland \\( -name '*.c' -o -name '*.so' \\) -print0 | xargs -0 rm -f",
    "metadata": {},
-   "execution_count": null,
-   "outputs": []
-  },
-  {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "54750273-0031-42a1-8422-5794e88cde4e",
-   "metadata": {},
    "outputs": [],
+   "execution_count": null,
    "source": [
     "for i in range(NUM_RUNS):\n",
     "    print(\"===================================================================\")\n",
     "    print(f'LOCAL - {i}')\n",
     "    print(\"===================================================================\")\n",
     "    !export PYTHONPATH={os.path.dirname(os.getcwd())} && python ../examples/flatland_performance_profiling.py -o flatland_performance_profiling.py_LOCAL_{i}.prof"
-   ]
+   ],
+   "id": "c84d991606d67ab0"
   },
   {
+   "metadata": {},
    "cell_type": "markdown",
-   "id": "b2ac37bc",
    "source": "### Cythonize `ext_modules` and run LOCAL_Cython",
-   "metadata": {}
+   "id": "679d8afe76f5f72e"
   },
   {
+   "metadata": {},
    "cell_type": "code",
-   "id": "04e4a5fa",
-   "source": "# cythonize + compile the ext_modules declared in pyproject.toml's [tool.setuptools] ext-modules (in-place,\n# so the .so lands next to the .py it shadows) - there is no setup.py anymore, so invoke setup() directly\n!python -m pip install \"cython>=3.3.0a1\" \"setuptools_scm>=8\"\n!cd {repo_root} && python -c \"from setuptools import setup; setup()\" build_ext --inplace",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "id": "0140aefe",
-   "source": "import subprocess\n\n# verify the ext-modules actually compiled under the same PYTHONPATH used for the LOCAL_Cython runs below —\n# pyproject.toml declares them `optional = true` (silent pure-Python fallback on missing Cython/compiler),\n# and the `!shell` build cell above doesn't raise on failure, so this is the only thing that would catch that.\nfor ext_module in (\"flatland.envs.step_utils.state_machine\", \"flatland.envs.step_utils.states\"):\n    result = subprocess.run(\n        [\"python\", \"-c\", f\"import {ext_module} as m; assert m.__file__.endswith(('.so', '.pyd')), m.__file__; print(m.__file__)\"],\n        env={**os.environ, \"PYTHONPATH\": str(repo_root)},\n        capture_output=True, text=True,\n    )\n    assert result.returncode == 0, (\n        f\"{ext_module} is not compiled (build_ext failed or fell back to pure Python):\\n\"\n        f\"{result.stdout}{result.stderr}\"\n    )\n    print(f\"verified compiled: {result.stdout.strip()}\")",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "id": "5c3361ba",
-   "source": "for i in range(NUM_RUNS):\n    print(\"===================================================================\")\n    print(f'LOCAL_Cython - {i}')\n    print(\"===================================================================\")\n    !export PYTHONPATH={repo_root} && python ../examples/flatland_performance_profiling.py -o flatland_performance_profiling.py_LOCAL_Cython_{i}.prof",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "id": "95d3fd67",
-   "source": "# restore the working tree to a pure-Python state so no other loop config or downstream test picks up the compiled extension\n!rm -rf {repo_root}/build && find {repo_root}/flatland \\( -name '*.c' -o -name '*.so' \\) -print0 | xargs -0 rm -f",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "markdown",
-   "id": "cd485f8b-83b1-4018-9b96-dd200b31194a",
-   "metadata": {},
-   "source": [
-    "## Analyse Profiling"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "14bd6a79-16c4-4fbc-8796-c4006249f21b",
-   "metadata": {},
    "outputs": [],
+   "execution_count": null,
+   "source": [
+    "# cythonize + compile the ext_modules declared in pyproject.toml's [tool.setuptools] ext-modules (in-place,\n",
+    "# so the .so lands next to the .py it shadows) - there is no setup.py anymore, so invoke setup() directly\n",
+    "!python -m pip install \"cython>=3.3.0a1\" \"setuptools_scm>=8\"\n",
+    "!cd {repo_root} && python -c \"from setuptools import setup; setup()\" build_ext --inplace"
+   ],
+   "id": "d7dc07a0cc1d79ae"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": [
+    "import subprocess\n",
+    "\n",
+    "# verify the ext-modules actually compiled under the same PYTHONPATH used for the LOCAL_Cython runs below —\n",
+    "# pyproject.toml declares them `optional = true` (silent pure-Python fallback on missing Cython/compiler),\n",
+    "# and the `!shell` build cell above doesn't raise on failure, so this is the only thing that would catch that.\n",
+    "for ext_module in (\"flatland.envs.step_utils.state_machine\", \"flatland.envs.step_utils.states\"):\n",
+    "    result = subprocess.run(\n",
+    "        [\"python\", \"-c\", f\"import {ext_module} as m; assert m.__file__.endswith(('.so', '.pyd')), m.__file__; print(m.__file__)\"],\n",
+    "        env={**os.environ, \"PYTHONPATH\": str(repo_root)},\n",
+    "        capture_output=True, text=True,\n",
+    "    )\n",
+    "    assert result.returncode == 0, (\n",
+    "        f\"{ext_module} is not compiled (build_ext failed or fell back to pure Python):\\n\"\n",
+    "        f\"{result.stdout}{result.stderr}\"\n",
+    "    )\n",
+    "    print(f\"verified compiled: {result.stdout.strip()}\")"
+   ],
+   "id": "b7679e5c2e400ec5"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": [
+    "for i in range(NUM_RUNS):\n",
+    "    print(\"===================================================================\")\n",
+    "    print(f'LOCAL_Cython - {i}')\n",
+    "    print(\"===================================================================\")\n",
+    "    !export PYTHONPATH={repo_root} && python ../examples/flatland_performance_profiling.py -o flatland_performance_profiling.py_LOCAL_Cython_{i}.prof"
+   ],
+   "id": "41d6e4ae6864b398"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": [
+    "# restore the working tree to a pure-Python state so no other loop config or downstream test picks up the compiled extension\n",
+    "!rm -rf {repo_root}/build && find {repo_root}/flatland \\( -name '*.c' -o -name '*.so' \\) -print0 | xargs -0 rm -f"
+   ],
+   "id": "8321a76031dd3b80"
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "## Analyse Profiling",
+   "id": "bab15ea3c54b77e6"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
    "source": [
     "# https://stackoverflow.com/questions/44302726/pandas-how-to-store-cprofile-output-in-a-pandas-dataframe\n",
     "def prof_to_df(st):\n",
@@ -165,24 +269,22 @@
     "        for i, kk in enumerate(keys_from_v):\n",
     "            data[kk].append(s[k][i])\n",
     "    return pd.DataFrame(data)"
-   ]
+   ],
+   "id": "6e1ef678c38e2706"
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "2a55ce17-e097-4690-96c7-f2fa8840efe0",
    "metadata": {},
+   "cell_type": "code",
    "outputs": [],
-   "source": [
-    "agg = {\"fn\": [\"first\"], \"sha\": [\"first\"], \"cumtime\": ['mean', 'median', 'min', 'max', 'std'], \"tottime\": ['mean', 'median', 'min', 'max', 'std']}"
-   ]
+   "execution_count": null,
+   "source": "agg = {\"fn\": [\"first\"], \"sha\": [\"first\"], \"cumtime\": ['mean', 'median', 'min', 'max', 'std'], \"tottime\": ['mean', 'median', 'min', 'max', 'std']}",
+   "id": "dc2aefb1a62527f6"
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "a09b686f-72a7-48fc-b164-71f5da05e105",
    "metadata": {},
+   "cell_type": "code",
    "outputs": [],
+   "execution_count": null,
    "source": [
     "def aggregate(example):\n",
     "    dfs = []\n",
@@ -198,39 +300,39 @@
     "            dfs.append(df)\n",
     "    df = pd.concat(dfs)\n",
     "    return df"
-   ]
+   ],
+   "id": "7e87ec7358d34a8a"
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "0ca28a94-94ef-4c5b-953b-527e957af71f",
    "metadata": {},
+   "cell_type": "code",
    "outputs": [],
+   "execution_count": null,
    "source": [
     "# tottime is the total time spent in the function alone.\n",
     "# cumtime is the total time spent in the function plus all functions that this function called."
-   ]
+   ],
+   "id": "91869c01a0ef88ba"
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "193ff906-8ec0-4b3b-bf0a-65cfa37a433a",
    "metadata": {},
+   "cell_type": "code",
    "outputs": [],
+   "execution_count": null,
    "source": [
     "def filter_df(df, conditions):\n",
     "    cond = False\n",
     "    for fn, file in conditions:\n",
     "        cond = cond | (df[\"fn\"] == fn) & (df[\"file\"].str.contains(file))\n",
     "    return df[cond]"
-   ]
+   ],
+   "id": "54d4abd646691155"
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "a0e26d63-e430-4f3f-83b9-9ff7a9d1e4e2",
    "metadata": {},
+   "cell_type": "code",
    "outputs": [],
+   "execution_count": null,
    "source": [
     "def analyse_df(df, fn, file, sort_by=\"cumtime\"):\n",
     "    df_ = df[(df[\"fn\"] == fn) & (df[\"file\"].str.contains(file))].groupby(\"name\").agg(agg).sort_values((sort_by, \"median\"), ascending=True)\n",
@@ -239,33 +341,31 @@
     "    df_[\"diff_mean\"] = df_[(sort_by, \"mean\")].diff().cumsum()\n",
     "    df_[\"diff%_mean\"] = df_[\"diff_mean\"] / (df_[(\"cumtime\", \"mean\")] + df_[\"diff_mean\"]) * 100\n",
     "    return df_"
-   ]
+   ],
+   "id": "8ddef60ee00c4da8"
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "151e0409-9106-4df0-b98f-bc084a6532d5",
    "metadata": {},
+   "cell_type": "code",
    "outputs": [],
+   "execution_count": null,
    "source": [
     "df_flatland_performance_profiling = aggregate(\"flatland_performance_profiling.py\")\n",
     "df_flatland_performance_profiling"
-   ]
+   ],
+   "id": "736203d1a574071"
   },
   {
+   "metadata": {},
    "cell_type": "markdown",
-   "id": "daeb7938-f6fa-4cea-93d2-d79117c21508",
-   "metadata": {},
-   "source": [
-    "### Look into overall performance"
-   ]
+   "source": "### Look into overall performance",
+   "id": "ac06577cf6814496"
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "4454d5b4-fe3d-4da2-afac-c4901585574d",
    "metadata": {},
+   "cell_type": "code",
    "outputs": [],
+   "execution_count": null,
    "source": [
     "plt.figure(figsize=(15, 8))\n",
     "ax = sns.barplot(filter_df(df_flatland_performance_profiling, [\n",
@@ -277,48 +377,56 @@
     "ax.bar_label(ax.containers[1], fontsize=10);\n",
     "ax.bar_label(ax.containers[2], fontsize=10);\n",
     "plt.savefig(\"performance_overall.png\")"
-   ]
+   ],
+   "id": "f78a62ab225fd165"
   },
   {
-   "cell_type": "markdown",
-   "id": "d52159af-4963-46e4-ab60-291ddfb1de44",
    "metadata": {},
+   "cell_type": "markdown",
+   "source": "The same data in tabular form:",
+   "id": "cce30172856fbe52"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": "analyse_df(df_flatland_performance_profiling, \"run_simulation\", \"flatland_performance_profiling.py\")",
+   "id": "40a8244056cc5a9f"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
    "source": [
-    "The same data in tabular form:"
-   ]
+    "import sys\n",
+    "\n",
+    "if sys.version_info >= (3, 12):\n",
+    "    median_step_local = df_flatland_performance_profiling[\n",
+    "        (df_flatland_performance_profiling[\"fn\"] == \"step\")\n",
+    "        & (df_flatland_performance_profiling[\"file\"].str.contains(\"rail_env.py\"))\n",
+    "        & (df_flatland_performance_profiling[\"name\"] == \"LOCAL\")\n",
+    "        ][\"cumtime\"].median()\n",
+    "    assert median_step_local <= 1.65, f\"step() median cumtime for LOCAL regressed: {median_step_local:.3f}s > 1.65s\""
+   ],
+   "id": "d9adb377d4801818"
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c5703038-6348-45ab-aff8-d994f65cb259",
    "metadata": {},
-   "outputs": [],
-   "source": "analyse_df(df_flatland_performance_profiling, \"run_simulation\", \"flatland_performance_profiling.py\")"
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "9a1d88f7-239e-4d44-868e-74a59d9227d2",
-   "metadata": {},
-   "outputs": [],
-   "source": "import sys\n\nif sys.version_info >= (3, 12):\n    median_step_local = df_flatland_performance_profiling[\n        (df_flatland_performance_profiling[\"fn\"] == \"step\")\n        & (df_flatland_performance_profiling[\"file\"].str.contains(\"rail_env.py\"))\n        & (df_flatland_performance_profiling[\"name\"] == \"LOCAL\")\n        ][\"cumtime\"].median()\n    assert median_step_local <= 1.65, f\"step() median cumtime for LOCAL regressed: {median_step_local:.3f}s > 1.65s\""
-  },
-  {
    "cell_type": "markdown",
-   "id": "620e31eb-c713-47eb-b7a1-33f2baf9b4dc",
-   "metadata": {},
    "source": [
     "### Look into `a_star()` and `find_conflicts()` in relation to `step()`\n",
     "- improvement of a star: https://github.com/flatland-association/flatland-rl/pull/68 (come in with v4.0.2)\n",
     "- improvement of motion check: https://github.com/flatland-association/flatland-rl/issues/6 (forthcoming)"
-   ]
+   ],
+   "id": "cedbb95ab9726e8c"
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "2a8ee058-4577-4533-92c8-3c50bd49c363",
    "metadata": {},
+   "cell_type": "code",
    "outputs": [],
+   "execution_count": null,
    "source": [
     "plt.figure(figsize=(15, 8))\n",
     "ax = sns.barplot(filter_df(df_flatland_performance_profiling, [\n",
@@ -330,23 +438,23 @@
     "]), x=\"name\", y=\"cumtime\", hue=\"fn\", legend=True, estimator=\"mean\")\n",
     "#ax.bar_label(ax.containers[1], fontsize=10);\n",
     "plt.savefig(\"performance_a_star_motion_check.png\")"
-   ]
+   ],
+   "id": "6f85d21c0d5b5e66"
   },
   {
-   "cell_type": "markdown",
-   "id": "a380cd51-4f73-4b11-8602-4617dc1e5c56",
    "metadata": {},
+   "cell_type": "markdown",
    "source": [
     "### Look into LRU caching speed-up\n",
     "- improvement of lru caching (came in with v4.0.0)"
-   ]
+   ],
+   "id": "9a034063bdd20f8"
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f043621b-2836-4bf0-b94c-a74cc0fc2f24",
    "metadata": {},
+   "cell_type": "code",
    "outputs": [],
+   "execution_count": null,
    "source": [
     "plt.figure(figsize=(15, 8))\n",
     "ax = sns.barplot(filter_df(df_flatland_performance_profiling, [\n",
@@ -355,67 +463,44 @@
     "]), x=\"name\", y=\"cumtime\", hue=\"fn\", legend=True, estimator=\"median\")\n",
     "ax.bar_label(ax.containers[0], fontsize=10);\n",
     "plt.savefig(\"performance_lru.png\")"
-   ]
+   ],
+   "id": "b26d2ab6ceb6ea84"
   },
   {
-   "cell_type": "markdown",
-   "id": "af48147f-f8bc-48ab-8143-28c9773bbc17",
    "metadata": {},
+   "cell_type": "markdown",
    "source": [
     "### Snakeviz of individual profiles\n",
     "Use the following line to start a snakeviz server and open a new browser window:"
-   ]
+   ],
+   "id": "f168e025ec133820"
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "48772c83-b91b-4081-a963-d1ec6a3d8622",
    "metadata": {},
+   "cell_type": "code",
    "outputs": [],
-   "source": [
-    "#!snakeviz \"flatland_performance_profiling.py_LOCAL_3.prof\""
-   ]
+   "execution_count": null,
+   "source": "#!snakeviz \"flatland_performance_profiling.py_LOCAL_3.prof\"",
+   "id": "dfd9d3fb2d60ee6"
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "a34dbed5-c3d0-49f8-afb0-389411246f8f",
    "metadata": {},
+   "cell_type": "code",
    "outputs": [],
-   "source": [
-    "# !snakeviz \"flatland_performance_profiling.py_4fecd60e49dfb144b452f100ce916af2ed2a58fd_3.prof\""
-   ]
+   "execution_count": null,
+   "source": "# !snakeviz \"flatland_performance_profiling.py_4fecd60e49dfb144b452f100ce916af2ed2a58fd_3.prof\"",
+   "id": "bae951101d90d9a4"
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "0f27b6c6-b91d-49d2-a2b6-1aecd32b68f3",
    "metadata": {},
+   "cell_type": "code",
    "outputs": [],
-   "source": [
-    "# !snakeviz \"flatland_performance_profiling.py_5a97ccb6aec2e7c6227aba8a3b33de54f567ee3a_3.prof\""
-   ]
+   "execution_count": null,
+   "source": "# !snakeviz \"flatland_performance_profiling.py_5a97ccb6aec2e7c6227aba8a3b33de54f567ee3a_3.prof\"",
+   "id": "7c00a324f8191b4"
   }
  ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.12.9"
-  }
- },
+ "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 5
 }

--- a/docker/install-build-toolchain.sh
+++ b/docker/install-build-toolchain.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -euo pipefail
+
+# Shared apt build-toolchain/utility layer for Dockerfile (published, multi-arch release image) and
+# Dockerfile.ci-env (CI-only test-dependency cache, see checks.yml's build-ci-env-ml/build-ci-env-default
+# jobs) - single source of truth so a toolchain fix needed by one image doesn't silently stay missing from
+# the other. This is exactly what happened before this file existed: Dockerfile.ci-env's base stage grew
+# gfortran/libopenblas-dev/pkg-config to fix a numpy==1.26.4 from-source build failure, but Dockerfile's own,
+# separately-maintained apt-get line never got the same fix.
+#
+# - build-essential/gfortran/libopenblas-dev/pkg-config: numpy==1.26.4 (pinned via pyproject.toml's
+#   "numpy<2" in requirements.txt/requirements-dev.txt/requirements-ml.txt alike) has no wheels for newer
+#   Pythons and builds from source - gfortran + libopenblas-dev + pkg-config are its meson build requirements
+#   (Fortran + BLAS/LAPACK backend + config lookup); meson/ninja/pybind11 themselves come from numpy's own
+#   PEP 517 build-requires via pip's build isolation, so they don't need to be installed here.
+# - ffmpeg: used by flatland's rendering code path (both at runtime for Dockerfile's users, and by
+#   Dockerfile.ci-env's rendering tests).
+# - git: Dockerfile needs it for its final `pip install git+https://...@ref` step; Dockerfile.ci-env needs
+#   it for setuptools_scm's `git describe --tags` during `pip install .` (checks.yml's test job) - without
+#   it, the failure is swallowed and surfaces as the misleading "setuptools-scm was unable to detect
+#   version" instead of a "git: command not found" (see pypa/setuptools-scm#278 for others hitting the same
+#   git-less-container symptom).
+# - curl/wget: Dockerfile fetches requirements*.txt via curl; Dockerfile.ci-env's episodes-download step
+#   (test/testml) uses wget.
+# - zip/unzip: episodes/scenario archives are unzipped inside Dockerfile.ci-env's steps; zip isn't currently
+#   exercised by either image's own RUN steps but is cheap to keep alongside unzip for symmetry.
+#
+# The Ubuntu CI runner (checks.yml's non-containerized jobs) has all of these preinstalled by default,
+# masking these requirements; neither Debian slim base here has any of them.
+apt-get update
+apt-get install -y --no-install-recommends \
+    build-essential \
+    gfortran \
+    libopenblas-dev \
+    pkg-config \
+    ffmpeg \
+    git \
+    curl \
+    wget \
+    zip \
+    unzip
+apt-get clean
+rm -rf /var/lib/apt/lists/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,9 @@ dev = [
     "snakeviz",
     "testcontainers",
     "tox",
+    # lets checks.yml's containerized jobs run `tox run -e ... --current-env` against this image's
+    # already-installed deps instead of hand-copying tox.ini's commands/set_env - see checks.yml for why.
+    "tox-current-env",
 ]
 ml = [
     "dm-tree<0.1.11,!=0.1.9", # pin dm-tree: 0.1.9 has import errors under MacOS M1 at least; <0.1.9 has no cp3.13/cp3.14 wheels, so allow up to 0.1.10 (latest) for python 3.13/3.14 support.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -46,7 +46,7 @@ build==1.5.0
     # via pip-tools
 cachetools==7.1.7
     # via tox
-certifi==2025.11.12
+certifi==2026.7.22
     # via
     #   httpcore
     #   httpx

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -46,7 +46,7 @@ build==1.5.0
     # via pip-tools
 cachetools==7.1.7
     # via tox
-certifi==2026.7.22
+certifi==2025.11.12
     # via
     #   httpcore
     #   httpx

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -522,6 +522,10 @@ tornado==6.5.7
     #   snakeviz
     #   terminado
 tox==4.58.0
+    # via
+    #   flatland-rl (pyproject.toml)
+    #   tox-current-env
+tox-current-env==0.0.17
     # via flatland-rl (pyproject.toml)
 tqdm==4.70.0
     # via flatland-rl (pyproject.toml)

--- a/tox.ini
+++ b/tox.ini
@@ -281,7 +281,7 @@ deps =
 set_env =
     {[testenv]set_env}
     PINNED_AND_DYNAMICALLY_LOADED_MODULES="cachetools|dm-tree|wandb|contourpy|scipy|rpds-py"
-    DEV_MODULES="coverage|deptry|flake8|flake8-eradicate|jupyter|jupyter-core|nbmake|notebook|pip-tools|pytest|pytest-retry|tox|testcontainers|pytest-xdist|cython"
+    DEV_MODULES="coverage|deptry|flake8|flake8-eradicate|jupyter|jupyter-core|nbmake|notebook|pip-tools|pytest|pytest-retry|tox|tox-current-env|testcontainers|pytest-xdist|cython"
 commands =
     python --version
 

--- a/tox.ini
+++ b/tox.ini
@@ -41,6 +41,10 @@ platform = linux|linux2|darwin
 deps =
     -r requirements-dev.txt
 set_env =
+    # tox does not merge a subsection's set_env with [testenv]'s - it replaces it outright - so every
+    # subsection below that needs its own extra keys (like this one) must re-pull in the base's via this
+    # substitution, or lose PYTHONPATH/CMAKE_POLICY_VERSION_MINIMUM silently.
+    {[testenv]set_env}
     BENCHMARK_EPISODES_FOLDER = {tox_root}/episodes
     # avoids a real race under -n auto on a cold checkout: concurrent xdist workers compiling+writing the
     # same module's __pycache__/*.pyc simultaneously can trigger "EOFError: marshal data too short".
@@ -52,12 +56,10 @@ commands =
 [testenv:py{3.10,3.11,3.12,3.13,3.14}-ml]
 platform = linux|linux2|darwin
 set_env =
+    {[testenv]set_env}
     BENCHMARK_EPISODES_FOLDER = {tox_root}/episodes
     # see the py{...} testenv above for why this is needed alongside -n auto.
     PYTHONDONTWRITEBYTECODE = 1
-    # some ml dependencies (e.g. dm-tree) build from source on newer Pythons and bundle very old
-    # CMakeLists.txt files; recent cmake (>=4.0) hard-errors on these unless told to allow them.
-    CMAKE_POLICY_VERSION_MINIMUM = 3.5
 deps =
     -r requirements-dev.txt
     -r requirements-ml.txt
@@ -92,6 +94,7 @@ commands =
 deps =
     -r requirements-dev.txt
 set_env =
+    {[testenv]set_env}
     PROFILING_OUTPUT_FOLDER = {work_dir}/{env_name}/log
     SCENARIOS_FOLDER = {tox_root}/scenarios
     NUM_RUNS=5
@@ -111,6 +114,7 @@ commands =
 deps =
     -r requirements-dev.txt
 set_env =
+    {[testenv]set_env}
     ECML2026_PKL = {tox_root}/level_0_scenario_1.pkl
     ECML2026_STATIONS_PKL = {tox_root}/stations.pkl
     NUM_RUNS=5
@@ -130,6 +134,7 @@ platform = linux|linux2|darwin
 deps =
     -r requirements-dev.txt
 set_env =
+    {[testenv]set_env}
     SCENARIOS_FOLDER = {tox_root}/scenarios
 commands =
     python --version
@@ -170,6 +175,7 @@ commands =
 [testenv:py{3.10,3.11,3.12,3.13,3.14}-notebooks-no-pickle]
 platform = linux|linux2|darwin
 set_env =
+    {[testenv]set_env}
     USE_PICKLE = false
 allowlist_externals =
     bash
@@ -273,11 +279,9 @@ deps =
     -r requirements-dev.txt
     -r requirements-ml.txt
 set_env =
+    {[testenv]set_env}
     PINNED_AND_DYNAMICALLY_LOADED_MODULES="cachetools|dm-tree|wandb|contourpy|scipy|rpds-py"
     DEV_MODULES="coverage|deptry|flake8|flake8-eradicate|jupyter|jupyter-core|nbmake|notebook|pip-tools|pytest|pytest-retry|tox|testcontainers|pytest-xdist|cython"
-    # some ml dependencies (e.g. dm-tree) build from source on newer Pythons and bundle very old
-    # CMakeLists.txt files; recent cmake (>=4.0) hard-errors on these unless told to allow them.
-    CMAKE_POLICY_VERSION_MINIMUM = 3.5
 commands =
     python --version
 
@@ -305,6 +309,7 @@ platform = linux|linux2|darwin
 deps =
     -r requirements-dev.txt
 set_env =
+    {[testenv]set_env}
     BENCHMARK_EPISODES_FOLDER = {tox_root}/episodes
 commands =
     python --version


### PR DESCRIPTION

## Changes
### Carried out

  | ID | Description | Category | Severity | Commit(s) |
  |---|---|---|---|---|
  | — | Cache pip-built scipy/dm-tree wheels across deptry/test/testml | ci | medium | 292bc34f |
  | — | Cache the downloaded benchmark episodes archive | ci | low | adc8f5e0 |
  | — | Fix cache-key using resolved Python patch version instead of matrix's nominal version | ci | high | fe6765f5 |
  | — | Fix pip-wheel cache race (make `test`'s cache restore-only) | ci | high | 1f0466b7 |
  | — | Build `testml`'s dependency env as a cached GHCR image (step 1) | ci | high | 99da995a |
  | — | Install cmake/git/wget/unzip in `Dockerfile.ci-env` (dm-tree build, episode download) | build | high | d5f4abd9, 9e84a9ac, d75a8381 |
  | — | Tag CI-env image by requirements hash, not commit SHA | ci | high | e5c908be → c7ec3d4e |
  | — | Skip disk cleanup/build when the image already exists | ci | medium | 4c994144 |
  | — | Bump docker/* actions past Node 20 EOL | ci | medium | 5e647155, 5e18699d, 1389bdd0 |
  | — | Extend GHCR image caching to `deptry`/`test` (step 2) | ci | high | dfbed14e | 
  | — | Containerize `examples` with the existing default-variant image | ci | medium | 5e3d6647 |
  | — | Fix `setuptools_scm` version detection in `test`'s install-verify step | build | high | 12e8bdb0, 6d173b77 |
  | — | Install `git` in the base image stage (was ml-true only) — root cause of the persistent `test` failure | build | critical | 51cc7bcd |
  | S2 | Key image tag/hash on `Dockerfile.ci-env` too, not just requirements files | ci | critical | 4eef78c5 |
  | S8 | Correct scipy/numpy attribution in `Dockerfile.ci-env` comment | docs | low | d04cb2f6 |
  | S3 | GHCR-unavailability fallback: implemented, reverted per your call, decision documented | ci | high | ebbaddfd → c4c23ff4 (net-zero) + 0e0a92aa |
  | S4 | Scheduled GHCR package retention/cleanup (`ci-env-cleanup.yml`) | ci | medium | 81d03315 |
  | S7a | Shared apt toolchain layer between `Dockerfile`/`Dockerfile.ci-env` (`docker/install-build-toolchain.sh`) | build | medium | d9d5eeaf |
  | S6 | Documented why `notebooks` isn't containerized; reframed as a deliberate decision to keep the current setup | docs | medium | 958c0e58, 91f99df8, b15030f7 |
  | — | Documented why GHCR was chosen over `actions/cache` (10GB cap vs. ~3GB per ml env) | docs | low | af93bceb |
  | S5 | Extracted `build-ci-env.yml`/`run-ci-env-test.yml` reusable workflows; containerized `publish.yml`'s test job against the same cache | ci | medium | 9f5b7f3d, 770fe9cc |
  | S7b | Documented why release images don't inherit from CI-env images | docs | low | f721cc8e |
  | S9 | Replaced with skip-if-unchanged builds (resolve-ref-to-SHA + content-hash tag + server-side retag) for `docker.yml`/`publish.yml` | ci | high | 5ebbc977 (via new `build-docker-image.yml`) |
  | — | Eliminated tox.ini/checks.yml config duplication: `deptry`/`testml`/`examples`/`test` jobs now run tox's own testenvs directly via `tox-current-env` instead of hand-copied commands/env blocks | ci | high | 2d4a1453 |
  | — | Fixed tox.ini's subenv `set_env` silently dropping inherited `PYTHONPATH`/`CMAKE_POLICY_VERSION_MINIMUM` (a pre-existing tox.ini bug exposed by the tox-current-env migration; broke the `examples` job in CI) | ci | critical | 91d1decb |
  | — | Fixed `deptry` flagging `tox-current-env` as unused (CLI-only dependency, never imported) | ci | low | 880fae11 |
  | — | Documented the tox.ini/checks.yml single-source-of-truth relationship and its two tox.ini gotchas in CLAUDE.md | docs | low | 8d4087ee |
  | — | Root-caused and fixed the CI-only py3.10 numpy-dtype-taint bug (`test_diamond_crossing_...`); CI confirmed green | bug | critical | 3 commits, now isolated on `fix-py310-numpy-dtype` |
  | — | Extracted the py310 fix onto its own branch; rebased `466-cleanup-ci` on top (verified byte-identical resulting tree) | chore | — | git history restructuring, no new commit content |
  
  ### Remaining
  
  | ID | Description | Category | Severity | Commit message |
  |---|---|---|---|---|
  | S4.2 | Confirm the GHCR package's "Manage Actions access" grants this repo Admin (or supply a PAT) so `actions/delete-package-versions` can actually delete | ci | medium | — (a settings check, not a code change) |
  | S9-follow-up | Extend `docker.yml`'s Python matrix from `["3.12"]` to 3.10–3.14 — cheaper now thanks to S9's skip-if-unchanged logic | ci | low | ci(docker): extend docker-publish matrix to full supported Python range |

## Related issues

Closes #466 

## Checklist

- [ ] Tests are included for relevant behavior changes.
- [ ] Documentation is added in the [flatland-book](https://github.com/flatland-association/flatland-book) repo for relevant behavior changes.
- [ ] If you made important user-facing changes, describe them under the `[Unreleased]` tag in `CHANGELOG.md`.
- [ ] New package dependencies are declared in the `pyproject.toml` file.
  Requirement files have been updated by running `tox -e requirements`.
- [ ] Code works with all supported Python versions (3.10, 3.11, 3.12 and 3.13). Checks run with all supported version and are
  required to run successfully.
- [ ] Code is formatted according to PEP 8 (an IDE like PyCharm can do this for you).
- [ ] Technical guidelines listed in `CONTRIBUTING.md` are followed.
