### PR TITLE
refactor!: D2.2 agents live on "edges" aka. configuration.

### DIFF
--- a/flatland/envs/agent_utils.py
+++ b/flatland/envs/agent_utils.py
@@ -239,6 +239,13 @@ class EnvAgent(Generic[EntryPoint]):
     old_entry_point = attrib(type=Optional[EntryPoint], default=Factory(lambda: None),
                              converter=_sanitize_entry_point)
 
+    # transient per-step scratch value: the entry point `RailEnv.step()` computed for this agent this step
+    # (independent of motion-check conflict resolution) - written in step()'s first per-agent loop, consumed
+    # in its second once conflicts are resolved. Not part of `Agent`/`to_agent()`: it is recomputed from
+    # scratch every step, never meaningful across a save/load boundary.
+    next_entry_point = attrib(type=Optional[EntryPoint], default=Factory(lambda: None),
+                              converter=_sanitize_entry_point)
+
     def reset(self):
         """
         Resets the agents to their initial values of the episode. Called after ScheduleTime generation.
@@ -246,6 +253,7 @@ class EnvAgent(Generic[EntryPoint]):
         self.current_entry_point = None
         self.old_entry_point = None
         self.target_entry_point = None
+        self.next_entry_point = None
         self.moving = False
         self.arrival_time = None
 

--- a/flatland/envs/persistence.py
+++ b/flatland/envs/persistence.py
@@ -298,7 +298,7 @@ class RailEnvPersister(object):
         if dev_obs_dict_ is not None:
             env.dev_obs_dict = dev_obs_dict_
 
-        env.temp_transition_data = {i: env_utils.AgentTransitionData(None, None, None, None, None) for i in range(env.get_num_agents())}
+        env.temp_transition_data = {i: env_utils.AgentTransitionData(None, None, None, None) for i in range(env.get_num_agents())}
         for i_agent in range(env.get_num_agents()):
             env.temp_transition_data[i_agent].state_transition_signal = StateTransitionSignals()
 

--- a/flatland/envs/rail_env.py
+++ b/flatland/envs/rail_env.py
@@ -224,7 +224,7 @@ class AbstractRailEnv(Environment, Generic[UnderlyingTransitionMap, UnderlyingRe
         else:
             self.effects_generator = make_multi_effects_generator(effects_generator, mf)
 
-        self.temp_transition_data = {i: env_utils.AgentTransitionData(None, None, None, None, None) for i in range(self.get_num_agents())}
+        self.temp_transition_data = {i: env_utils.AgentTransitionData(None, None, None, None) for i in range(self.get_num_agents())}
         for i_agent in range(self.get_num_agents()):
             self.temp_transition_data[i_agent].state_transition_signal = StateTransitionSignals()
 
@@ -352,7 +352,7 @@ class AbstractRailEnv(Environment, Generic[UnderlyingTransitionMap, UnderlyingRe
         # Empty the episode store of agent positions
         self.cur_episode = []
 
-        self.temp_transition_data = {i: env_utils.AgentTransitionData(None, None, None, None, None) for i in range(self.get_num_agents())}
+        self.temp_transition_data = {i: env_utils.AgentTransitionData(None, None, None, None) for i in range(self.get_num_agents())}
         for i_agent in range(self.get_num_agents()):
             self.temp_transition_data[i_agent].state_transition_signal = StateTransitionSignals()
 
@@ -542,7 +542,7 @@ class AbstractRailEnv(Environment, Generic[UnderlyingTransitionMap, UnderlyingRe
             self.temp_transition_data[i_agent].speed = agent.speed_counter.speed
             self.temp_transition_data[i_agent].current_resource = current_resource
 
-            self.temp_transition_data[i_agent].new_entry_point = new_entry_point
+            agent.next_entry_point = new_entry_point
             self.temp_transition_data[i_agent].new_speed = new_speed
 
             self.motion_check.add_agent(i_agent, current_resource, new_resource)
@@ -571,7 +571,7 @@ class AbstractRailEnv(Environment, Generic[UnderlyingTransitionMap, UnderlyingRe
             # - inside cell or at end of cell and no conflict with other trains and
             # TODO https://github.com/flatland-association/flatland-rl/issues/178 revise design (D2a): distinguish forced stop (motion check or invalid action)
             movement_allowed = action_valid and (
-                (agent.state.is_on_map_state() and agent.current_entry_point == agent_transition_data.new_entry_point) or motion_check)
+                (agent.state.is_on_map_state() and agent.current_entry_point == agent.next_entry_point) or motion_check)
 
             agent_transition_data.state_transition_signal.movement_allowed = movement_allowed
 
@@ -581,7 +581,7 @@ class AbstractRailEnv(Environment, Generic[UnderlyingTransitionMap, UnderlyingRe
 
             # (10a) POSITION UPDATE
             if agent.state == TrainState.MOVING:
-                agent.current_entry_point = _sanitize_entry_point(agent_transition_data.new_entry_point)
+                agent.current_entry_point = _sanitize_entry_point(agent.next_entry_point)
                 agent.state_machine.update_if_reached(agent.current_entry_point, agent.targets)
             # TODO https://github.com/flatland-association/flatland-rl/issues/280 revise design: condition could be generalized to not MOVING if we would enforce MALFUNCTION_OFF_MAP to go to READY_TO_DEPART first.
             elif agent.state_machine.previous_state == TrainState.MALFUNCTION_OFF_MAP and agent.state == TrainState.STOPPED:
@@ -594,7 +594,7 @@ class AbstractRailEnv(Environment, Generic[UnderlyingTransitionMap, UnderlyingRe
                 # TODO https://github.com/flatland-association/flatland-rl/issues/280 revise design (D3) speed off map is 0 (changes behaviour when not full acceleration delta)
                 if not (agent.state_machine.previous_state == TrainState.READY_TO_DEPART or
                         agent.state_machine.previous_state == TrainState.MALFUNCTION_OFF_MAP):
-                    crossing_completed = (current_or_initial_entry_point != agent_transition_data.new_entry_point) and motion_check
+                    crossing_completed = (current_or_initial_entry_point != agent.next_entry_point) and motion_check
                     # TODO simplify
                     speed = agent_transition_data.new_speed if agent.state == TrainState.MOVING else Fraction(0)
                     agent.speed_counter.step(speed=speed, crossing_completed=crossing_completed)

--- a/flatland/envs/step_utils/env_utils.py
+++ b/flatland/envs/step_utils/env_utils.py
@@ -9,7 +9,6 @@ from flatland.envs.step_utils.states import StateTransitionSignals
 class AgentTransitionData:
     """ Class for keeping track of temporary agent data for position update """
     speed: Fraction
-    new_entry_point: Tuple[Tuple[int, int], int]
     new_speed: Fraction
     current_resource: Tuple[int, int]
     state_transition_signal: StateTransitionSignals

--- a/tests/test_rewards.py
+++ b/tests/test_rewards.py
@@ -203,7 +203,7 @@ def test_rewards_intermediate_served_and_stopped_multiple_times_but_late_arrival
     agent.old_entry_point = ((4, 4), 0)
     agent.current_entry_point = ((2, 2), 2)
     agent.state = TrainState.STOPPED
-    assert rewards.step_reward(agent, AgentTransitionData(Fraction(0), None, None, None, None), distance_map, 15) == rewards.empty()
+    assert rewards.step_reward(agent, AgentTransitionData(Fraction(0), None, None, None), distance_map, 15) == rewards.empty()
 
     # end of episode reward while done
     agent.state = TrainState.DONE
@@ -230,7 +230,7 @@ def test_rewards_intermediate_served_and_stopped_multiple_times_but_late_arrival
     agent.old_entry_point = ((4, 4), 0)
     agent.current_entry_point = ((2, 2), 2)
     agent.state = TrainState.STOPPED
-    assert rewards.step_reward(agent, AgentTransitionData(Fraction(0), None, None, None, None), distance_map, 15) == rewards.empty()
+    assert rewards.step_reward(agent, AgentTransitionData(Fraction(0), None, None, None), distance_map, 15) == rewards.empty()
 
     # end of episode reward while done
     agent.state = TrainState.DONE
@@ -365,7 +365,7 @@ def test_rewards_departed_but_never_arrived():
     agent.old_entry_point = ((0, 0), 0)
     agent.current_entry_point = ((2, 2), 2)
     agent.state = TrainState.STOPPED
-    rewards.step_reward(agent=agent, agent_transition_data=AgentTransitionData(0.5, None, None, None, StateTransitionSignals()),
+    rewards.step_reward(agent=agent, agent_transition_data=AgentTransitionData(0.5, None, None, StateTransitionSignals()),
                         distance_map=distance_map,
                         elapsed_steps=5)
     assert rewards.end_of_episode_reward(agent, distance_map, elapsed_steps=25) == -99 - 15
@@ -389,7 +389,7 @@ def test_rewards_departed_but_never_arrived_minimum_penalty():
     agent.old_entry_point = ((0, 0), 0)
     agent.current_entry_point = ((2, 2), 2)
     agent.state = TrainState.STOPPED
-    rewards.step_reward(agent=agent, agent_transition_data=AgentTransitionData(0.5, None, None, None, StateTransitionSignals()),
+    rewards.step_reward(agent=agent, agent_transition_data=AgentTransitionData(0.5, None, None, StateTransitionSignals()),
                         distance_map=distance_map,
                         elapsed_steps=5)
     assert rewards.end_of_episode_reward(agent, distance_map, elapsed_steps=25) == -1 * target_not_reached_minimum_penalty
@@ -763,7 +763,7 @@ def test_arrival_recorded_once_per_waypoint():
     agent.current_entry_point = ((5, 5), 0)
     agent.old_entry_point = ((5, 4), 0)
 
-    transition_data = AgentTransitionData(1.0, None, None, None, StateTransitionSignals())
+    transition_data = AgentTransitionData(1.0, None, None, StateTransitionSignals())
 
     # First step at this waypoint - should record arrival
     rewards.step_reward(agent, transition_data, distance_map, elapsed_steps=10)
@@ -795,7 +795,7 @@ def test_departure_only_when_moving():
     distance_map = DistanceMap(agents=[agent], env_height=20, env_width=20)
     distance_map.reset(agents=[agent], rail=RailGridTransitionMap(20, 20, transitions=RailEnvTransitions()))
 
-    transition_data = AgentTransitionData(1.0, None, None, None, StateTransitionSignals())
+    transition_data = AgentTransitionData(1.0, None, None, StateTransitionSignals())
 
     # agent off map
     rewards.step_reward(agent, transition_data, distance_map, elapsed_steps=1)
@@ -856,7 +856,7 @@ def test_waypoint_comparison_uses_waypoint_objects():
     distance_map = DistanceMap(agents=[agent], env_height=20, env_width=20)
     distance_map.reset(agents=[agent], rail=RailGridTransitionMap(20, 20, transitions=RailEnvTransitions()))
 
-    transition_data = AgentTransitionData(1.0, None, None, None, StateTransitionSignals())
+    transition_data = AgentTransitionData(1.0, None, None, StateTransitionSignals())
 
     agent.current_entry_point = ((7, 8), 1)
     agent.old_entry_point = ((7, 7), 1)
@@ -911,10 +911,10 @@ def _agent_with_two_cell_intermediate_station(latest_arrival_intermediate: int =
 def _visit(rewards, agent, distance_map, waypoint: Waypoint, state: TrainState, elapsed_steps: int, old: Waypoint):
     agent.old_entry_point = (old.position, old.direction)
     agent.current_entry_point = (waypoint.position, waypoint.direction)
+    agent.next_entry_point = (waypoint.position, waypoint.direction)
     agent.state = state
     transition_data = AgentTransitionData(
-        speed=Fraction(0), new_entry_point=(waypoint.position, waypoint.direction),
-        new_speed=Fraction(0), current_resource=waypoint.position,
+        speed=Fraction(0), new_speed=Fraction(0), current_resource=waypoint.position,
         state_transition_signal=StateTransitionSignals(stop_action_given=True, new_speed_zero=True, movement_allowed=True))
     rewards.step_reward(agent, transition_data, distance_map, elapsed_steps)
 
@@ -1060,7 +1060,7 @@ def test_no_collision_penalty_on_voluntary_stop():
     signals = StateTransitionSignals(stop_action_given=True, new_speed_zero=True, movement_allowed=True)
     _stop_moving_agent(agent, signals)
 
-    transition_data = AgentTransitionData(Fraction(1), None, Fraction(0), None, signals)
+    transition_data = AgentTransitionData(Fraction(1), Fraction(0), None, signals)
     d = rewards.step_reward(agent, transition_data, distance_map, elapsed_steps=5)
     assert d[DefaultPenalties.COLLISION.value] == 0, \
         "A controlled stop must not incur the collision penalty"
@@ -1075,7 +1075,7 @@ def test_collision_penalty_on_env_forced_stop():
     _stop_moving_agent(agent, signals)
 
     speed_at_impact = Fraction(1)
-    transition_data = AgentTransitionData(speed_at_impact, None, speed_at_impact, None, signals)
+    transition_data = AgentTransitionData(speed_at_impact, speed_at_impact, None, signals)
     d = rewards.step_reward(agent, transition_data, distance_map, elapsed_steps=5)
     assert d[DefaultPenalties.COLLISION.value] == -1 * speed_at_impact * COLLISION_FACTOR
 
@@ -1090,7 +1090,7 @@ def test_collision_penalty_when_braking_interrupted_by_conflict():
     _stop_moving_agent(agent, signals)
 
     residual_speed = Fraction(1, 4)
-    transition_data = AgentTransitionData(residual_speed, None, residual_speed, None, signals)
+    transition_data = AgentTransitionData(residual_speed, residual_speed, None, signals)
     d = rewards.step_reward(agent, transition_data, distance_map, elapsed_steps=5)
     assert d[DefaultPenalties.COLLISION.value] == -1 * residual_speed * COLLISION_FACTOR
 
@@ -1104,7 +1104,7 @@ def test_collision_penalty_on_invalid_action_stop():
     signals = StateTransitionSignals(stop_action_given=False, new_speed_zero=True, movement_allowed=False)
     _stop_moving_agent(agent, signals)
 
-    transition_data = AgentTransitionData(Fraction(1), None, Fraction(0), None, signals)
+    transition_data = AgentTransitionData(Fraction(1), Fraction(0), None, signals)
     d = rewards.step_reward(agent, transition_data, distance_map, elapsed_steps=5)
     assert d[DefaultPenalties.COLLISION.value] == -1 * Fraction(1) * COLLISION_FACTOR
 
@@ -1119,7 +1119,7 @@ def test_collision_penalty_on_invalid_stop_action():
     signals = StateTransitionSignals(stop_action_given=True, new_speed_zero=True, movement_allowed=False)
     _stop_moving_agent(agent, signals)
 
-    transition_data = AgentTransitionData(Fraction(1), None, Fraction(0), None, signals)
+    transition_data = AgentTransitionData(Fraction(1), Fraction(0), None, signals)
     d = rewards.step_reward(agent, transition_data, distance_map, elapsed_steps=5)
     assert d[DefaultPenalties.COLLISION.value] == -1 * Fraction(1) * COLLISION_FACTOR, \
         "An env-forced stop must be penalized even if it happens to coincide with a STOP_MOVING action"


### PR DESCRIPTION
## Changes

| ID | Description | Category | Severity | Commit(s) |
|---|---|---|---|---|
| — | Move `new_entry_point` off the per-step scratch `AgentTransitionData` and onto `EnvAgent` as `next_entry_point` (alongside `current_entry_point`/`old_entry_point`), since it's written and read back on the same agent a few lines apart; remains purely transient, excluded from `Agent`/`to_agent()` persistence | refactor | low | 455c6827 |

Next:
* actions are applied at cell entry + position update post conditions
* remove Action Saver Class
* resource map: attach resources to edges/configurations instead of entry points.

## Related issues


Second part of #178 
Follow-up of https://github.com/flatland-association/flatland-rl/pull/499

## Checklist

- [ ] Tests are included for relevant behavior changes.
- [ ] Documentation is added in the [flatland-book](https://github.com/flatland-association/flatland-book) repo for relevant behavior changes.
- [ ] If you made important user-facing changes, describe them under the `[Unreleased]` tag in `CHANGELOG.md`.
- [ ] New package dependencies are declared in the `pyproject.toml` file.
  Requirement files have been updated by running `tox -e requirements`.
- [ ] Code works with all supported Python versions (3.10, 3.11, 3.12 and 3.13). Checks run with all supported version and are
  required to run successfully.
- [ ] Code is formatted according to PEP 8 (an IDE like PyCharm can do this for you).
- [ ] Technical guidelines listed in `CONTRIBUTING.md` are followed.