### PR TITLE
fix(ci): push docker images tagged with release version.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -212,9 +212,14 @@ jobs:
                     fi
 
     # See build-docker-image.yml (shared with docker.yml's own docker-publish job) for the actual
-    # build/skip-if-unchanged/retag logic. No explicit `if:` needed here - resolve-docker-publish-ref being
-    # skipped already propagates via the default needs-implies-success() condition.
+    # build/skip-if-unchanged/retag logic. Needs its own explicit guard here (same reasoning as
+    # publish-test-pypi's above): the implicit needs-success() check walks the *whole* transitive
+    # ancestor chain, not just the direct `resolve-docker-publish-ref` need - so on a real release
+    # (a push event), publish-test-pypi being skipped by design would poison this job too, one hop
+    # further out through resolve-docker-publish-ref, silently skipping the Docker publish on every
+    # release (confirmed: this is exactly what happened for the 4.3.0 release).
     docker-publish:
+        if: ${{ !failure() && !cancelled() && needs.resolve-docker-publish-ref.result == 'success' }}
         needs: [ resolve-docker-publish-ref ]
         strategy:
             fail-fast: false


### PR DESCRIPTION


## Changes

| ID | Description | Category | Severity | Commit(s) |
  |---|---|---|---|---|
  | — | Add explicit `!failure() && !cancelled() && needs.resolve-docker-publish-ref.result == 'success'` guard to `docker-publish` in publish.yml, since the default `needs`-implies-`success()` check walks the whole transitive  ancestor chain (through `resolve-docker-publish-ref` → `publish-test-pypi`), so `publish-test-pypi` being skipped-by-design on every real (push-triggered) release silently skipped `docker-publish` too — exactly what happened for  the 4.3.0 release, where the `v4.3.0-py3.12`/`-ml` images were never pushed to GHCR | Fix | High | 77143f6d100c6e367998d1f3bd0091898cfaa725 |




## Related issues

Follow-up of  https://github.com/flatland-association/flatland-rl/pull/490

Link to every issue from the issue tracker (if any) you addressed in this PR.

## Checklist

- [ ] Tests are included for relevant behavior changes.
- [ ] Documentation is added in the [flatland-book](https://github.com/flatland-association/flatland-book) repo for relevant behavior changes.
- [ ] If you made important user-facing changes, describe them under the `[Unreleased]` tag in `CHANGELOG.md`.
- [ ] New package dependencies are declared in the `pyproject.toml` file.
  Requirement files have been updated by running `tox -e requirements`.
- [ ] Code works with all supported Python versions (3.10, 3.11, 3.12 and 3.13). Checks run with all supported version and are
  required to run successfully.
- [ ] Code is formatted according to PEP 8 (an IDE like PyCharm can do this for you).
- [ ] Technical guidelines listed in `CONTRIBUTING.md` are followed.
