### PR TITLE
refactor: D2.5 resource map: attach resources to edges/configurations instead of entry points.

### DIFF
--- a/flatland/core/graph/graph_resource_map.py
+++ b/flatland/core/graph/graph_resource_map.py
@@ -7,7 +7,7 @@ class GraphResourceMap(ResourceMap[str, str]):
     def __init__(self, _resource_map: Dict[str, str]):
         self._resource_map = _resource_map
 
-    def get_resource(self, entry_point: Optional[str]) -> Optional[str]:
-        if entry_point is None:
+    def get_resource(self, from_entry_point: Optional[str], to_entry_point: Optional[str]) -> Optional[str]:
+        if from_entry_point is None:
             return None
-        return self._resource_map[entry_point]
+        return self._resource_map[from_entry_point]

--- a/flatland/core/grid/grid_resource_map.py
+++ b/flatland/core/grid/grid_resource_map.py
@@ -10,10 +10,11 @@ class GridResourceMap(ResourceMap[Tuple[Tuple[int, int], int], Union[Tuple[Tuple
         if self.level_free_positions is None:
             self.level_free_positions = set()
 
-    def get_resource(self, entry_point: Optional[Tuple[Tuple[int, int], int]]) -> Optional[Tuple[int, int]]:
-        if entry_point is None:
+    def get_resource(self, from_entry_point: Optional[Tuple[Tuple[int, int], int]],
+                      to_entry_point: Optional[Tuple[Tuple[int, int], int]]) -> Optional[Tuple[int, int]]:
+        if from_entry_point is None:
             return None
-        position, direction = entry_point
+        position, direction = from_entry_point
         if position in self.level_free_positions:
             return position, direction % 2
         return position

--- a/flatland/core/resource_map.py
+++ b/flatland/core/resource_map.py
@@ -6,9 +6,13 @@ ResourceT = TypeVar('ResourceT')
 
 class ResourceMap(Generic[EntryPointT, ResourceT]):
     """
-    ResourceT Map stores the single resource required to be at the entry point
-    (i.e. to be in the cell or level-free crossing cell in grid world, resp. at the node in graph world).
+    ResourceT Map stores the single resource occupied while traversing the edge from `from_entry_point` to
+    `to_entry_point` - the resource held is always the one at `from_entry_point` (the cell/node entered;
+    `to_entry_point` is the neighbor entered once the edge is left, see `GraphTransitionMap`'s docstring
+    for the `[u,v)` framing this mirrors), i.e. to be in the cell or level-free crossing cell in grid
+    world, resp. at the node in graph world. Keyed by the edge rather than a bare entry point, so a
+    resource can in principle depend on the whole transition, not just where it starts.
     """
 
-    def get_resource(self, entry_point: Optional[EntryPointT]) -> Optional[ResourceT]:
+    def get_resource(self, from_entry_point: Optional[EntryPointT], to_entry_point: Optional[EntryPointT]) -> Optional[ResourceT]:
         raise NotImplementedError()

--- a/flatland/envs/rail_env.py
+++ b/flatland/envs/rail_env.py
@@ -572,8 +572,8 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
 
             # (4) MOTION/RESOURCE CHECK
             # only conflict if the level-free cell is traversed through the same axis (horizontally (0 north or 2 south), or vertically (1 east or 3 west)
-            current_resource = self.resource_map.get_resource(agent.current_entry_point)
-            new_resource = self.resource_map.get_resource(candidate_entry_point)
+            current_resource = self.resource_map.get_resource(agent.current_entry_point, agent.next_entry_point)
+            new_resource = self.resource_map.get_resource(candidate_entry_point, candidate_next_entry_point)
 
             # (5) GATHER STATE TRANSITION SIGNALS
             # Malfunction starts when in_malfunction is set to true (inverse of malfunction_counter_complete)
@@ -734,7 +734,8 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
         return True
 
     def _verify_mutually_exclusive_resource_allocation(self):
-        resources = [self.resource_map.get_resource(agent.current_entry_point) for agent in self.agents if agent.current_entry_point is not None]
+        resources = [self.resource_map.get_resource(agent.current_entry_point, agent.next_entry_point)
+                     for agent in self.agents if agent.current_entry_point is not None]
         if len(resources) != len(set(resources)):
             msgs = f"Found two agents occupying same resource (cell or level-free cell) in step {self._elapsed_steps}: {resources}\n"
             msgs += f"- motion check: {list(self.resource_check.stopped)}"
@@ -743,7 +744,7 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
             dup_resources = [res for res, count in counts.items() if count > 1]
             for dup in dup_resources:
                 for agent in self.agents:
-                    if self.resource_map.get_resource(agent.current_entry_point) == dup:
+                    if self.resource_map.get_resource(agent.current_entry_point, agent.next_entry_point) == dup:
                         msg = (f"\n================== BAD AGENT ==================================\n\n\n\n\n"
                                f"- agent:\t{agent} \n"
                                f"- state_machine:\t{agent.state_machine}\n"


### PR DESCRIPTION


## Changes

* refactor: key ResourceMap.get_resource by edge (from/to entry point). Generalizes ResourceMap to resolve the resource occupied while traversing an edge from_entry_point -> to_entry_point, rather than a single entry point in isolation - the resource held is always the one at from_entry_point (the cell/node entered), mirroring GraphTransitionMap's own [u,v) edge/resource-occupation framing. Pure API refactor: resource values are unchanged (grid: position, or (position, direction % 2) at level-free crossings; graph: dict lookup), just keyed on the edge now so a future resource can depend on the whole transition, not just where it starts.


## Related issues

Link to every issue from the issue tracker (if any) you addressed in this PR.

## Checklist

- [ ] Tests are included for relevant behavior changes.
- [ ] Documentation is added in the [flatland-book](https://github.com/flatland-association/flatland-book) repo for relevant behavior changes.
- [ ] If you made important user-facing changes, describe them under the `[Unreleased]` tag in `CHANGELOG.md`.
- [ ] New package dependencies are declared in the `pyproject.toml` file.
  Requirement files have been updated by running `tox -e requirements`.
- [ ] Code works with all supported Python versions (3.10, 3.11, 3.12 and 3.13). Checks run with all supported version and are
  required to run successfully.
- [ ] Code is formatted according to PEP 8 (an IDE like PyCharm can do this for you).
- [ ] Technical guidelines listed in `CONTRIBUTING.md` are followed.
