### PR TITLE
fix(tests): de-flake test_env_generator_no_seed.

### DIFF
--- a/flatland/core/grid/grid4.py
+++ b/flatland/core/grid/grid4.py
@@ -35,6 +35,7 @@ def fast_grid4_get_transition(cell_transition, orientation, direction):
 
 @lru_cache(maxsize=128)
 def fast_grid4_set_transitions(cell_transition, orientation, new_transitions):
+    cell_transition = int(cell_transition)
     mask = (1 << ((4 - orientation) * 4)) - (1 << ((3 - orientation) * 4))
     negmask = ~mask
 
@@ -54,6 +55,7 @@ def fast_grid4_remove_deadends(cell_transition):
     """
     Remove all turn-arounds (e.g. N-S, S-N, E-W,...).
     """
+    cell_transition = int(cell_transition)
     maskDeadEnds = Grid4Transitions.maskDeadEnds()
     cell_transition &= cell_transition & (~maskDeadEnds) & 0xffff
     return cell_transition

--- a/tests/test_random_seeding.py
+++ b/tests/test_random_seeding.py
@@ -264,11 +264,20 @@ def test_env_generator_no_seed():
     `env_generator` without `seed` nor `post_seed` behaves
     - non-deterministically for rail generation
     - non-deterministically for initialization of env's random state
+
+    N.B. `sparse_rail_generator`'s default city placement occasionally falls back to a
+    deterministic layout (`SparseRailGen._generate_evenly_distr_city_positions`), so a single
+    pair of draws can rarely collide by chance. Draw several samples and require variation
+    across them instead of asserting inequality on just one pair.
     """
-    env_generated_1, _, _ = env_generator()
-    env_generated_2, _, _ = env_generator()
-    assert not (env_generated_1.rail.grid == env_generated_2.rail.grid).all()
-    assert not (env_generated_1.np_random.get_state()[1] == env_generated_2.np_random.get_state()[1]).all()
+    grids = []
+    random_states = []
+    for _ in range(8):
+        env_generated, _, _ = env_generator()
+        grids.append(str(env_generated.rail.grid.tolist()))
+        random_states.append(str(env_generated.np_random.get_state()[1].tolist()))
+    assert len(set(grids)) > 1
+    assert len(set(random_states)) > 1
 
 
 def test_env_generator_no_seed_but_post_seed():


### PR DESCRIPTION

## Changes

  ## Carried out

  | ID | Description | Category | Severity | Commit(s) |
  |---|---|---|---|---|
  | — | De-flake `test_env_generator_no_seed`: sample 8 draws and require variation across them, instead of asserting inequality on a single pair, since `sparse_rail_generator`'s default city placement can rarely collapse to a deterministic fallback and collide by chance | Test flakiness | Medium | 3cef55d3 |
  | — | Cast `cell_transition` to plain `int` in `fast_grid4_set_transitions`/`fast_grid4_remove_deadends`, closing a numpy-dtype leak these two module-level `lru_cache`s were missed by in the original b41a9643 fix | Bug fix | Medium | 2500a5bf |
  
  ## Remaining
  
  | ID | Description | Category | Severity | Commit message |
  |---|---|---|---|---|
  | — | `EnvAgent.old_position`/`old_direction` setters skip `_sanitize_configuration`, unlike `position`/`direction`/`initial_position`/`initial_direction` — inconsistent boundary, no live failure yet but a future raw-value assignment would reintroduce numpy-dtype taint | Bug fix | Low | fix(core): sanitize old_position/old_direction setters in EnvAgent |
  | — | `ray_policy_wrapper`'s action sampling (`flatland/ml/ray/wrappers.py`) uses global `np.random.choice` instead of a seeded/env RNG, breaking reproducibility of replayed checkpoints against seeded envs | Bug fix | Medium | fix(ml): seed ray_policy_wrapper action sampling instead of using global RNG |

## Related issues

Link to every issue from the issue tracker (if any) you addressed in this PR.

## Checklist

- [ ] Tests are included for relevant behavior changes.
- [ ] Documentation is added in the [flatland-book](https://github.com/flatland-association/flatland-book) repo for relevant behavior changes.
- [ ] If you made important user-facing changes, describe them under the `[Unreleased]` tag in `CHANGELOG.md`.
- [ ] New package dependencies are declared in the `pyproject.toml` file.
  Requirement files have been updated by running `tox -e requirements`.
- [ ] Code works with all supported Python versions (3.10, 3.11, 3.12 and 3.13). Checks run with all supported version and are
  required to run successfully.
- [ ] Code is formatted according to PEP 8 (an IDE like PyCharm can do this for you).
- [ ] Technical guidelines listed in `CONTRIBUTING.md` are followed.
