### PR TITLE
fix(persistence): keep serialized agent.targets hashable for older readers.

### DIFF
--- a/flatland/envs/persistence.py
+++ b/flatland/envs/persistence.py
@@ -18,7 +18,7 @@ from flatland.envs import rail_env
 from flatland.envs.step_utils import env_utils
 from flatland.utils.seeding import random_state_to_hashablestate
 from flatland.core.env_observation_builder import DummyObservationBuilder, ObservationBuilder
-from flatland.envs.agent_utils import EnvAgent, load_env_agent
+from flatland.envs.agent_utils import Agent, EnvAgent, load_env_agent
 
 # cannot import objects / classes directly because of circular import
 from flatland.envs import malfunction_generators as mal_gen
@@ -26,6 +26,32 @@ from flatland.envs import rail_generators as rail_gen
 from flatland.envs import line_generators as line_gen
 from flatland.envs import timetable_generators as tt_gen
 from flatland.envs import malfunction_effects_generators as mal_eff_gen
+
+
+def _serialize_agent(agent: EnvAgent) -> Agent:
+    """
+    `EnvAgent.to_agent()` puts a raw `set` in `targets`, which is unhashable to any `flatland-rl` older than
+    the `Agent.target` -> `Agent.targets` rename (that old code still expects a bare `(row, col)` position in
+    that slot and does `{(agent_tuple.target, d) for d in Grid4TransitionsEnum}` on it unconditionally). A
+    tuple is equally lossless but hashable everywhere.
+    """
+    agent_tuple = agent.to_agent()
+    return agent_tuple._replace(targets=tuple(sorted(agent_tuple.targets)))
+
+
+def _deserialize_agent_tuple(agent_tuple: Agent) -> Agent:
+    """
+    Undo `_serialize_agent`'s tuple encoding before handing off to `load_env_agent`, which otherwise only
+    recognizes a `set`/`frozenset` of configurations (or, for legacy pre-`targets` pickles, a bare
+    `(row, col)` position - left untouched here). Discriminate structurally rather than by scalar type, since
+    legacy pickles hold `numpy.int32` row/col values, not plain `int`s: a bare position's first element is a
+    scalar, whereas a tuple of `(position, direction)` pairs has a `tuple` as its first element.
+    """
+    targets = agent_tuple.targets
+    is_legacy_bare_position = isinstance(targets, tuple) and len(targets) == 2 and not isinstance(targets[0], tuple)
+    if isinstance(targets, (tuple, list)) and not is_legacy_bare_position:
+        agent_tuple = agent_tuple._replace(targets=set(targets))
+    return agent_tuple
 
 
 class RailEnvPersister(object):
@@ -230,7 +256,7 @@ class RailEnvPersister(object):
             # remove the legacy key
             del env_dict["agents_static"]
         elif "agents" in env_dict:
-            env_dict["agents"] = [load_env_agent(d, env.rail) for d in env_dict["agents"]]
+            env_dict["agents"] = [load_env_agent(_deserialize_agent_tuple(d), env.rail) for d in env_dict["agents"]]
 
         # Initialise the env with the frozen agents in the file
         env.agents = env_dict.get("agents", [])
@@ -346,7 +372,7 @@ class RailEnvPersister(object):
         grid_data = env.rail.grid.tolist()
 
         # msgpack cannot persist EnvAgent so use the Agent namedtuple.
-        agent_data = [agent.to_agent() for agent in env.agents]
+        agent_data = [_serialize_agent(agent) for agent in env.agents]
         malfunction_data: mal_gen.MalfunctionProcessData = env.malfunction_process_data
 
         effects_generator = env.effects_generator.__getstate__()

--- a/tests/test_flatland_envs_persistence.py
+++ b/tests/test_flatland_envs_persistence.py
@@ -6,6 +6,7 @@ import numpy as np
 import pytest
 
 from flatland.core.effects_generator import EffectsGenerator, find_all_effects_generators, find_effects_generator
+from flatland.core.grid.grid4 import Grid4TransitionsEnum
 from flatland.core.env_observation_builder import DummyObservationBuilder
 from flatland.env_generation.env_generator import env_generator_legacy
 from flatland.envs.line_generators import sparse_line_generator
@@ -380,3 +381,48 @@ def test_set_full_state_legacy_flat_waypoints():
 
     # must not raise - Rewards._sanitize_waypoints() assumes every waypoints entry is a list.
     Rewards._sanitize_waypoints(agent.waypoints)
+
+
+def test_get_full_state_targets_hashable_for_legacy_readers():
+    """
+    Regression test for the `TypeError: unhashable type: 'set'` crash seen when a `flatland-rl` older than the
+    `Agent.target` -> `Agent.targets` rename (PR #479) loads a trajectory persisted by a newer one: old code's
+    `load_env_agent` unconditionally does `{(agent_tuple.target, d) for d in Grid4TransitionsEnum}`, assuming
+    that slot is always a bare, hashable `(row, col)` position. `_serialize_agent` must keep it hashable (a
+    tuple, not a `set`) so that exact expression - the old reader's code, verbatim - does not raise, even
+    though the slot's meaning has changed to a full configuration set.
+    """
+    rail, rail_map, optionals = make_simple_rail()
+    env = RailEnv(width=rail_map.shape[1], height=rail_map.shape[0], rail_generator=rail_from_grid_transition_map(rail, optionals),
+                  line_generator=sparse_line_generator(), number_of_agents=2)
+    env.reset(False, False)
+
+    env_dict = RailEnvPersister.get_full_state(env)
+
+    for agent_tuple in env_dict["agents"]:
+        assert isinstance(agent_tuple.targets, tuple)
+        # the exact expression from the pre-#479 `load_env_agent` - must not raise TypeError: unhashable type: 'set'
+        legacy_exploded = {(agent_tuple.targets, d) for d in Grid4TransitionsEnum}
+        assert len(legacy_exploded) == len(Grid4TransitionsEnum)
+
+
+def test_persistence_roundtrip_multi_direction_targets():
+    """
+    Regression test: an env round-tripped through `RailEnvPersister.save`/`load_new` (`.pkl`) must preserve a
+    target cell's full set of valid arrival directions, not just one - `_serialize_agent`/`_deserialize_agent_tuple`
+    must not lose information while making the on-disk `targets` representation hashable.
+    """
+    rail, rail_map, optionals = make_simple_rail()
+    env_initial = RailEnv(width=rail_map.shape[1], height=rail_map.shape[0], rail_generator=rail_from_grid_transition_map(rail, optionals),
+                          line_generator=sparse_line_generator(), number_of_agents=2)
+    env_initial.reset(False, False)
+
+    targets_initial = [set(agent.targets) for agent in env_initial.agents]
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        filename = os.path.join(tmpdir, "test_roundtrip_multi_direction_targets.pkl")
+        RailEnvPersister.save(env_initial, filename)
+        env_loaded, _ = RailEnvPersister.load_new(filename)
+
+    targets_loaded = [set(agent.targets) for agent in env_loaded.agents]
+    assert targets_loaded == targets_initial


### PR DESCRIPTION




## Changes
* fix(persistence): keep serialized agent targets hashable for older readers Agent.targets changed from a bare position to a full configuration set in the same tuple slot (#479), but readers older than that change still unconditionally build a hashable tuple around whatever is in that slot - a raw set there raises TypeError: unhashable type: 'set'. Serialize it as a tuple instead (equally lossless, hashable everywhere), converting back to a set on load.



## Related issues

Follow-up of https://github.com/flatland-association/flatland-rl/pull/479 and https://github.com/flatland-association/ai4realnet-orchestrators/pull/48/checks

Downstream validations: https://github.com/flatland-association/flatland-benchmarks/pull/690 https://github.com/flatland-association/ai4realnet-orchestrators/pull/48


## Checklist

- [ ] Tests are included for relevant behavior changes.
- [ ] Documentation is added in the [flatland-book](https://github.com/flatland-association/flatland-book) repo for relevant behavior changes.
- [ ] If you made important user-facing changes, describe them under the `[Unreleased]` tag in `CHANGELOG.md`.
- [ ] New package dependencies are declared in the `pyproject.toml` file.
  Requirement files have been updated by running `tox -e requirements`.
- [ ] Code works with all supported Python versions (3.10, 3.11, 3.12 and 3.13). Checks run with all supported version and are
  required to run successfully.
- [ ] Code is formatted according to PEP 8 (an IDE like PyCharm can do this for you).
- [ ] Technical guidelines listed in `CONTRIBUTING.md` are followed.
