### PR TITLE
fix(ci): verify CI-env image is pullable, not just that its manifest …

### DIFF
--- a/.github/workflows/build-ci-env.yml
+++ b/.github/workflows/build-ci-env.yml
@@ -83,12 +83,23 @@ jobs:
                     fi
             # Lets everything below skip the disk-space dance (and the build itself) when this exact
             # (python-version, variant, hash) combination was already built and pushed - most runs, once the
-            # cache is warm, since requirements change far less often than commits.
+            # cache is warm, since requirements change far less often than commits. A manifest reference
+            # existing isn't enough on its own to prove that: GHCR can end up with a dangling manifest whose
+            # blobs were garbage-collected out from under it (observed in practice - ci-env-cleanup.yml's
+            # "delete untagged versions" step deleting a version that turned out to share blobs with a still-
+            # tagged manifest), which `imagetools inspect` alone can't detect since it only fetches the
+            # manifest JSON, not the blobs it references. Actually pulling is the same operation the
+            # downstream test/examples/deptry/testml jobs need to succeed, so it's what actually proves the
+            # image is usable - if the pull fails, this falls through to a real rebuild+push below instead of
+            # leaving a broken tag for those jobs to discover later. The pulled image is removed immediately
+            # after, since this job doesn't otherwise need it.
             -   name: Check if CI-env image already exists
                 id: image-exists
                 run: |
-                    if docker buildx imagetools inspect "${{ steps.image-name.outputs.IMAGE_NAME }}:py${{ inputs.python-version }}-${{ steps.variant.outputs.name }}-${{ steps.image-hash.outputs.hash }}" > /dev/null 2>&1; then
+                    IMAGE="${{ steps.image-name.outputs.IMAGE_NAME }}:py${{ inputs.python-version }}-${{ steps.variant.outputs.name }}-${{ steps.image-hash.outputs.hash }}"
+                    if docker buildx imagetools inspect "$IMAGE" > /dev/null 2>&1 && docker pull "$IMAGE" > /dev/null 2>&1; then
                         echo "exists=true" >> "$GITHUB_OUTPUT"
+                        docker rmi "$IMAGE" > /dev/null 2>&1 || true
                     else
                         echo "exists=false" >> "$GITHUB_OUTPUT"
                     fi

--- a/.github/workflows/ci-env-cleanup.yml
+++ b/.github/workflows/ci-env-cleanup.yml
@@ -17,20 +17,20 @@ jobs:
         permissions:
             packages: write
         steps:
-            # Untagged versions are always safe to remove here: build-ci-env-ml/-default never re-push an
-            # already-existing runnable tag (their "Check if CI-env image already exists" step skips the
-            # build entirely in that case), so a given tag is pushed exactly once. The only way a version
-            # becomes untagged is BuildKit's cache-to (mode=max) overwriting cache-py{version}-{ml,default}
-            # in place, leaving its previous manifest dangling. Dockerfile.ci-env only ever builds
-            # linux/amd64 (no multi-arch manifest lists), so there's no risk of this deleting a still-
-            # referenced per-platform child of a tagged multi-arch image.
-            -   name: Delete untagged versions
-                uses: actions/delete-package-versions@v5
-                with:
-                    package-name: flatland-rl-ci-env
-                    package-type: container
-                    delete-only-untagged-versions: true
-                    token: ${{ secrets.GITHUB_TOKEN }}
+            # Deliberately does NOT delete untagged versions, despite BuildKit's cache-to (mode=max)
+            # overwriting cache-py{version}-{ml,default} in place leaving its previous manifest dangling as
+            # one. This used to run `delete-package-versions --delete-only-untagged-versions=true` on the
+            # assumption that an untagged manifest can never be depended on by anything else - but GHCR
+            # doesn't guarantee that layer blobs are exclusive to the manifest "owning" them: deleting an
+            # untagged version can garbage-collect a blob a *different*, still-tagged manifest also
+            # references. That's what broke py3.11-default-<hash> in practice - its manifest reference kept
+            # resolving fine (`imagetools inspect` only fetches the manifest JSON), but the image was no
+            # longer actually pullable, and nothing here could tell which untagged version was safe to
+            # remove and which wasn't. build-ci-env.yml's own existence check now verifies pullability, not
+            # just manifest presence, so a recurrence would self-heal there instead of silently breaking a
+            # tag - but that doesn't make deleting untagged versions safe again, so it stays removed. Untagged
+            # cache-manifest orphans are left to accumulate: unlike actions/cache, GHCR has no hard quota
+            # forcing eviction (see build-ci-env.yml's own comment on why GHCR was chosen for that reason).
             # Flat count across the whole package, not grouped per (python-version, variant): the action
             # doesn't support grouping, and since a single requirements/Dockerfile change tends to bump most
             # of build-ci-env-ml/-default's 10 (5 versions x 2 variants) tags at once, 30 is roughly 3


### PR DESCRIPTION

## Changes

  | ID | Description | Category | Severity | Commit(s) |
  |---|---|---|---|---|
  | — | Verify the CI-env image is actually pullable (not just that its manifest reference exists) before skipping a rebuild, so a GHCR manifest left dangling by garbage-collected blobs self-heals via a real rebuild+push instead of leaving a broken tag for downstream test/examples/deptry/testml jobs to hit | ci | high | 8b829b01 |
  | — | Stop the weekly cleanup workflow from deleting untagged GHCR package versions, since GHCR doesn't guarantee layer blobs are exclusive to the manifest that "owns" them - this was the actual mechanism that broke py3.11-default-fc049e96... by garbage-collecting a blob a still-tagged manifest also referenced | ci | high | 10d45e3e |

## Related issues

Link to every issue from the issue tracker (if any) you addressed in this PR.

## Checklist

- [ ] Tests are included for relevant behavior changes.
- [ ] Documentation is added in the [flatland-book](https://github.com/flatland-association/flatland-book) repo for relevant behavior changes.
- [ ] If you made important user-facing changes, describe them under the `[Unreleased]` tag in `CHANGELOG.md`.
- [ ] New package dependencies are declared in the `pyproject.toml` file.
  Requirement files have been updated by running `tox -e requirements`.
- [ ] Code works with all supported Python versions (3.10, 3.11, 3.12 and 3.13). Checks run with all supported version and are
  required to run successfully.
- [ ] Code is formatted according to PEP 8 (an IDE like PyCharm can do this for you).
- [ ] Technical guidelines listed in `CONTRIBUTING.md` are followed.
