### PR TITLE
refactor: D2.3c standardize TypeVar naming to <BoundClassName>T convention.

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,12 @@ flags it as unused.
   plain-Python fallback instead (e.g. to reproduce
   `verify-build-no-gcc`'s behavior), fake a missing compiler: `CC=/nonexistent-cc CXX=/nonexistent-cxx python -c
   "from setuptools import setup; setup()" build_ext --inplace`.
+- **Run tests against the compiled Cython build** (catches a `.pxd`/`.py` mismatch that compiles cleanly but
+  breaks at runtime, e.g. a `cdef class` field only ever assigned in the `.py` source): build in place per
+  above, then `python -m pytest --ignore=tests/ml -m cython_ext` - a fast, targeted subset (not the full suite)
+  of tests marked `pytest.mark.cython_ext` for exercising `state_machine.py`/`states.py`/
+  `rail_env_shortest_paths.py`. Wired into `tox -e py3.13-verify-cython-build-no-isolation`. Mark any new test
+  that exercises these modules the same way - see `CONTRIBUTING.md`'s Cython section.
 - **Profiling notebooks** (`benchmarks/flatland_performance_profiling.ipynb`,
   `benchmarks/benchmark_k_shortest_paths_profiling.ipynb`): `tox -e py3.13-profiling` /
   `tox -e py3.13-profiling-get-k-shortest-paths` — use Python 3.13, not 3.12 (see the Cython section below for
@@ -204,6 +210,15 @@ sibling (mirrors `pip install --no-build-isolation -e .`) both assert a wheel's 
 compiled`; `[testenv:build]` asserts the published artifact is a pure-Python `--artifact sdist` (trivially true
 by construction, but guards against e.g. stray `.c`/`.so` files accidentally being packaged).
 
+**None of the above actually execute the compiled code** - they only check that a `.so`/`.pyd` artifact exists
+(or doesn't). A `.pxd`/`.py` mismatch that compiles cleanly but breaks at runtime (e.g. a `cdef class` field
+assigned in the `.py` source but never declared in the `.pxd` - Cython's `cdef class` has no `__dict__`
+fallback for undeclared attributes, unlike a plain Python object) previously only surfaced via the profiling
+notebook's `LOCAL_Cython` step, since that's the only path that both compiles in-place and actually runs
+`env.step()` against the result. `py{...}-verify-cython-build-no-isolation` now also builds in-place and runs
+the tests marked `pytest.mark.cython_ext` against it for exactly this reason - see the `Commands` section above
+and `CONTRIBUTING.md`'s Cython section.
+
 **Known gap: `cProfile` can't see calls into compiled Cython functions on Python 3.12.** Python 3.12's `cProfile`
 registers itself via PEP 669's `sys.monitoring` instead of the legacy `PyEval_SetProfile` hook, and Cython's own
 `sys.monitoring` bridge (`CYTHON_USE_SYS_MONITORING`) is gated to Python ≥3.13 — confirmed independent of the
@@ -294,3 +309,19 @@ The `flatland-trajectory-*` scripts (generate-from-policy/generate-from-metadata
   hot paths" above.
 - Read packaged resource files (e.g. rail data shipped inside a subpackage) via `importlib_resources`
   (`path`/`read_binary`), not a raw path relative to the module.
+- `TypeVar` names are always `T`-suffixed (`EntryPointT = TypeVar('EntryPointT')`, `DistanceMapT =
+  TypeVar('DistanceMapT')`, etc., down to `ObsT`/`ActT`) - matches pylint's default `typevar-rgx`, which rejects
+  a bare `T`/`T1`. The string passed to `TypeVar()` must match the variable name exactly. This also sidesteps a
+  real footgun: several of these names (`TransitionMapT`, `ResourceMapT`, `TransitionsT`) would otherwise
+  collide with an imported class of the same bare name used elsewhere in that same file (e.g. `rail_env.py`
+  imports both `TransitionMap` and `ResourceMap` as classes) - a bare-named TypeVar declaration there would
+  silently shadow the import for every reference below it in the file.
+- When a `TypeVar` has a `bound=`, its name must be exactly `<BoundClassName>T` (e.g. `policy.py`'s
+  `EnvironmentT = TypeVar('EnvironmentT', bound=Environment)`, `rail_env_policy.py`'s `RailEnvT`/
+  `RailEnvActionsT` bound to `RailEnv`/`RailEnvActions`, `distance_map_walker.py`'s `EntryPointDistanceMapT`
+  bound to `EntryPointDistanceMap`) - an abbreviated or generic name (e.g. a bare `EnvT` bound to `Environment`)
+  is disallowed even though it's still `T`-suffixed, since the point is that the name alone should tell you the
+  bound without checking the declaration. An *unbound* `TypeVar` has no such constraint and can stay generic
+  (e.g. `env_observation_builder.py`'s unbound `EnvT`, `entry_point_distance_map.py`'s unbound `DistanceMapT`) -
+  don't confuse the two: the same base name can be legitimately unbound-and-generic in one file and
+  bound-and-specific in another.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,6 +138,12 @@ We use the pylint naming conventions:
 - `instance_var_name`
 - `function_parameter_name`
 - `local_var_name`
+- `TypeVarNameT` - pylint's default `typevar-rgx` rejects a bare `T`/`T1`/etc.
+  ([reference](https://stackoverflow.com/questions/74589610/whats-pylints-typevar-name-specification)), so every
+  `TypeVar` gets a descriptive `CamelCase` name ending in `T` (e.g. `EntryPointT = TypeVar('EntryPointT')`) - the
+  string passed to `TypeVar()` must match the variable name exactly. If the `TypeVar` has a `bound=`, its name
+  must be exactly `<BoundClassName>T` (e.g. `EnvironmentT = TypeVar('EnvironmentT', bound=Environment)`, not an
+  abbreviated `EnvT`) - an unbound `TypeVar` has no such constraint and can use a more generic name.
 
 ### numpydoc
 

--- a/flatland/callbacks/callbacks.py
+++ b/flatland/callbacks/callbacks.py
@@ -3,10 +3,10 @@ from typing import Optional, TypeVar, Generic
 
 from flatland.core.env import Environment
 
-Env = TypeVar('Env', bound=Environment, covariant=True)
+EnvironmentT = TypeVar('EnvironmentT', bound=Environment, covariant=True)
 
 
-class FlatlandCallbacks(Generic[Env]):
+class FlatlandCallbacks(Generic[EnvironmentT]):
     """
     Abstract base class for Flatland callbacks similar to rllib, see https://github.com/ray-project/ray/blob/master/rllib/callbacks/callbacks.py.
 
@@ -18,7 +18,7 @@ class FlatlandCallbacks(Generic[Env]):
     def on_episode_start(
         self,
         *,
-        env: Optional[Env] = None,
+        env: Optional[EnvironmentT] = None,
         data_dir: Path = None,
         **kwargs,
     ) -> None:
@@ -40,7 +40,7 @@ class FlatlandCallbacks(Generic[Env]):
     def on_episode_step(
         self,
         *,
-        env: Optional[Env] = None,
+        env: Optional[EnvironmentT] = None,
         data_dir: Path = None,
         **kwargs,
     ) -> None:
@@ -68,7 +68,7 @@ class FlatlandCallbacks(Generic[Env]):
     def on_episode_end(
         self,
         *,
-        env: Optional[Env] = None,
+        env: Optional[EnvironmentT] = None,
         data_dir: Path = None,
         **kwargs,
     ) -> None:
@@ -89,8 +89,8 @@ class FlatlandCallbacks(Generic[Env]):
 
 
 # https://github.com/ray-project/ray/blob/3b94e5ff0038798a6955cde37459a0d30aa718c4/rllib/callbacks/utils.py#L41
-def make_multi_callbacks(*_callback_list: FlatlandCallbacks[Env]):
-    class _MultiFlatlandCallbacks(FlatlandCallbacks[Env]):
+def make_multi_callbacks(*_callback_list: FlatlandCallbacks[EnvironmentT]):
+    class _MultiFlatlandCallbacks(FlatlandCallbacks[EnvironmentT]):
         IS_CALLBACK_CONTAINER = True
 
         def __init__(self, *callback_list: FlatlandCallbacks):

--- a/flatland/core/distance_map.py
+++ b/flatland/core/distance_map.py
@@ -3,10 +3,10 @@ from typing import Callable, Dict, List, Optional, Set
 
 from flatland.core.entry_point_distance_map import (
     EntryPointDistanceMap,
-    UnderlyingEntryPoint,
-    UnderlyingDistanceMap,
-    UnderlyingTransitionMap,
-    UnderlyingWaypoint,
+    EntryPointT,
+    DistanceMapT,
+    TransitionMapT,
+    WaypointT,
 )
 from flatland.core.distance_map_walker import DistanceMapWalker
 from flatland.envs.agent_utils import EnvAgent
@@ -14,8 +14,8 @@ from flatland.envs.step_utils.states import TrainState
 
 
 class AgentSourceTargetDistanceMap(
-    EntryPointDistanceMap[UnderlyingTransitionMap, UnderlyingDistanceMap, UnderlyingEntryPoint,
-    UnderlyingWaypoint]
+    EntryPointDistanceMap[TransitionMapT, DistanceMapT, EntryPointT,
+    WaypointT]
 ):
     """
     Adds agent-handle (target_nr) aware querying on top of `EntryPointDistanceMap`. `get_agent_distance`
@@ -23,19 +23,19 @@ class AgentSourceTargetDistanceMap(
     concrete subclasses provide the underlying per-agent storage via `_set_agent_distance`.
     """
 
-    def __init__(self, agents: List[EnvAgent], waypoint_init: Callable[[UnderlyingEntryPoint], UnderlyingWaypoint]):
+    def __init__(self, agents: List[EnvAgent], waypoint_init: Callable[[EntryPointT], WaypointT]):
         super().__init__(agents=agents, waypoint_init=waypoint_init)
         self.distance_map = None
         self.agents_previous_computation = None
         self.reset_was_called = False
 
-    def set(self, distance_map: UnderlyingDistanceMap):
+    def set(self, distance_map: DistanceMapT):
         """
         Set the distance map
         """
         self.distance_map = distance_map
 
-    def get(self) -> UnderlyingDistanceMap:
+    def get(self) -> DistanceMapT:
         """
         Get the distance map
         """
@@ -55,14 +55,14 @@ class AgentSourceTargetDistanceMap(
 
         return self.distance_map
 
-    def reset(self, agents: List[EnvAgent], rail: UnderlyingTransitionMap):
+    def reset(self, agents: List[EnvAgent], rail: TransitionMapT):
         """
         Reset the distance map
         """
         super().reset(agents=agents, rail=rail)
         self.reset_was_called = True
 
-    def _compute(self, agents: List[EnvAgent], rail: UnderlyingTransitionMap):
+    def _compute(self, agents: List[EnvAgent], rail: TransitionMapT):
         """
         Computes the distance maps for each unique target. Thus, if several targets are the same we only
         compute the distance for them once and copy to all agents with the same target.
@@ -86,20 +86,20 @@ class AgentSourceTargetDistanceMap(
                 self._copy_agent_distance(i, computed_targets.index(targets))
             computed_targets.append(targets)
 
-    def _new_distance_map(self, num_agents: int) -> UnderlyingDistanceMap:
+    def _new_distance_map(self, num_agents: int) -> DistanceMapT:
         raise NotImplementedError()
 
-    def _valid_targets(self, agent: EnvAgent, rail: UnderlyingTransitionMap) -> List[UnderlyingEntryPoint]:
+    def _valid_targets(self, agent: EnvAgent, rail: TransitionMapT) -> List[EntryPointT]:
         raise NotImplementedError()
 
     def _copy_agent_distance(self, target_nr: int, source_target_nr: int):
         raise NotImplementedError()
 
     # N.B. get_shortest_paths is not part of distance_map since it refers to RailEnvActions (would lead to circularity!)
-    def get_shortest_paths(self, max_depth: Optional[int] = None, agent_handle: Optional[int] = None) -> Dict[int, Optional[List[UnderlyingWaypoint]]]:
+    def get_shortest_paths(self, max_depth: Optional[int] = None, agent_handle: Optional[int] = None) -> Dict[int, Optional[List[WaypointT]]]:
         """
         Computes the shortest path for each agent to its target and the action to be taken to do so.
-        The paths are derived from a `DistanceMap`.
+        The paths are derived from a `DistanceMapT`.
 
         If there is no path (rail disconnected), the path is given as None.
         The agent state (moving or not) and its speed are not taken into account
@@ -116,7 +116,7 @@ class AgentSourceTargetDistanceMap(
 
         Returns
         -------
-            Dict[int, Optional[List[UnderlyingWaypoint]]]
+            Dict[int, Optional[List[WaypointT]]]
 
         """
 
@@ -147,11 +147,11 @@ class AgentSourceTargetDistanceMap(
 
     def _reconstruct_shortest_path(
         self,
-        source: UnderlyingEntryPoint,
+        source: EntryPointT,
         handle,
         max_depth: Optional[int],
-        targets: Set[UnderlyingEntryPoint]
-    ) -> List[UnderlyingWaypoint]:
+        targets: Set[EntryPointT]
+    ) -> List[WaypointT]:
         """
         Reconstruct shortest path from distance map going forward from source to any of targets.
         """
@@ -181,12 +181,12 @@ class AgentSourceTargetDistanceMap(
             agent_shortest_path.append(self.waypoint_init(source))
         return agent_shortest_path
 
-    def get_agent_distance(self, source_entry_point: UnderlyingEntryPoint, target_nr: int):
+    def get_agent_distance(self, source_entry_point: EntryPointT, target_nr: int):
         self.get()
         return self._get_agent_distance(source_entry_point, target_nr)
 
-    def _set_agent_distance(self, source_entry_point: UnderlyingEntryPoint, target_nr: int, new_distance: int):
+    def _set_agent_distance(self, source_entry_point: EntryPointT, target_nr: int, new_distance: int):
         raise NotImplementedError()
 
-    def _get_agent_distance(self, source_entry_point: UnderlyingEntryPoint, target_nr: int):
+    def _get_agent_distance(self, source_entry_point: EntryPointT, target_nr: int):
         raise NotImplementedError()

--- a/flatland/core/distance_map_walker.py
+++ b/flatland/core/distance_map_walker.py
@@ -4,12 +4,12 @@ from typing import List, Generic, Set, TypeVar
 from flatland.core.entry_point_distance_map import EntryPointDistanceMap
 from flatland.core.transition_map import TransitionMap
 
-UnderlyingDistanceMap = TypeVar('UnderlyingDistanceMap', bound=EntryPointDistanceMap)
-UnderlyingTransitionMap = TypeVar('UnderlyingTransitionMap', bound=TransitionMap)
-UnderlyingEntryPoint = TypeVar('UnderlyingEntryPoint')
+EntryPointDistanceMapT = TypeVar('EntryPointDistanceMapT', bound=EntryPointDistanceMap)
+TransitionMapT = TypeVar('TransitionMapT', bound=TransitionMap)
+EntryPointT = TypeVar('EntryPointT')
 
 
-class DistanceMapWalker(Generic[UnderlyingDistanceMap, UnderlyingTransitionMap, UnderlyingEntryPoint]):
+class DistanceMapWalker(Generic[EntryPointDistanceMapT, TransitionMapT, EntryPointT]):
     """
     "All-to-any-one-in-cluster": utility class to compute distance maps from each entry point in the rail network (cell and each possible orientation within it in grid case)
      to any one in the set of target entry points using backwards BFS. Agnostic of any agent/target_nr - operates
@@ -20,9 +20,9 @@ class DistanceMapWalker(Generic[UnderlyingDistanceMap, UnderlyingTransitionMap, 
         self.distance_map = distance_map
 
     def _distance_map_walker(self,
-                             rail: UnderlyingTransitionMap,
-                             target_entry_points: List[UnderlyingEntryPoint]
-                             ) -> Set[UnderlyingEntryPoint]:
+                             rail: TransitionMapT,
+                             target_entry_points: List[EntryPointT]
+                             ) -> Set[EntryPointT]:
         """
         Utility function to compute distance maps from each cell in the rail network (and each possible
         orientation within it) to each of the target entry points. Each target entry point is walked
@@ -39,7 +39,7 @@ class DistanceMapWalker(Generic[UnderlyingDistanceMap, UnderlyingTransitionMap, 
 
         Returns
         -------
-        Set[UnderlyingEntryPoint]
+        Set[EntryPointT]
             the set of all entry points backwards-reachable from any of the target entry points (i.e.
             those a distance was filled in for).
         """
@@ -48,8 +48,8 @@ class DistanceMapWalker(Generic[UnderlyingDistanceMap, UnderlyingTransitionMap, 
             reachable_entry_points |= self._walk_to_target(rail, target_entry_point)
         return reachable_entry_points
 
-    def _walk_to_target(self, rail: UnderlyingTransitionMap, target_entry_point: UnderlyingEntryPoint
-                        ) -> Set[UnderlyingEntryPoint]:
+    def _walk_to_target(self, rail: TransitionMapT, target_entry_point: EntryPointT
+                        ) -> Set[EntryPointT]:
         """
         Backward BFS from a single target entry point to every entry point that can reach it, filling in
         the minimum distances.
@@ -80,8 +80,8 @@ class DistanceMapWalker(Generic[UnderlyingDistanceMap, UnderlyingTransitionMap, 
 
         return visited
 
-    def _get_and_update_neighbors(self, rail: UnderlyingTransitionMap, entry_point: UnderlyingEntryPoint,
-                                  current_distance: int, target_entry_point: UnderlyingEntryPoint):
+    def _get_and_update_neighbors(self, rail: TransitionMapT, entry_point: EntryPointT,
+                                  current_distance: int, target_entry_point: EntryPointT):
         """
         Utility function used by _walk_to_target to perform a BFS walk over the rail, filling in the
         minimum distances to a single target entry point.

--- a/flatland/core/effects_generator.py
+++ b/flatland/core/effects_generator.py
@@ -3,13 +3,13 @@ from typing import Callable, TypeVar, Generic, Dict, Any, List, Optional, Type
 from flatland.core.env import Environment
 from flatland.utils.cli_utils import resolve_type
 
-Env = TypeVar('Env', bound=Environment, covariant=True)
+EnvironmentT = TypeVar('EnvironmentT', bound=Environment, covariant=True)
 
 StateDict = Dict[str, Any]
 Specs = Dict[str, Any]
 
 
-class EffectsGenerator(Generic[Env]):
+class EffectsGenerator(Generic[EnvironmentT]):
     """
     Hook for external events modifying the env (state) before observations and rewards are computed.
 
@@ -18,15 +18,15 @@ class EffectsGenerator(Generic[Env]):
 
     def __init__(
         self,
-        on_episode_start: Callable[[Env], Env] = None,
-        on_episode_step_start: Callable[[Env], Env] = None,
-        on_episode_step_end: Callable[[Env], Env] = None,
+        on_episode_start: Callable[[EnvironmentT], EnvironmentT] = None,
+        on_episode_step_start: Callable[[EnvironmentT], EnvironmentT] = None,
+        on_episode_step_end: Callable[[EnvironmentT], EnvironmentT] = None,
     ):
         self._on_episode_start = on_episode_start
         self._on_episode_step_start = on_episode_step_start
         self._on_episode_step_end = on_episode_step_end
 
-    def on_episode_start(self, env: Env, *args, **kwargs) -> Env:
+    def on_episode_start(self, env: EnvironmentT, *args, **kwargs) -> EnvironmentT:
         """
         Called by env at the end of reset before computing observations and infos.
 
@@ -48,7 +48,7 @@ class EffectsGenerator(Generic[Env]):
             return env
         return self._on_episode_start(*args, **kwargs)
 
-    def on_episode_step_start(self, env: Env, *args, **kwargs) -> Env:
+    def on_episode_step_start(self, env: EnvironmentT, *args, **kwargs) -> EnvironmentT:
         """
         Called by env at the beginning of step before evaluating the agent's actions.
 
@@ -70,7 +70,7 @@ class EffectsGenerator(Generic[Env]):
             return env
         return self._on_episode_step_start(*args, **kwargs)
 
-    def on_episode_step_end(self, env: Env, *args, **kwargs) -> Env:
+    def on_episode_step_end(self, env: EnvironmentT, *args, **kwargs) -> EnvironmentT:
         """
         Called by env at the end of step before computing observations and infos.
 
@@ -119,21 +119,21 @@ class EffectsGenerator(Generic[Env]):
 
 
 
-class MultiEffectsGeneratorWrapped(EffectsGenerator[Env]):
-    def __init__(self, *effects_generators: EffectsGenerator[Env]):
+class MultiEffectsGeneratorWrapped(EffectsGenerator[EnvironmentT]):
+    def __init__(self, *effects_generators: EffectsGenerator[EnvironmentT]):
         self.effects_generators = effects_generators
 
-    def on_episode_start(self, env: Env, *args, **kwargs) -> Env:
+    def on_episode_start(self, env: EnvironmentT, *args, **kwargs) -> EnvironmentT:
         for eff in self.effects_generators:
             env = eff.on_episode_start(env, *args, **kwargs)
         return env
 
-    def on_episode_step_start(self, env: Env, *args, **kwargs) -> Env:
+    def on_episode_step_start(self, env: EnvironmentT, *args, **kwargs) -> EnvironmentT:
         for eff in self.effects_generators:
             env = eff.on_episode_step_start(env, *args, **kwargs)
         return env
 
-    def on_episode_step_end(self, env: Env, *args, **kwargs) -> Env:
+    def on_episode_step_end(self, env: EnvironmentT, *args, **kwargs) -> EnvironmentT:
         for eff in self.effects_generators:
             env = eff.on_episode_step_end(env, *args, **kwargs)
         return env
@@ -161,7 +161,7 @@ def _flatten_effects_generators(effects_generators):
     return flattened
 
 
-def make_multi_effects_generator(*effects_generators: EffectsGenerator[Env]) -> EffectsGenerator[Env]:
+def make_multi_effects_generator(*effects_generators: EffectsGenerator[EnvironmentT]) -> EffectsGenerator[EnvironmentT]:
     """
     Compose effects generators into a single flat `MultiEffectsGeneratorWrapped` - any argument that is itself a
     `MultiEffectsGeneratorWrapped` (however deeply nested) is unwrapped first, so nesting never accumulates
@@ -170,10 +170,10 @@ def make_multi_effects_generator(*effects_generators: EffectsGenerator[Env]) -> 
     return MultiEffectsGeneratorWrapped(*_flatten_effects_generators(effects_generators))
 
 
-T = TypeVar('T', bound=EffectsGenerator)
+EffectsGeneratorT = TypeVar('EffectsGeneratorT', bound=EffectsGenerator)
 
 
-def find_all_effects_generators(effects_generator: EffectsGenerator[Env], cls: Type[T]) -> List[T]:
+def find_all_effects_generators(effects_generator: EffectsGenerator[EnvironmentT], cls: Type[EffectsGeneratorT]) -> List[EffectsGeneratorT]:
     """
     Recursively collect all instances of `cls` within a (possibly `MultiEffectsGeneratorWrapped`-composed) effects generator.
     """
@@ -186,7 +186,7 @@ def find_all_effects_generators(effects_generator: EffectsGenerator[Env], cls: T
     return found
 
 
-def find_effects_generator(effects_generator: EffectsGenerator[Env], cls: Type[T]) -> Optional[T]:
+def find_effects_generator(effects_generator: EffectsGenerator[EnvironmentT], cls: Type[EffectsGeneratorT]) -> Optional[EffectsGeneratorT]:
     """
     Recursively search a (possibly `MultiEffectsGeneratorWrapped`-composed) effects generator for an instance of `cls`.
     """

--- a/flatland/core/entry_point_distance_map.py
+++ b/flatland/core/entry_point_distance_map.py
@@ -6,45 +6,45 @@ from flatland.core.transition_map import TransitionMap
 from flatland.envs.agent_utils import EnvAgent
 from flatland.envs.rail_grid_transition_map import RailGridTransitionMap
 
-UnderlyingTransitionMap = TypeVar('UnderlyingTransitionMap', bound=TransitionMap)
-UnderlyingDistanceMap = TypeVar('UnderlyingDistanceMap')
-UnderlyingEntryPoint = TypeVar('UnderlyingEntryPoint')
-UnderlyingWaypoint = TypeVar('UnderlyingWaypoint')
+TransitionMapT = TypeVar('TransitionMapT', bound=TransitionMap)
+DistanceMapT = TypeVar('DistanceMapT')
+EntryPointT = TypeVar('EntryPointT')
+WaypointT = TypeVar('WaypointT')
 
 
 def _infinite_distance():
     return math.inf
 
 
-class EntryPointDistanceMap(Generic[UnderlyingTransitionMap, UnderlyingDistanceMap, UnderlyingEntryPoint, UnderlyingWaypoint]):
+class EntryPointDistanceMap(Generic[TransitionMapT, DistanceMapT, EntryPointT, WaypointT]):
     """
     Base distance map collecting the distance from every entry point visited during the BFS walk to the
     effective target entry point reached, keyed by (source_entry_point, target_entry_point) - agnostic
     of any numeric target_nr (agent handle), which `DistanceMapWalker` has no notion of.
     """
 
-    def __init__(self, agents: List[EnvAgent], waypoint_init: Callable[[UnderlyingEntryPoint], UnderlyingWaypoint]):
+    def __init__(self, agents: List[EnvAgent], waypoint_init: Callable[[EntryPointT], WaypointT]):
         self.agents: List[EnvAgent] = agents
         self.rail: Optional[RailGridTransitionMap] = None
         self.waypoint_init = waypoint_init
         self.distances: Dict[
-            Tuple[UnderlyingEntryPoint, UnderlyingEntryPoint], int
+            Tuple[EntryPointT, EntryPointT], int
         ] = defaultdict(_infinite_distance)
 
-    def reset(self, agents: List[EnvAgent], rail: UnderlyingTransitionMap):
+    def reset(self, agents: List[EnvAgent], rail: TransitionMapT):
         """
         Reset the distance map
         """
         self.agents: List[EnvAgent] = agents
         self.rail = rail
         self.distances: Dict[
-            Tuple[UnderlyingEntryPoint, UnderlyingEntryPoint], int
+            Tuple[EntryPointT, EntryPointT], int
         ] = defaultdict(_infinite_distance)
 
-    def _set_distance(self, source_entry_point: UnderlyingEntryPoint,
-                      target_entry_point: UnderlyingEntryPoint, new_distance: int):
+    def _set_distance(self, source_entry_point: EntryPointT,
+                      target_entry_point: EntryPointT, new_distance: int):
         self.distances[(source_entry_point, target_entry_point)] = new_distance
 
-    def _get_distance(self, source_entry_point: UnderlyingEntryPoint,
-                      target_entry_point: UnderlyingEntryPoint) -> int:
+    def _get_distance(self, source_entry_point: EntryPointT,
+                      target_entry_point: EntryPointT) -> int:
         return self.distances[(source_entry_point, target_entry_point)]

--- a/flatland/core/env_observation_builder.py
+++ b/flatland/core/env_observation_builder.py
@@ -17,20 +17,20 @@ from numpy.random import RandomState
 
 from flatland.core.env import Environment
 
-Env = TypeVar('Env')
-Observation = TypeVar('Observation')
+EnvT = TypeVar('EnvT')
+ObservationT = TypeVar('ObservationT')
 AgentHandle = int
 
 
-class ObservationBuilder(Generic[Env, Observation]):
+class ObservationBuilder(Generic[EnvT, ObservationT]):
     """
     ObservationBuilder base class.
     """
 
     def __init__(self):
-        self.env: Optional[Env] = None
+        self.env: Optional[EnvT] = None
 
-    def reset(self, env: Env):
+    def reset(self, env: EnvT):
         """
         Called after each environment reset, to allow for pre-computing relevant data. Receives the
         (possibly newly generated) env instance, so any instantiations depending on env parameters
@@ -41,12 +41,12 @@ class ObservationBuilder(Generic[Env, Observation]):
 
         Parameters
         ----------
-        env : Env
+        env : EnvT
             the (possibly newly generated) environment instance
         """
-        self.env: Env = env
+        self.env: EnvT = env
 
-    def get_many(self, handles: Optional[List[AgentHandle]] = None) -> Dict[AgentHandle, Observation]:
+    def get_many(self, handles: Optional[List[AgentHandle]] = None) -> Dict[AgentHandle, ObservationT]:
         """
         Called whenever an observation has to be computed for the `env` environment, for each agent with handle
         in the `handles` list.
@@ -69,7 +69,7 @@ class ObservationBuilder(Generic[Env, Observation]):
             observations[h] = self.get(h)
         return observations
 
-    def get(self, handle: AgentHandle = 0) -> Observation:
+    def get(self, handle: AgentHandle = 0) -> ObservationT:
         """
         Called whenever an observation has to be computed for the `env` environment, possibly
         for each agent independently (agent id `handle`).

--- a/flatland/core/env_prediction_builder.py
+++ b/flatland/core/env_prediction_builder.py
@@ -12,11 +12,11 @@ case of multi-agent environments.
 """
 from typing import Generic, TypeVar
 
-Prediction = TypeVar('Prediction')
-Env = TypeVar('Env')
+PredictionT = TypeVar('PredictionT')
+EnvT = TypeVar('EnvT')
 
 
-class PredictionBuilder(Generic[Env, Prediction]):
+class PredictionBuilder(Generic[EnvT, PredictionT]):
     """
     PredictionBuilder base class.
 
@@ -24,21 +24,21 @@ class PredictionBuilder(Generic[Env, Prediction]):
 
     def __init__(self, max_depth: int = 20):
         self.max_depth = max_depth
-        self.env: Env = None
+        self.env: EnvT = None
 
-    def reset(self, env: Env):
+    def reset(self, env: EnvT):
         """
         Called after each environment reset. Receives the env instance so prediction-builder-specific
         instantiations depending on env parameters can be made here.
 
         Parameters
         ----------
-        env : Env
+        env : EnvT
             the (possibly newly generated) environment instance
         """
         self.env = env
 
-    def get(self, handle: int = 0) -> Prediction:
+    def get(self, handle: int = 0) -> PredictionT:
         """
         Called whenever get_many in the observation builder is called.
 

--- a/flatland/core/policy.py
+++ b/flatland/core/policy.py
@@ -3,19 +3,19 @@ from typing import List, Dict, TypeVar, Generic
 
 from flatland.core.env import Environment
 
-T_env = TypeVar('T_env', bound=Environment)
-T_obs = TypeVar('T_obs', covariant=True)
-T_act = TypeVar('T_act', covariant=True)
+EnvironmentT = TypeVar('EnvironmentT', bound=Environment)
+ObsT = TypeVar('ObsT', covariant=True)
+ActT = TypeVar('ActT', covariant=True)
 
 
-class Policy(ABC, Generic[T_env, T_obs, T_act]):
+class Policy(ABC, Generic[EnvironmentT, ObsT, ActT]):
     """
     Abstract base class for Flatland policies. Used for evaluation.
 
     Loosely corresponding to https://github.com/ray-project/ray/blob/master/rllib/core/rl_module/rl_module.py, but much simpler.
     """
 
-    def act(self, observation: T_obs, **kwargs) -> T_act:
+    def act(self, observation: ObsT, **kwargs) -> ActT:
         """
         Get action for agent. Called by `act_many()` for each agent.
 
@@ -33,7 +33,7 @@ class Policy(ABC, Generic[T_env, T_obs, T_act]):
         """
         raise NotImplementedError()
 
-    def act_many(self, handles: List[int], observations: List[T_obs], **kwargs) -> Dict[int, T_act]:
+    def act_many(self, handles: List[int], observations: List[ObsT], **kwargs) -> Dict[int, ActT]:
         """
         Get action_dict for all agents. Default implementation calls `act()` for each handle in the list.
 

--- a/flatland/core/resource_map.py
+++ b/flatland/core/resource_map.py
@@ -1,14 +1,14 @@
 from typing import Generic, TypeVar, Optional
 
-EntryPoint = TypeVar('EntryPoint')
-Resource = TypeVar('Resource')
+EntryPointT = TypeVar('EntryPointT')
+ResourceT = TypeVar('ResourceT')
 
 
-class ResourceMap(Generic[EntryPoint, Resource]):
+class ResourceMap(Generic[EntryPointT, ResourceT]):
     """
-    Resource Map stores the single resource required to be at the entry point
+    ResourceT Map stores the single resource required to be at the entry point
     (i.e. to be in the cell or level-free crossing cell in grid world, resp. at the node in graph world).
     """
 
-    def get_resource(self, entry_point: Optional[EntryPoint]) -> Optional[Resource]:
+    def get_resource(self, entry_point: Optional[EntryPointT]) -> Optional[ResourceT]:
         raise NotImplementedError()

--- a/flatland/core/transition_map.py
+++ b/flatland/core/transition_map.py
@@ -19,20 +19,20 @@ from flatland.core.transitions import Transitions
 from flatland.envs.fast_methods import fast_count_nonzero
 from flatland.utils.ordered_set import OrderedSet
 
-UnderlyingEntryPoint = TypeVar('EntryPoint')
-UnderlyingTransitions = TypeVar('UnderlyingTransitions')
-UnderlyingTransitionsValidity = TypeVar('UnderlyingTransitionsValidity')
-Actions = TypeVar('Actions')
+EntryPointT = TypeVar('EntryPointT')
+TransitionsT = TypeVar('TransitionsT')
+TransitionsValidityT = TypeVar('TransitionsValidityT')
+ActionsT = TypeVar('ActionsT')
 
 
-class TransitionMap(Generic[UnderlyingEntryPoint, UnderlyingTransitions, UnderlyingTransitionsValidity, Actions]):
+class TransitionMap(Generic[EntryPointT, TransitionsT, TransitionsValidityT, ActionsT]):
     """
     Base TransitionMap class.
 
     Generic class that implements a collection of transitions over a set of cells.
     """
 
-    def get_transitions(self, entry_point: UnderlyingEntryPoint) -> Tuple[UnderlyingTransitionsValidity]:
+    def get_transitions(self, entry_point: EntryPointT) -> Tuple[TransitionsValidityT]:
         """
         Return a tuple of transitions available in a cell specified by
         `entry_point` (e.g., a tuple of size of the maximum number of transitions,
@@ -51,7 +51,7 @@ class TransitionMap(Generic[UnderlyingEntryPoint, UnderlyingTransitions, Underly
         """
         raise NotImplementedError()
 
-    def set_transitions(self, entry_point: UnderlyingEntryPoint, new_transitions: UnderlyingTransitions):
+    def set_transitions(self, entry_point: EntryPointT, new_transitions: TransitionsT):
         """
         Replaces the available transitions in cell `entry_point` with the tuple
         `new_transitions'. `new_transitions` must have
@@ -59,7 +59,7 @@ class TransitionMap(Generic[UnderlyingEntryPoint, UnderlyingTransitions, Underly
 
         Parameters
         ----------
-        entry_point : [EntryPoint]
+        entry_point : [EntryPointT]
             The entry_point object depends on the specific implementation.
             It generally is an int (e.g., an index) or a tuple of indices.
         new_transitions : [TransitionsType]
@@ -68,7 +68,7 @@ class TransitionMap(Generic[UnderlyingEntryPoint, UnderlyingTransitions, Underly
         """
         raise NotImplementedError()
 
-    def get_transition(self, entry_point: UnderlyingEntryPoint, transition_index: int) -> UnderlyingTransitionsValidity:
+    def get_transition(self, entry_point: EntryPointT, transition_index: int) -> TransitionsValidityT:
         """
         Return the status of whether an agent in cell `entry_point` can perform a
         movement along transition `transition_index` (e.g., the NESW direction
@@ -93,7 +93,7 @@ class TransitionMap(Generic[UnderlyingEntryPoint, UnderlyingTransitions, Underly
         """
         raise NotImplementedError()
 
-    def set_transition(self, entry_point: UnderlyingEntryPoint, transition_index, new_transition):
+    def set_transition(self, entry_point: EntryPointT, transition_index, new_transition):
         """
         Replaces the validity of transition to `transition_index` in cell
         `entry_point' with the new `new_transition`.
@@ -115,39 +115,39 @@ class TransitionMap(Generic[UnderlyingEntryPoint, UnderlyingTransitions, Underly
         """
         raise NotImplementedError()
 
-    def apply_action_independent(self, action: Actions, entry_point: UnderlyingEntryPoint) -> Optional[UnderlyingEntryPoint]:
+    def apply_action_independent(self, action: ActionsT, entry_point: EntryPointT) -> Optional[EntryPointT]:
         """
         Apply the action on the train regardless of locations of other agents.
         Checks for valid cells to move and valid rail transitions.
 
         Parameters
         ----------
-        action : [Actions]
+        action : [ActionsT]
             Action to execute
-        entry_point : [EntryPoint]
+        entry_point : [EntryPointT]
             position and orientation
 
         Returns
         -------
-        entry_point : Optional[UnderlyingEntryPoint]
+        entry_point : Optional[EntryPointT]
             the next entry_point (cell + entry direction), or `None` if the action has no valid transition
         """
         raise NotImplementedError()
 
-    def get_successor_entry_points(self, entry_point: UnderlyingEntryPoint) -> Set[UnderlyingEntryPoint]:
+    def get_successor_entry_points(self, entry_point: EntryPointT) -> Set[EntryPointT]:
         raise NotImplementedError()
 
-    def get_predecessor_entry_points(self, entry_point: UnderlyingEntryPoint) -> Set[UnderlyingEntryPoint]:
+    def get_predecessor_entry_points(self, entry_point: EntryPointT) -> Set[EntryPointT]:
         raise NotImplementedError()
 
-    def is_valid_entry_point(self, entry_point: UnderlyingEntryPoint) -> bool:
+    def is_valid_entry_point(self, entry_point: EntryPointT) -> bool:
         """
         Whether the map contains the entry_point (a cell plus entry direction - a position+direction tuple
         for grid, a node id encoding the same for graph).
 
         Parameters
         ----------
-        entry_point : UnderlyingEntryPoint
+        entry_point : EntryPointT
             the entry_point to check
 
         Returns
@@ -158,7 +158,7 @@ class TransitionMap(Generic[UnderlyingEntryPoint, UnderlyingTransitions, Underly
         raise NotImplementedError()
 
 
-class GridTransitionMap(TransitionMap[Tuple[Tuple[int, int], int], Grid4Transitions, Tuple[bool], Any], Generic[Actions]):
+class GridTransitionMap(TransitionMap[Tuple[Tuple[int, int], int], Grid4Transitions, Tuple[bool], Any], Generic[ActionsT]):
     """
     Implements a TransitionMap over a 2D grid.
 
@@ -201,7 +201,7 @@ class GridTransitionMap(TransitionMap[Tuple[Tuple[int, int], int], Grid4Transiti
         return self.uuid
 
     @lru_cache(maxsize=1_000_000)
-    def get_full_transitions(self, row, column) -> UnderlyingTransitions:
+    def get_full_transitions(self, row, column) -> TransitionsT:
         """
         Returns the full transitions for the cell at (row, column) in the format transition_map's transitions.
 

--- a/flatland/core/transitions.py
+++ b/flatland/core/transitions.py
@@ -6,12 +6,12 @@ possible transitions over a 2D grid.
 from enum import IntEnum
 from typing import TypeVar, Generic, Tuple
 
-TransitionsData = TypeVar('TransitionsData')
-TransitionsOrientation = TypeVar('TransitionsOrientation')
-TransitionsValidity = TypeVar('TransitionsValidity')
+TransitionsDataT = TypeVar('TransitionsDataT')
+TransitionsOrientationT = TypeVar('TransitionsOrientationT')
+TransitionsValidityT = TypeVar('TransitionsValidityT')
 
 
-class Transitions(Generic[TransitionsData, TransitionsOrientation, TransitionsValidity]):
+class Transitions(Generic[TransitionsDataT, TransitionsOrientationT, TransitionsValidityT]):
     """
     Base Transitions class.
 
@@ -23,7 +23,7 @@ class Transitions(Generic[TransitionsData, TransitionsOrientation, TransitionsVa
     def get_type(self):
         raise NotImplementedError()
 
-    def get_transitions(self, cell_transition: TransitionsData, orientation: TransitionsOrientation) -> Tuple[TransitionsValidity]:
+    def get_transitions(self, cell_transition: TransitionsDataT, orientation: TransitionsOrientationT) -> Tuple[TransitionsValidityT]:
         """
         Return a tuple of transitions available in a cell specified by
         `cell_transition' for an agent facing direction `orientation`
@@ -48,7 +48,7 @@ class Transitions(Generic[TransitionsData, TransitionsOrientation, TransitionsVa
         """
         raise NotImplementedError()
 
-    def set_transitions(self, cell_transition: TransitionsData, orientation: TransitionsOrientation, new_transitions: Tuple[TransitionsValidity]):
+    def set_transitions(self, cell_transition: TransitionsDataT, orientation: TransitionsOrientationT, new_transitions: Tuple[TransitionsValidityT]):
         """
         Return a `cell_transition` specification where the transitions
         available for an agent facing direction `orientation` are replaced
@@ -76,7 +76,7 @@ class Transitions(Generic[TransitionsData, TransitionsOrientation, TransitionsVa
         """
         raise NotImplementedError()
 
-    def get_transition(self, cell_transition: TransitionsData, orientation: TransitionsOrientation, direction: TransitionsOrientation):
+    def get_transition(self, cell_transition: TransitionsDataT, orientation: TransitionsOrientationT, direction: TransitionsOrientationT):
         """
         Return the status of whether an agent oriented in directions
         `orientation' and inside a cell with transitions `cell_transition`
@@ -103,8 +103,8 @@ class Transitions(Generic[TransitionsData, TransitionsOrientation, TransitionsVa
         """
         raise NotImplementedError()
 
-    def set_transition(self, cell_transition: TransitionsData, orientation: TransitionsOrientation, direction: TransitionsOrientation,
-                       new_transition: TransitionsValidity):
+    def set_transition(self, cell_transition: TransitionsDataT, orientation: TransitionsOrientationT, direction: TransitionsOrientationT,
+                       new_transition: TransitionsValidityT):
         """
         Return a `cell_transition` specification where the status of
         whether an agent oriented in direction `orientation` and inside

--- a/flatland/envs/agent_utils.py
+++ b/flatland/envs/agent_utils.py
@@ -176,7 +176,7 @@ def load_env_agent(agent_tuple: Agent, rail: TransitionMap):
     )
 
 
-EntryPoint = TypeVar('EntryPoint')
+EntryPointT = TypeVar('EntryPointT')
 
 
 def _sanitize_entry_point(entry_point):
@@ -191,7 +191,7 @@ def _sanitize_entry_point(entry_point):
     attribute assignment, so this has to be called explicitly at every write site instead.
 
     A no-op for graph entry points (or anything else that doesn't look like a grid
-    ((row, col), direction) tuple), since EntryPoint is generic across grid and graph envs.
+    ((row, col), direction) tuple), since EntryPointT is generic across grid and graph envs.
     """
     if entry_point is None:
         return None
@@ -208,7 +208,7 @@ def _sanitize_entry_point(entry_point):
 
 
 @attrs
-class EnvAgent(Generic[EntryPoint]):
+class EnvAgent(Generic[EntryPointT]):
     # INIT FROM HERE IN _from_line()
     # converter=_sanitize_entry_point: covers construction (e.g. from rail/line generation code, which is
     # exactly where the numpy-dtype taint described on _sanitize_entry_point has been observed entering) -
@@ -216,17 +216,17 @@ class EnvAgent(Generic[EntryPoint]):
     # agent.current_entry_point = ..., agent.old_entry_point = ..., agent.target_entry_point = ...)
     # still need to call _sanitize_entry_point explicitly themselves, unless the assigned value is already
     # known-sanitized (e.g. copied from another already-sanitized entry point attrib on the same agent).
-    initial_entry_point = attrib(type=EntryPoint, converter=_sanitize_entry_point)
+    initial_entry_point = attrib(type=EntryPointT, converter=_sanitize_entry_point)
 
-    current_entry_point = attrib(type=Optional[EntryPoint], default=Factory(lambda: None),
+    current_entry_point = attrib(type=Optional[EntryPointT], default=Factory(lambda: None),
                                  converter=_sanitize_entry_point)
-    targets = attrib(type=Set[EntryPoint], default=Factory(lambda: set()))
+    targets = attrib(type=Set[EntryPointT], default=Factory(lambda: set()))
     # the specific entry point (a member of `targets`) the agent actually arrived at, once
     # `state == TrainState.DONE` - set exactly once, by `AbstractRailEnv.handle_done_state()`, before
     # `current_entry_point` is possibly cleared to `None` (`remove_agents_at_target`). `None` until
     # the agent reaches DONE. Unlike `next(iter(targets))`, this is deterministic: `targets` may hold
     # several direction alternatives at the same position, only one of which was actually reached.
-    target_entry_point = attrib(type=Optional[EntryPoint], default=Factory(lambda: None),
+    target_entry_point = attrib(type=Optional[EntryPointT], default=Factory(lambda: None),
                                 converter=_sanitize_entry_point)
 
     moving = attrib(default=False, type=bool)
@@ -255,11 +255,11 @@ class EnvAgent(Generic[EntryPoint]):
     # NEW : EnvAgent Reward Handling
     arrival_time = attrib(default=None, type=int)
 
-    old_entry_point = attrib(type=Optional[EntryPoint], default=Factory(lambda: None),
+    old_entry_point = attrib(type=Optional[EntryPointT], default=Factory(lambda: None),
                              converter=_sanitize_entry_point)
 
     # design: actions applied at cell entry.
-    next_entry_point = attrib(type=Optional[EntryPoint], default=Factory(lambda: None),
+    next_entry_point = attrib(type=Optional[EntryPointT], default=Factory(lambda: None),
                               converter=_sanitize_entry_point)
 
     def reset(self):

--- a/flatland/envs/rail_env.py
+++ b/flatland/envs/rail_env.py
@@ -35,9 +35,9 @@ from flatland.envs.step_utils.speed_counter import _cap_speed, SEGMENT_LENGTH
 from flatland.envs.step_utils.states import TrainState, StateTransitionSignals
 from flatland.utils import seeding
 
-UnderlyingTransitionMap = TypeVar('UnderlyingTransitionMap', bound=TransitionMap)
-UnderlyingResourceMap = TypeVar('UnderlyingResourceMap', bound=ResourceMap)
-EntryPoint = TypeVar('EntryPoint')
+TransitionMapT = TypeVar('TransitionMapT', bound=TransitionMap)
+ResourceMapT = TypeVar('ResourceMapT', bound=ResourceMap)
+EntryPointT = TypeVar('EntryPointT')
 
 
 class PreStepSnapshot(NamedTuple):
@@ -51,7 +51,7 @@ class PreStepSnapshot(NamedTuple):
     pre_offsets: Dict[int, Fraction]
 
 
-class AbstractRailEnv(Environment, Generic[UnderlyingTransitionMap, UnderlyingResourceMap, EntryPoint]):
+class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPointT]):
     """
     AbstractRailEnv environment class.
 
@@ -182,7 +182,7 @@ class AbstractRailEnv(Environment, Generic[UnderlyingTransitionMap, UnderlyingRe
         self.line_generator: "LineGenerator" = line_generator
         self.timetable_generator = timetable_generator
 
-        self.rail: Optional[UnderlyingTransitionMap] = None
+        self.rail: Optional[TransitionMapT] = None
         self.stations_links = None
 
         self.remove_agents_at_target = remove_agents_at_target
@@ -197,7 +197,7 @@ class AbstractRailEnv(Environment, Generic[UnderlyingTransitionMap, UnderlyingRe
         self.dev_obs_dict = {}
         self.dev_pred_dict = {}
 
-        self.agents: List[EnvAgent[EntryPoint]] = []
+        self.agents: List[EnvAgent[EntryPointT]] = []
         self.num_resets = 0
 
         self.dones = None
@@ -209,7 +209,7 @@ class AbstractRailEnv(Environment, Generic[UnderlyingTransitionMap, UnderlyingRe
         self.resource_check = ac.MotionCheck()
 
         # TODO https://github.com/flatland-association/flatland-rl/issues/242 bad design smell - resource map is not persisted, in particular level_free_positions is not persisted, only rail!
-        self.resource_map: UnderlyingResourceMap = self._extract_resource_map_from_optionals({})
+        self.resource_map: ResourceMapT = self._extract_resource_map_from_optionals({})
 
         if rewards is None:
             self.rewards = DefaultRewards()
@@ -363,7 +363,7 @@ class AbstractRailEnv(Environment, Generic[UnderlyingTransitionMap, UnderlyingRe
         observation_dict: Dict = self._get_observations()
         return observation_dict, info_dict
 
-    def _extract_resource_map_from_optionals(self, optionals: dict) -> UnderlyingResourceMap:
+    def _extract_resource_map_from_optionals(self, optionals: dict) -> ResourceMapT:
         raise NotImplementedError()
 
     def clear_rewards_dict(self):
@@ -918,7 +918,7 @@ class AbstractRailEnv(Environment, Generic[UnderlyingTransitionMap, UnderlyingRe
                     assert_speed_matches_if_movement_allowed(agent.speed_counter.speed, pre_speed,
                                                              movement_allowed, agent)
 
-    def _infrastructure_representation(self, entry_point: EntryPoint) -> str:
+    def _infrastructure_representation(self, entry_point: EntryPointT) -> str:
         raise NotImplementedError()
 
     def _get_observations(self):
@@ -929,15 +929,15 @@ class AbstractRailEnv(Environment, Generic[UnderlyingTransitionMap, UnderlyingRe
         self.obs_dict = self.obs_builder.get_many(list(range(self.get_num_agents())))
         return self.obs_dict
 
-    def _call_rail_generator(self, optionals) -> Tuple[dict, UnderlyingTransitionMap]:
+    def _call_rail_generator(self, optionals) -> Tuple[dict, TransitionMapT]:
 
         # TODO https://github.com/flatland-association/flatland-rl/issues/242 fix signature
         return self.rail_generator(self.number_of_agents, self.num_resets, self.np_random)
 
-    def _apply_timetable_to_agents(self, agents, timetable: "Timetable") -> List[EnvAgent[EntryPoint]]:
+    def _apply_timetable_to_agents(self, agents, timetable: "Timetable") -> List[EnvAgent[EntryPointT]]:
         return EnvAgent.apply_timetable(agents, timetable)
 
-    def _agents_from_line(self, line: "Line") -> List[EnvAgent[EntryPoint]]:
+    def _agents_from_line(self, line: "Line") -> List[EnvAgent[EntryPointT]]:
         raise NotImplementedError()
 
 

--- a/flatland/envs/rail_env_policy.py
+++ b/flatland/envs/rail_env_policy.py
@@ -4,10 +4,10 @@ from flatland.core.policy import Policy
 from flatland.envs.rail_env import RailEnv
 from flatland.envs.rail_env_action import RailEnvActions
 
-T_env = TypeVar('T_env', bound=RailEnv)
-T_obs = TypeVar('T_obs', covariant=True)
-T_act = TypeVar('T_act', bound=RailEnvActions)
+RailEnvT = TypeVar('RailEnvT', bound=RailEnv)
+ObsT = TypeVar('ObsT', covariant=True)
+RailEnvActionsT = TypeVar('RailEnvActionsT', bound=RailEnvActions)
 
 
-class RailEnvPolicy(Policy[T_env, T_obs, T_act]):
+class RailEnvPolicy(Policy[RailEnvT, ObsT, RailEnvActionsT]):
     pass

--- a/flatland/envs/rewards.py
+++ b/flatland/envs/rewards.py
@@ -11,16 +11,16 @@ from flatland.envs.rail_trainrun_data_structures import Waypoint
 from flatland.envs.step_utils.env_utils import AgentTransitionData
 from flatland.envs.step_utils.states import TrainState
 
-Reward = TypeVar('Reward')
-EntryPoint = TypeVar('EntryPoint')
+RewardT = TypeVar('RewardT')
+EntryPointT = TypeVar('EntryPointT')
 
 
-class Rewards(Generic[Reward]):
+class Rewards(Generic[RewardT]):
     """
-    Reward Function Interface.
+    RewardT Function Interface.
     """
 
-    def step_reward(self, agent: EnvAgent, agent_transition_data: AgentTransitionData, distance_map: DistanceMap, elapsed_steps: int) -> Reward:
+    def step_reward(self, agent: EnvAgent, agent_transition_data: AgentTransitionData, distance_map: DistanceMap, elapsed_steps: int) -> RewardT:
         """
         Handles end-of-step-reward for a particular agent.
 
@@ -33,7 +33,7 @@ class Rewards(Generic[Reward]):
         """
         raise NotImplementedError()
 
-    def end_of_episode_reward(self, agent: EnvAgent, distance_map: DistanceMap, elapsed_steps: int) -> Reward:
+    def end_of_episode_reward(self, agent: EnvAgent, distance_map: DistanceMap, elapsed_steps: int) -> RewardT:
         """
         Handles end-of-episode reward for a particular agent.
 
@@ -45,7 +45,7 @@ class Rewards(Generic[Reward]):
         """
         raise NotImplementedError()
 
-    def cumulate(self, *rewards: Reward) -> Reward:
+    def cumulate(self, *rewards: RewardT) -> RewardT:
         """
         Cumulate multiple rewards to one.
 
@@ -60,19 +60,19 @@ class Rewards(Generic[Reward]):
         """
         raise NotImplementedError()
 
-    def empty(self) -> Reward:
+    def empty(self) -> RewardT:
         """
         Return empty initial value neutral for the cumulation.
         """
         raise NotImplementedError()
 
-    def normalize(self, *rewards: Reward, num_agents: int, max_episode_steps: int) -> Optional[float]:
+    def normalize(self, *rewards: RewardT, num_agents: int, max_episode_steps: int) -> Optional[float]:
         """
         Return normalized cumulated rewards. Can be `None` for some rewards.
 
         Parameters
         ----------
-        rewards : List[Reward]
+        rewards : List[RewardT]
         num_agents : int
         max_episode_steps : int
 
@@ -82,19 +82,19 @@ class Rewards(Generic[Reward]):
         """
         return None
 
-    # TODO we should drop these methods once EnvAgent.waypoints is also of EntryPoint instead of Waypoint.
+    # TODO we should drop these methods once EnvAgent.waypoints is also of EntryPointT instead of Waypoint.
     @staticmethod
-    def _sanitize_waypoints(agent_waypoints: List[List[Waypoint]]) -> List[List[EntryPoint]]:
+    def _sanitize_waypoints(agent_waypoints: List[List[Waypoint]]) -> List[List[EntryPointT]]:
         agent_waypoints = [[(Rewards._sanitize_waypoint(wp)) for wp in wps] for wps in agent_waypoints]
         return agent_waypoints
 
     @staticmethod
-    def _sanitize_waypoint(wp: Waypoint) -> EntryPoint:
+    def _sanitize_waypoint(wp: Waypoint) -> EntryPointT:
         return wp._to_tuple() if isinstance(wp, Waypoint) else wp
 
     @staticmethod
-    def _intermediate_waypoints(agent_waypoints: List[List[EntryPoint]],
-                                agent: EnvAgent) -> Iterator[Tuple[List[EntryPoint], int, int]]:
+    def _intermediate_waypoints(agent_waypoints: List[List[EntryPointT]],
+                                agent: EnvAgent) -> Iterator[Tuple[List[EntryPointT], int, int]]:
         """
         Zips an agent's intermediate waypoint alternatives (i.e. excluding the initial and target stops)
         with their corresponding earliest-departure/latest-arrival time windows.
@@ -121,9 +121,9 @@ class DefaultPenalties(fastenum.Enum):
     INTERMEDIATE_EARLY_DEPARTURE = "INTERMEDIATE_EARLY_DEPARTURE"
 
 
-class BaseDefaultRewards(Rewards[Dict[str, float]], Generic[EntryPoint]):
+class BaseDefaultRewards(Rewards[Dict[str, float]], Generic[EntryPointT]):
     r"""
-    Reward Function.
+    RewardT Function.
 
     This scoring function is designed to capture key operational metrics such as punctuality, efficiency in responding to disruptions, and safety.
 
@@ -176,9 +176,9 @@ class BaseDefaultRewards(Rewards[Dict[str, float]], Generic[EntryPoint]):
         assert self.cancellation_factor >= 0
         assert self.target_not_reached_minimum_penalty >= 0
         # https://stackoverflow.com/questions/16439301/cant-pickle-defaultdict
-        self.arrivals: Dict[AgentHandle, Dict[EntryPoint, List[int]]] = defaultdict(defaultdict_list)
-        self.departures: Dict[AgentHandle, Dict[EntryPoint, List[int]]] = defaultdict(defaultdict_list)
-        self.states: Dict[AgentHandle, Dict[EntryPoint, Set[TrainState]]] = defaultdict(defaultdict_set)
+        self.arrivals: Dict[AgentHandle, Dict[EntryPointT, List[int]]] = defaultdict(defaultdict_list)
+        self.departures: Dict[AgentHandle, Dict[EntryPointT, List[int]]] = defaultdict(defaultdict_list)
+        self.states: Dict[AgentHandle, Dict[EntryPointT, Set[TrainState]]] = defaultdict(defaultdict_set)
 
     def step_reward(self, agent: EnvAgent, agent_transition_data: AgentTransitionData, distance_map: DistanceMap, elapsed_steps: int) -> Dict[str, float]:
         d = self.empty()
@@ -254,12 +254,12 @@ class BaseDefaultRewards(Rewards[Dict[str, float]], Generic[EntryPoint]):
                                                                    agent.get_current_delay(elapsed_steps, distance_map))
         agent_waypoints = self._sanitize_waypoints(agent.waypoints)
         for intermediate_alternatives, la, ed in self._intermediate_waypoints(agent_waypoints, agent):
-            agent_arrivals: Set[EntryPoint] = set(self.arrivals[agent.handle])
-            intermediate_alternatives: Set[EntryPoint] = set(intermediate_alternatives)
-            wps_intersection: Set[EntryPoint] = intermediate_alternatives.intersection(agent_arrivals)
+            agent_arrivals: Set[EntryPointT] = set(self.arrivals[agent.handle])
+            intermediate_alternatives: Set[EntryPointT] = set(intermediate_alternatives)
+            wps_intersection: Set[EntryPointT] = intermediate_alternatives.intersection(agent_arrivals)
             # a station may consist of several halting cells (alternative waypoints);
             # the stop is served iff the train stopped at any of them
-            stopped_wps: Set[EntryPoint] = {wp for wp in wps_intersection if TrainState.STOPPED in self.states[agent.handle][wp]}
+            stopped_wps: Set[EntryPointT] = {wp for wp in wps_intersection if TrainState.STOPPED in self.states[agent.handle][wp]}
             if len(stopped_wps) == 0:
                 # stop not served or served but not stopped
                 d[DefaultPenalties.INTERMEDIATE_NOT_SERVED.value] += -1 * self.intermediate_not_served_penalty

--- a/flatland/ml/observations/gym_observation_builder.py
+++ b/flatland/ml/observations/gym_observation_builder.py
@@ -5,13 +5,13 @@ import gymnasium as gym
 import numpy as np
 from ray.rllib.utils.typing import MultiAgentDict
 
-from flatland.core.env_observation_builder import DummyObservationBuilder, AgentHandle, Observation, Env
+from flatland.core.env_observation_builder import DummyObservationBuilder, AgentHandle, ObservationT, EnvT
 from flatland.core.env_observation_builder import ObservationBuilder
 from flatland.envs.observations import GlobalObsForRailEnv
 from flatland.envs.rail_env import RailEnv
 
 
-class GymObservationBuilder(Generic[Env, Observation], ObservationBuilder[Env, Observation]):
+class GymObservationBuilder(Generic[EnvT, ObservationT], ObservationBuilder[EnvT, ObservationT]):
     """
     Adds `observation_space` method to `ObservationBuilder`.
     """
@@ -24,7 +24,7 @@ class GymObservationBuilder(Generic[Env, Observation], ObservationBuilder[Env, O
         raise NotImplementedError()
 
 
-class GymObservationBuilderWrapper(GymObservationBuilder[Env, Observation]):
+class GymObservationBuilderWrapper(GymObservationBuilder[EnvT, ObservationT]):
     """
     Wraps an existing `ObservationBuilder` into a `GymObservationBuilder`.
     """
@@ -34,7 +34,7 @@ class GymObservationBuilderWrapper(GymObservationBuilder[Env, Observation]):
         self.wrap = wrap
         self.observation_space = observation_space
 
-    def reset(self, env: Env):
+    def reset(self, env: EnvT):
         super().reset(env)
         self.wrap.reset(env)
 

--- a/tests/trajectories/test_policy_runner.py
+++ b/tests/trajectories/test_policy_runner.py
@@ -7,7 +7,7 @@ import numpy as np
 import pytest
 
 from flatland.callbacks.callbacks import FlatlandCallbacks, make_multi_callbacks
-from flatland.core.env_observation_builder import ObservationBuilder, AgentHandle, Observation
+from flatland.core.env_observation_builder import ObservationBuilder, AgentHandle, ObservationT
 from flatland.env_generation.env_generator import env_generator, env_generator_legacy
 from flatland.envs.RailEnvPolicy import RailEnvPolicy
 from flatland.envs.persistence import RailEnvPersister
@@ -47,7 +47,7 @@ class RandomPolicy(RailEnvPolicy):
 class EnvStepObservationBuilder(ObservationBuilder[RailEnv, int]):
     """Returns elapsed steps as observation."""
 
-    def get(self, handle: AgentHandle = 0) -> Observation:
+    def get(self, handle: AgentHandle = 0) -> ObservationT:
         return self.env._elapsed_steps
 
 


### PR DESCRIPTION

## Changes

* refactor: standardize TypeVar naming to <BoundClassName>T convention. Every TypeVar now ends in T (satisfying pylint's default typevar-rgx, which rejects a bare T/T1) and, when bound, spells out the bound class exactly (EnvT -> EnvironmentT/RailEnvT, ActT -> RailEnvActionsT, DistanceMapT -> EntryPointDistanceMapT) rather than an abbreviated name, so the TypeVar's name alone tells you what it's bound to.


## Related issues

Link to every issue from the issue tracker (if any) you addressed in this PR.

## Checklist

- [ ] Tests are included for relevant behavior changes.
- [ ] Documentation is added in the [flatland-book](https://github.com/flatland-association/flatland-book) repo for relevant behavior changes.
- [ ] If you made important user-facing changes, describe them under the `[Unreleased]` tag in `CHANGELOG.md`.
- [ ] New package dependencies are declared in the `pyproject.toml` file.
  Requirement files have been updated by running `tox -e requirements`.
- [ ] Code works with all supported Python versions (3.10, 3.11, 3.12 and 3.13). Checks run with all supported version and are
  required to run successfully.
- [ ] Code is formatted according to PEP 8 (an IDE like PyCharm can do this for you).
- [ ] Technical guidelines listed in `CONTRIBUTING.md` are followed.
