### PR TITLE
fix!: D2.7 let `STOP_MOVING` complete an in-flight cell-boundary crossing. 

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,7 +1,7 @@
 name: Checks
 
 env:
-    flatland-benchmarks-episodes-url: "https://github.com/flatland-association/flatland-scenarios/raw/refs/heads/178-agents-living-on-the-edge-3/trajectories/FLATLAND_BENCHMARK_EPISODES_FOLDER_v6.zip"
+    flatland-benchmarks-episodes-url: "https://github.com/flatland-association/flatland-scenarios/raw/refs/heads/178-agents-living-on-the-edge-9/trajectories/FLATLAND_BENCHMARK_EPISODES_FOLDER_v7.zip"
     flatland-scenarios-olten-partially-closed-url: "https://github.com/flatland-association/flatland-scenarios/raw/refs/heads/main/scenario_olten/data/OLTEN_PARTIALLY_CLOSED_v2.zip"
     ecml2026-pkl: "https://github.com/flatland-association/ecml2026-starterkit/raw/refs/heads/main/reinforcement_learning/sampling/level_0_scenario_1.pkl"
     ecml2026-stations-pkl: "https://github.com/flatland-association/ecml2026-starterkit/raw/refs/heads/main/reinforcement_learning/sampling/stations.pkl"

--- a/.github/workflows/run-ci-env-test.yml
+++ b/.github/workflows/run-ci-env-test.yml
@@ -22,7 +22,7 @@ on:
                 default: ""
 
 env:
-    flatland-benchmarks-episodes-url: "https://github.com/flatland-association/flatland-scenarios/raw/refs/heads/178-agents-living-on-the-edge-3/trajectories/FLATLAND_BENCHMARK_EPISODES_FOLDER_v6.zip"
+    flatland-benchmarks-episodes-url: "https://github.com/flatland-association/flatland-scenarios/raw/refs/heads/178-agents-living-on-the-edge-9/trajectories/FLATLAND_BENCHMARK_EPISODES_FOLDER_v7.zip"
 
 jobs:
     # requirements-dev.txt (incl. scipy, already built from source) is baked into the image by build-ci-env.yml

--- a/benchmarks/benchmark_episodes.py
+++ b/benchmarks/benchmark_episodes.py
@@ -5,8 +5,8 @@ import pytest
 
 from flatland.evaluators.trajectory_evaluator import TrajectoryEvaluator
 
-DOWNLOAD_INSTRUCTIONS = "Download from https://github.com/flatland-association/flatland-scenarios/raw/refs/heads/178-agents-living-on-the-edge-3/trajectories/FLATLAND_BENCHMARK_EPISODES_FOLDER_v6.zip and set BENCHMARK_EPISODES_FOLDER env var to extracted folder."
-# zip -r FLATLAND_BENCHMARK_EPISODES_FOLDER_v6.zip 30x30\ map -x "*.DS_Store"; zip -r FLATLAND_BENCHMARK_EPISODES_FOLDER_v6.zip malfunction_deadlock_avoidance_heuristics -x "*.DS_Store"
+DOWNLOAD_INSTRUCTIONS = "Download from https://github.com/flatland-association/flatland-scenarios/raw/refs/heads/178-agents-living-on-the-edge-9/trajectories/FLATLAND_BENCHMARK_EPISODES_FOLDER_v7.zip and set BENCHMARK_EPISODES_FOLDER env var to extracted folder."
+# zip -r FLATLAND_BENCHMARK_EPISODES_FOLDER_v7.zip 30x30\ map -x "*.DS_Store"; zip -r FLATLAND_BENCHMARK_EPISODES_FOLDER_v7.zip malfunction_deadlock_avoidance_heuristics -x "*.DS_Store"
 from flatland.trajectories.trajectories import Trajectory
 
 

--- a/flatland/core/transition_map.py
+++ b/flatland/core/transition_map.py
@@ -140,6 +140,13 @@ class TransitionMap(Generic[EntryPointT, TransitionsT, TransitionsValidityT, Act
     def get_predecessor_entry_points(self, entry_point: EntryPointT) -> Set[EntryPointT]:
         raise NotImplementedError()
 
+    def is_successor(self, entry_point: EntryPointT, successor_entry_point: EntryPointT) -> bool:
+        """
+        Whether successor_entry_point is reachable from entry_point by exactly one action, i.e. is a
+        member of get_successor_entry_points(entry_point).
+        """
+        return successor_entry_point in self.get_successor_entry_points(entry_point)
+
     def is_valid_entry_point(self, entry_point: EntryPointT) -> bool:
         """
         Whether the map contains the entry_point (a cell plus entry direction - a position+direction tuple

--- a/flatland/envs/rail_env.py
+++ b/flatland/envs/rail_env.py
@@ -784,7 +784,8 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
 
     def _check_configuration_invariant(self, current_entry_point: Any, next_entry_point: Any):
         assert (current_entry_point is None) == (next_entry_point is None)
-        assert current_entry_point is None or self.rail.is_successor(current_entry_point, next_entry_point)
+        if current_entry_point is not None:
+            assert self.rail.is_successor(current_entry_point, next_entry_point)
 
     def _check_post_position_invariants(self, action_dict: Dict[int, RailEnvActions],
                                         pre_step: PreStepSnapshot) -> None:
@@ -794,14 +795,13 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
         """
         for h in pre_step.pre_speeds.keys():
             agent = self.agents[h]
-            action = RailEnvActions.from_value(action_dict.get(h, RailEnvActions.DO_NOTHING))
-            # candidates discarded
+            # candidates discarded in distribute phase -> previous configuration
             if not self.temp_transition_data[h].resource_check:
                 assert agent.current_entry_point == pre_step.pre_current_entry_points[h]
                 assert agent.next_entry_point == pre_step.pre_next_entry_points[h]
-            # candidates accepted
+            # candidates accepted in distribute phase
             else:
-                # done or
+                # done
                 if pre_step.pre_dones[h]:
                     if self.remove_agents_at_target:
                         assert agent.current_entry_point is None
@@ -832,94 +832,154 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
                         assert agent.current_entry_point == self.temp_transition_data[h].candidate_entry_point
                         assert agent.next_entry_point == self.temp_transition_data[h].candidate_next_entry_point
                         assert agent.current_entry_point == agent.target_entry_point
-                # cell transition
-                elif agent.current_entry_point is not None and (
-                    pre_step.pre_offsets[h] + pre_step.pre_speeds[h] >= SEGMENT_LENGTH):
+                # on-map cell transition
+                elif agent.current_entry_point is not None and (pre_step.pre_offsets[h] + pre_step.pre_speeds[h] >= SEGMENT_LENGTH):
                     assert agent.current_entry_point is not None
                     assert agent.current_entry_point == self.temp_transition_data[h].candidate_entry_point
-                    # TODO diff overleaf vs. implementation!
-                    # assert agent.next_entry_point == self.temp_transition_data[h].candidate_next_entry_point
-                # else:
-                #     assert agent.current_entry_point == pre_step.pre_current_entry_points[h]
-                #     assert agent.next_entry_point == pre_step.pre_next_entry_points[h]
+                    assert agent.next_entry_point == self.temp_transition_data[h].candidate_next_entry_point
+                # stay
+                else:
+                    assert agent.current_entry_point == pre_step.pre_current_entry_points[h]
+                    assert agent.next_entry_point == pre_step.pre_next_entry_points[h]
 
-    def _check_post_speed_invariants(self, action_dict: Dict[int, RailEnvActions],
-                                     pre_step: PreStepSnapshot) -> None:
+    def _check_post_speed_distance_invariants(self, action_dict: Dict[int, RailEnvActions],
+                                              pre_step: PreStepSnapshot) -> None:
         """
         Verify, for every agent, that this step's speed update matches the expected transition given the
         pre-step snapshot.
         """
+        # distance update invariant
+        for h, pre_speed in pre_step.pre_speeds.items():
+            agent = self.agents[h]
 
-        def assert_speed_matches_if_movement_allowed(actual: Fraction, expected: Fraction, movement_allowed: bool,
-                                                     agent: EnvAgent) -> None:
-            if movement_allowed:
-                assert actual == expected, agent
+            # candidates discarded in distribute phase -> speed 0 and distance updated with pre-speed
+            if not self.temp_transition_data[h].resource_check:
+                if agent.state in [TrainState.WAITING, TrainState.READY_TO_DEPART, TrainState.MALFUNCTION_OFF_MAP]:
+                    # TODO (D3) initialize speed and distance to None instead of max_speed
+                    assert agent.speed_counter.distance is None or agent.speed_counter.distance == 0
+                else:
+                    assert agent.speed_counter.distance == min((pre_step.pre_offsets[h] + pre_speed), SEGMENT_LENGTH)
+
+            # candidates accepted in distribute phase
             else:
-                assert actual == 0, agent
+                action_valid = self.temp_transition_data[h].state_transition_signal.action_valid
+                # done or target reached
+                if pre_step.pre_dones[h] or self.temp_transition_data[h].candidate_entry_point in agent.targets:
+                    assert agent.target_entry_point is not None
+                    assert agent.target_entry_point in agent.targets
+                    if self.remove_agents_at_target:
+                        assert agent.speed_counter.distance is None
+                    else:
+                        assert agent.speed_counter.distance == min((pre_step.pre_offsets[h] + pre_speed), SEGMENT_LENGTH)
+                # off map
+                elif pre_step.pre_offsets[h] is None:
+                    if agent.state in [TrainState.WAITING, TrainState.READY_TO_DEPART, TrainState.MALFUNCTION_OFF_MAP]:
+                        assert agent.speed_counter.distance is None
+                    # TODO is this map entry?
+                    elif agent.state in [TrainState.MOVING]:
+                        # TODO (D3) initialize speed to 0 instead of max_speed, then should be in-line with  with pre-speed invariant
+                        assert agent.speed_counter.distance == 0
+                    else:
+                        raise
+                # off map 2
+                elif agent.state in [TrainState.WAITING, TrainState.READY_TO_DEPART, TrainState.MALFUNCTION_OFF_MAP]:
+                    # TODO (D3) initialize speed and distance to None instead of max_speed
+                    assert agent.speed_counter.distance is None or agent.speed_counter.distance == 0
+                # malfunction
+                elif agent.malfunction_handler.in_malfunction:
+                    assert agent.speed_counter.distance == pre_step.pre_offsets[h]
+                # invalid action
+                elif not action_valid:
+                    # TODO ouch! STOPPED->MOVING should never accumulate distance, violating pre-speed invariant of (D1), however it seems not to do cell transition
+                    # assert agent.speed_counter.distance == pre_step.pre_offsets[h]
+                    assert agent.speed_counter.distance == min((pre_step.pre_offsets[h] + pre_speed), SEGMENT_LENGTH)
+                # stopped
+                elif pre_speed == 0 and agent.speed_counter.speed == 0:
+                    assert agent.speed_counter.distance == pre_step.pre_offsets[h]
+                elif pre_speed == 0 and agent.speed_counter.speed > 0:
+                    # TODO ouch! STOPPED->MOVING should never accumulate distance, violating pre-speed invariant of (D1), it can even do cell transition
+                    # assert agent.speed_counter.distance == pre_step.pre_offsets[h]
+                    assert agent.speed_counter.distance == ((pre_step.pre_offsets[h] + pre_speed) % SEGMENT_LENGTH)
+                # TODO https://github.com/flatland-association/flatland-rl/issues/280 very dodgy - when does this happen? This seems a bug: when the malfunction stops (done before/beginning step), agent be allowed to accelerate? Or is the step when it reaches 0 the last in malfunction?
+                elif agent.state in [TrainState.MALFUNCTION] and not agent.malfunction_handler.in_malfunction:
+                    assert pre_step.pre_in_malfunctions[h]
+                    assert agent.speed_counter.distance == pre_step.pre_offsets[h]
+                else:
+                    assert agent.speed_counter.distance == ((pre_step.pre_offsets[h] + pre_speed) % SEGMENT_LENGTH)
 
         # speed update invariant
         for h, pre_speed in pre_step.pre_speeds.items():
-            # in malfunction
             agent = self.agents[h]
             action = RailEnvActions.from_value(action_dict.get(h, RailEnvActions.DO_NOTHING))
-            action_valid = self.temp_transition_data[h].action_valid
-            movement_allowed = self.temp_transition_data[h].state_transition_signal.movement_allowed
-            # done (covers both an agent already done before this step and one that just reached
-            # its target this exact step - see rail_env.py step()'s (10b))
-            if agent.state == TrainState.DONE:
-                if self.remove_agents_at_target:
-                    assert agent.speed_counter.speed == pre_speed
-                else:
-                    # design: DONE but not removed freezes speed at 0, see rail_env.py step()'s (10b)
-                    assert agent.speed_counter.speed == Fraction(0)
-            # malfunction
-            elif agent.malfunction_handler.in_malfunction:  # N.B. in_malfunction updated
-                if agent.state in [TrainState.MALFUNCTION_OFF_MAP]:
-                    assert agent.speed_counter.speed == agent.speed_counter.max_speed
-                else:
-                    assert agent.speed_counter.speed == 0
-            # map entry
-            elif pre_step.pre_current_entry_points[h] is None and RailEnvActions.is_moving_action(action) \
-                and pre_step.pre_dones[h] is False and self._elapsed_steps >= agent.earliest_departure:
-                # TODO https://github.com/flatland-association/flatland-rl/issues/280 revise design (D3): set speed 0 off map (changes behaviour when not full acceleration delta)
-                assert agent.speed_counter.speed == pre_speed
-            # TODO https://github.com/flatland-association/flatland-rl/issues/280 does not work yet
-            # # invalid action
-            # elif not action_valid:
-            #     if agent.state in [TrainState.WAITING, TrainState.READY_TO_DEPART]:
-            #         assert agent.speed_counter.speed == pre_step.pre_speeds[h]
-            #     else:
-            #         assert agent.speed_counter.speed == 0
-            # TODO https://github.com/flatland-association/flatland-rl/issues/280 what about straight condition from overleaf?
-            elif action == RailEnvActions.MOVE_FORWARD or (pre_speed == 0 and RailEnvActions.is_moving_action(action)):
-                if agent.state in [TrainState.WAITING]:
-                    assert agent.speed_counter.speed == pre_step.pre_speeds[h]
-                else:
-                    # TODO https://github.com/flatland-association/flatland-rl/issues/280 very dodgy - when does this happen? This seems a bug: when the malfunction stops (done before/beginning step), agent be allowed to accelerate? Or is the step when it reaches 0 the last in malfunction?
-                    if agent.state in [TrainState.MALFUNCTION] and not agent.malfunction_handler.in_malfunction:
 
-                        assert agent.speed_counter.speed == 0
-                    elif agent.state in [TrainState.MALFUNCTION_OFF_MAP] and not agent.malfunction_handler.in_malfunction:
+            # candidates discarded in distribute phase -> speed 0 and distance updated with pre-speed
+            if not self.temp_transition_data[h].resource_check:
+                # TODO (D3) initialize speed and distance to None instead of max_speed
+                if agent.state not in [TrainState.READY_TO_DEPART]:
+                    assert agent.speed_counter.speed == 0
+                else:
+                    assert agent.speed_counter.speed == pre_speed
+            # candidates accepted in distribute phase
+            else:
+                action_valid = self.temp_transition_data[h].state_transition_signal.action_valid
+                # done or target reached
+                if pre_step.pre_dones[h] or self.temp_transition_data[h].candidate_entry_point in agent.targets:
+                    assert agent.target_entry_point is not None
+                    assert agent.target_entry_point in agent.targets
+                    if self.remove_agents_at_target:
+                        # TODO cleanup? Make speed None off map?
+                        assert agent.speed_counter.speed == pre_speed
+                    else:
+                        assert agent.speed_counter.speed == Fraction(0)
+                # malfunction
+                elif agent.malfunction_handler.in_malfunction:
+                    if agent.state in [TrainState.MALFUNCTION_OFF_MAP]:
+                        # TODO (D3) initialize speed to 0 instead of max_speed
                         assert agent.speed_counter.speed == agent.speed_counter.max_speed
                     else:
-                        assert_speed_matches_if_movement_allowed(
-                            agent.speed_counter.speed,
-                            min(pre_speed + self.acceleration_delta, agent.speed_counter.max_speed),
-                            movement_allowed, agent)
-            # braking
-            elif action == RailEnvActions.STOP_MOVING:
-                if agent.state in [TrainState.WAITING, TrainState.READY_TO_DEPART, TrainState.MALFUNCTION_OFF_MAP]:
-                    assert agent.speed_counter.speed == agent.speed_counter.max_speed
+                        assert agent.speed_counter.speed == 0
+                # map entry
+                elif pre_step.pre_current_entry_points[h] is None and RailEnvActions.is_moving_action(action) \
+                    and pre_step.pre_dones[h] is False and self._elapsed_steps >= agent.earliest_departure:
+                    # TODO https://github.com/flatland-association/flatland-rl/issues/280 revise design (D3): set speed 0 off map (changes behaviour when not full acceleration delta)
+                    assert agent.speed_counter.speed == pre_speed
+                # stay off map
+                elif pre_step.pre_current_entry_points[h] is None:
+                    # TODO (D3) initialize speed to 0 instead of max_speed
+                    assert agent.speed_counter.speed == pre_speed
+                    assert agent.speed_counter.distance is None
+                # invalid action
+                elif not action_valid:
+                    if agent.state in [TrainState.WAITING, TrainState.READY_TO_DEPART]:
+                        assert agent.speed_counter.speed == pre_step.pre_speeds[h]
+                    else:
+                        assert agent.speed_counter.speed == 0
+                # acceleration or start moving
+                elif action == RailEnvActions.MOVE_FORWARD or (pre_speed == 0 and RailEnvActions.is_moving_action(action)):
+                    if agent.state in [TrainState.WAITING]:
+                        assert agent.speed_counter.speed == pre_step.pre_speeds[h]
+                    else:
+                        # TODO https://github.com/flatland-association/flatland-rl/issues/280 very dodgy - when does this happen? This seems a bug: when the malfunction stops (done before/beginning step), agent be allowed to accelerate? Or is the step when it reaches 0 the last in malfunction?
+                        if agent.state in [TrainState.MALFUNCTION] and not agent.malfunction_handler.in_malfunction:
+                            assert agent.speed_counter.speed == 0
+                        elif agent.state in [TrainState.MALFUNCTION_OFF_MAP] and not agent.malfunction_handler.in_malfunction:
+                            assert agent.speed_counter.speed == agent.speed_counter.max_speed
+                        else:
+                            assert agent.speed_counter.speed == min(pre_speed + self.acceleration_delta, agent.speed_counter.max_speed)
+
+                # braking
+                elif action == RailEnvActions.STOP_MOVING:
+                    # TODO (D3) initialize speed to 0 instead of max_speed
+                    if agent.state in [TrainState.WAITING, TrainState.READY_TO_DEPART, TrainState.MALFUNCTION_OFF_MAP]:
+                        assert agent.speed_counter.speed == agent.speed_counter.max_speed
+                    else:
+                        assert agent.speed_counter.speed == max(pre_speed + self.braking_delta, 0)
+                # default
                 else:
-                    assert_speed_matches_if_movement_allowed(
-                        agent.speed_counter.speed, max(pre_speed + self.braking_delta, 0), movement_allowed, agent)
-            # default
-            else:
-                if agent.state in [TrainState.WAITING, TrainState.READY_TO_DEPART, TrainState.MALFUNCTION_OFF_MAP]:
-                    assert agent.speed_counter.speed == agent.speed_counter.max_speed
-                else:
-                    assert_speed_matches_if_movement_allowed(agent.speed_counter.speed, pre_speed,
-                                                             movement_allowed, agent)
+                    if agent.state in [TrainState.WAITING, TrainState.READY_TO_DEPART, TrainState.MALFUNCTION_OFF_MAP]:
+                        assert agent.speed_counter.speed == agent.speed_counter.max_speed
+                    else:
+                        assert agent.speed_counter.speed == pre_speed
 
     def _infrastructure_representation(self, entry_point: EntryPointT) -> str:
         raise NotImplementedError()
@@ -1061,7 +1121,7 @@ class RailEnv(AbstractRailEnv[GridTransitionMap, GridResourceMap, Tuple[Tuple[in
         self._update_agent_positions_map()
         if self.check_step_pre_post_conditions:
             self._verify_mutually_exclusive_resource_allocation()
-            self._check_post_speed_invariants(action_dict, pre_step_snapshot)
+            self._check_post_speed_distance_invariants(action_dict, pre_step_snapshot)
             self._check_post_position_invariants(action_dict, pre_step_snapshot)
         return obs, rewards, dones, info
 

--- a/flatland/envs/rail_env.py
+++ b/flatland/envs/rail_env.py
@@ -784,8 +784,7 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
 
     def _check_configuration_invariant(self, current_entry_point: Any, next_entry_point: Any):
         assert (current_entry_point is None) == (next_entry_point is None)
-        # TODO replace by is successor?
-        assert current_entry_point is None or current_entry_point != next_entry_point
+        assert current_entry_point is None or self.rail.is_successor(current_entry_point, next_entry_point)
 
     def _check_post_position_invariants(self, action_dict: Dict[int, RailEnvActions],
                                         pre_step: PreStepSnapshot) -> None:

--- a/flatland/envs/rail_env.py
+++ b/flatland/envs/rail_env.py
@@ -541,7 +541,7 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
             # (3b.5) cell transition - attempt granted (is_cell_exit reached, allowed to get moving
             # independently, and a valid look-ahead exists beyond the already-decided target)
             elif is_on_map and is_cell_exit and candidate_entry_point_independent is not None and (
-                (state == TrainState.MOVING and not (stop_action_given and candidate_speed == 0))
+                state == TrainState.MOVING
                 or (state != TrainState.MOVING and movement_action_given)
             ):
                 assert agent.current_entry_point is not None
@@ -644,7 +644,10 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
             # beyond it (see (3b) above, where the crossing itself is only attempted if that candidate
             # exists - so candidate_entry_point below is guaranteed non-None whenever entering_new_cell
             # is True).
-            if agent.state == TrainState.MOVING:
+            if agent.state == TrainState.MOVING or (
+                agent.state == TrainState.STOPPED and agent.state_machine.previous_state == TrainState.MOVING
+                and resource_check
+            ):
                 entering_new_cell = agent.current_entry_point != candidate_entry_point
                 agent.current_entry_point = _sanitize_entry_point(candidate_entry_point)
                 if entering_new_cell:

--- a/notebooks/trajectories-analysis.ipynb
+++ b/notebooks/trajectories-analysis.ipynb
@@ -74,9 +74,9 @@
    },
    "outputs": [],
    "source": [
-    "!wget -q https://github.com/flatland-association/flatland-scenarios/raw/refs/heads/178-agents-living-on-the-edge-3/trajectories/FLATLAND_BENCHMARK_EPISODES_FOLDER_v6.zip -O /tmp/FLATLAND_BENCHMARK_EPISODES_FOLDER_v6.zip\n",
+    "!wget -q https://github.com/flatland-association/flatland-scenarios/raw/refs/heads/178-agents-living-on-the-edge-9/trajectories/FLATLAND_BENCHMARK_EPISODES_FOLDER_v7.zip -O /tmp/FLATLAND_BENCHMARK_EPISODES_FOLDER_v7.zip\n",
     "!mkdir -p /tmp/episodes\n",
-    "!unzip -o -qq /tmp/FLATLAND_BENCHMARK_EPISODES_FOLDER_v6.zip -d /tmp/episodes"
+    "!unzip -o -qq /tmp/FLATLAND_BENCHMARK_EPISODES_FOLDER_v7.zip -d /tmp/episodes"
    ]
   },
   {

--- a/notebooks/trajectories.ipynb
+++ b/notebooks/trajectories.ipynb
@@ -47,9 +47,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!wget -q https://github.com/flatland-association/flatland-scenarios/raw/refs/heads/178-agents-living-on-the-edge-3/trajectories/FLATLAND_BENCHMARK_EPISODES_FOLDER_v6.zip -O /tmp/FLATLAND_BENCHMARK_EPISODES_FOLDER_v6.zip\n",
+    "!wget -q https://github.com/flatland-association/flatland-scenarios/raw/refs/heads/178-agents-living-on-the-edge-9/trajectories/FLATLAND_BENCHMARK_EPISODES_FOLDER_v7.zip -O /tmp/FLATLAND_BENCHMARK_EPISODES_FOLDER_v7.zip\n",
     "!mkdir -p /tmp/episodes\n",
-    "!unzip -o -qq /tmp/FLATLAND_BENCHMARK_EPISODES_FOLDER_v6.zip -d /tmp/episodes"
+    "!unzip -o -qq /tmp/FLATLAND_BENCHMARK_EPISODES_FOLDER_v7.zip -d /tmp/episodes"
    ]
   },
   {

--- a/tests/test_envs_malfunction_effects_generator.py
+++ b/tests/test_envs_malfunction_effects_generator.py
@@ -28,14 +28,16 @@ def test_conditional_stopped_cells_and_range_malfunction_effects_generator():
         env.step({agent.handle: RailEnvActions.STOP_MOVING if agent.state == TrainState.MOVING else RailEnvActions.MOVE_FORWARD for agent in env.agents})
 
     initial_positions = {agent.initial_entry_point[0] for agent in env.agents}
-    in_malfunction = dict()
-    for agent in env.agents:
-        if agent.malfunction_handler.in_malfunction:
-            in_malfunction[agent.current_entry_point[0]] = agent
+    in_malfunction = [agent for agent in env.agents if agent.malfunction_handler.in_malfunction]
 
     # there is an agent stopped by the conditional malfunction generator at each initial position
-    assert len(in_malfunction) == len(initial_positions)
-    for _, agents in in_malfunction.items():
+    assert {agent.initial_entry_point[0] for agent in in_malfunction} == initial_positions
+    for agent in in_malfunction:
+        # a STOP_MOVING may complete an in-flight crossing before halting (pre-step momentum already
+        # past the cell boundary), so the agent may be stopped one cell into the successor entry point
+        # reached by that crossing rather than exactly at its initial entry point
+        assert agent.current_entry_point == agent.initial_entry_point or agent.current_entry_point in env.rail.get_successor_entry_points(
+            agent.initial_entry_point)
         assert agent.malfunction_handler.malfunction_down_counter > 700
 
 
@@ -179,6 +181,17 @@ def _run_with_sthortest_path(env, rendering, num_steps=400, stop_at_first_interm
                         agents_at[agent.handle] += 1
                         actions[agent.handle] = RailEnvActions.STOP_MOVING
                         continue
+                # design: actions applied at cell entry -- once the agent's pre-step momentum is
+                # about to carry it across the cell boundary into next_entry_point this step
+                # (is_cell_exit), that crossing happens regardless of the action given, so if the
+                # already-locked-in target is next_waypoint_position, STOP_MOVING must be given NOW,
+                # one step before arrival is observable via current_entry_point - otherwise the
+                # agent's pre-step momentum carries it one cell past the waypoint before halting.
+                target_locked_in = agent.next_entry_point is not None \
+                    and agent.next_entry_point[0] == next_waypoint_position
+                if target_locked_in and agent.speed_counter.is_cell_exit():
+                    actions[agent.handle] = RailEnvActions.STOP_MOVING
+                    continue
                 # design: actions applied at cell entry -- once next_entry_point is already
                 # pending, this step's action decides the look-ahead beyond it, not the arrival
                 # at next_waypoint_position itself, so compute it from next_entry_point instead of

--- a/tests/test_flatland_envs_rail_env.py
+++ b/tests/test_flatland_envs_rail_env.py
@@ -728,6 +728,13 @@ def test_blocked_agent_cannot_redirect_via_later_action():
     agent1.initial_entry_point = ((3, 5), 3)
     agent0.earliest_departure = 0
     agent1.earliest_departure = 0
+    # agent 1 must genuinely stay parked at (3, 5) to block agent 0: at max_speed 1, its pre-step
+    # momentum on departure (distance 0, speed 1) would already reach the cell boundary on the very
+    # next step, so STOP_MOVING would complete an in-flight crossing out of (3, 5) instead of
+    # holding it there (see the STOP_MOVING boundary-crossing fix, issue #178 design D2a). A slower
+    # max_speed keeps it mid-cell (is_cell_exit false) when STOP_MOVING brakes it to 0.
+    agent1.speed_counter._max_speed = Fraction(1, 2)
+    agent1.speed_counter._speed = Fraction(1, 2)
 
     # MOVE_LEFT from the switch at (3, 6) is a genuine, valid redirect onto the southward branch -
     # confirms the escape route agent 0 will be denied further down is real, not just invalid input.
@@ -756,9 +763,11 @@ def test_blocked_agent_cannot_redirect_via_later_action():
 
     # once agent 1 vacates (3, 5), agent 0 enters it and continues straight to (3, 4) - even though
     # it is still being given MOVE_LEFT - confirming the earlier MOVE_LEFTs were never consulted
-    # for the (3, 6) -> (3, 5) crossing itself, only (uselessly) for the look-ahead beyond it.
-    env.step({0: RailEnvActions.MOVE_LEFT, 1: RailEnvActions.MOVE_FORWARD})
-    assert agent0.current_entry_point == ((3, 5), 3)
+    # for the (3, 6) -> (3, 5) crossing itself, only (uselessly) for the look-ahead beyond it. Agent
+    # 1 was braked to a stop at its reduced max_speed, so it needs a few steps of MOVE_FORWARD to
+    # regain enough momentum before it actually crosses out of (3, 5).
+    while agent0.current_entry_point != ((3, 5), 3):
+        env.step({0: RailEnvActions.MOVE_LEFT, 1: RailEnvActions.MOVE_FORWARD})
     assert agent0.next_entry_point == ((3, 4), 3)
     assert agent0.state == TrainState.MOVING
 

--- a/tests/test_flatland_malfunction.py
+++ b/tests/test_flatland_malfunction.py
@@ -409,7 +409,7 @@ def test_initial_malfunction_stop_moving():
 
             ),
             Replay(  # 5
-                position=(3, 2),
+                position=(3, 3),
                 direction=Grid4TransitionsEnum.EAST,
                 state=TrainState.STOPPED,
 
@@ -419,8 +419,6 @@ def test_initial_malfunction_stop_moving():
                 reward=env.step_penalty * 1.0,  # full step penalty while stopped
 
             ),
-            # TODO bug: braking (STOP_MOVING) reaching speed 0 does not go over the boundary (stays at distance 1.0) event if no conflict!
-            #  Inconsistent with DO_NOTHING also has the same pre_step speed but goes over the boundary if there is no conflict.
             Replay(  # 6
                 position=(3, 3),
                 direction=Grid4TransitionsEnum.EAST,
@@ -433,7 +431,7 @@ def test_initial_malfunction_stop_moving():
 
             ),
             Replay(  # 7
-                position=(3, 3),
+                position=(3, 4),
                 direction=Grid4TransitionsEnum.EAST,
                 state=TrainState.STOPPED,
 
@@ -453,17 +451,18 @@ def test_initial_malfunction_stop_moving():
                       skip_reward_check=True, set_ready_to_depart=True, skip_action_required_check=True)
 
 
-def test_stop_moving_vs_do_nothing_crossing_completion_inconsistency():
+def test_stop_moving_crossing_completion_consistent_with_do_nothing():
     """
-    Documents a known inconsistency (tracked as issue #178, design D2a): STOP_MOVING and DO_NOTHING
-    have the identical pre-step speed at the moment the agent's accumulated distance reaches the cell
-    boundary, so per the "distance always advances by pre-step speed" design this tick's
-    distance/position update should be identical regardless of which action is given - only the speed
-    that applies from the NEXT tick onward should differ. It isn't:
-    TrainStateMachine.can_get_moving_independent() treats "stop action given and resulting speed == 0"
-    so STOP_MOVING blocks the crossing outright this tick (new_entry_point is never
-    even set to the next cell), while DO_NOTHING - sharing the exact same pre-step speed - completes
-    the same crossing normally in the same tick.
+    STOP_MOVING and DO_NOTHING have the identical pre-step speed at the moment the agent's accumulated
+    distance reaches the cell boundary, so per the "distance always advances by pre-step speed" design
+    this tick's distance/position update is identical regardless of which action is given - only the
+    speed that applies from the NEXT tick onward differs (fixed: issue #178, design D2a). The gating
+    condition in rail_env.py step()'s (3b.5) POSITION UPDATE used to special-case
+    `stop_action_given and candidate_speed == 0` and block the crossing outright for STOP_MOVING
+    (candidate_entry_point was never even set to the next cell); it's now gated purely on
+    `is_cell_exit`/`candidate_entry_point_independent`, same as every other action, so STOP_MOVING
+    completes the crossing exactly like DO_NOTHING does - it just ends the tick STOPPED (already inside
+    the newly-entered cell) rather than blocked short of it.
     """
 
     def build_env_at_critical_step():
@@ -502,26 +501,25 @@ def test_stop_moving_vs_do_nothing_crossing_completion_inconsistency():
     env_stop.step({0: RailEnvActions.STOP_MOVING})
     env_nothing.step({0: RailEnvActions.DO_NOTHING})
 
-    # same pre-step speed, same distance, same intended movement - yet STOP_MOVING blocks the
-    # crossing outright (distance capped, position unchanged) while DO_NOTHING completes it normally
+    # same pre-step speed, same distance, same intended movement - STOP_MOVING now completes the
+    # crossing exactly like DO_NOTHING does; only the resulting state differs (braking vs continuing)
     assert agent_stop.state == TrainState.STOPPED
-    assert agent_stop.current_entry_point == pre_entry_point
-    assert agent_stop.speed_counter.distance == 1
+    assert agent_stop.current_entry_point == agent_nothing.current_entry_point
+    assert agent_stop.current_entry_point != pre_entry_point
+    assert agent_stop.speed_counter.distance == agent_nothing.speed_counter.distance
 
     assert agent_nothing.state == TrainState.MOVING
     assert agent_nothing.current_entry_point != pre_entry_point
     assert agent_nothing.speed_counter.distance == 0
 
 
-def test_stop_moving_discards_overshoot_beyond_boundary():
+def test_stop_moving_wraps_overshoot_beyond_boundary():
     """
-    Documents a further consequence of STOP_MOVING blocking the crossing (see
-    test_stop_moving_vs_do_nothing_crossing_completion_inconsistency): capping distance at the cell
-    boundary doesn't just stop it there - it silently discards however far past the boundary the
-    agent's pre-step speed would have carried it. `distance + pre_speed` reaching exactly `1` and
-    reaching e.g. `3/2` produce the identical capped result (`distance == 1`), even though the agent's
-    momentum - and thus how much of the next cell it should already have entered once unblocked -
-    was very different in each case.
+    Further consequence of the fix in test_stop_moving_crossing_completion_consistent_with_do_nothing:
+    once STOP_MOVING completes an in-flight crossing like any other action, overshoot past the cell
+    boundary is preserved (wrapped via `SpeedCounter._distance_update`'s `distance % SEGMENT_LENGTH`),
+    not discarded - `distance + pre_speed` reaching `3/2` lands the agent `1/2` into the new cell, not
+    capped at exactly the boundary.
     """
     rail, rail_map, optionals = make_simple_rail2()
     env = RailEnv(width=25, height=30, rail_generator=rail_from_grid_transition_map(rail, optionals),
@@ -552,11 +550,11 @@ def test_stop_moving_discards_overshoot_beyond_boundary():
 
     env.step({0: RailEnvActions.STOP_MOVING})
 
-    # capped at exactly the boundary, not at the 1/2 remainder `(distance+pre_speed) mod 1` would give,
-    # and not at 3/2 either - the 1/2 of overshoot is simply gone
+    # wrapped to the 1/2 remainder `(distance+pre_speed) mod 1`, not capped at exactly the boundary
+    # and not left at 3/2 either - the crossing completes and the overshoot carries over
     assert agent.state == TrainState.STOPPED
-    assert agent.current_entry_point == pre_entry_point
-    assert agent.speed_counter.distance == 1
+    assert agent.current_entry_point != pre_entry_point
+    assert agent.speed_counter.distance == Fraction(1, 2)
 
 
 def test_initial_malfunction_do_nothing():

--- a/tests/test_flatland_states_edge_cases.py
+++ b/tests/test_flatland_states_edge_cases.py
@@ -175,7 +175,10 @@ def test_malfunction_off_map_not_on_map_with_stop_action_after_malfunction():
     # step 3
     env.step({0: RailEnvActions.STOP_MOVING, 1: RailEnvActions.STOP_MOVING})
 
-    assert env.agents[0].current_entry_point[0] == (6, 6)
+    # agent 0's pre-step momentum (speed 1, distance 0 at fresh departure) already reaches the cell
+    # boundary this step, so STOP_MOVING completes the in-flight crossing before halting - same as
+    # DO_NOTHING/MOVE_FORWARD would - landing one cell past (6, 6) rather than blocking in place.
+    assert env.agents[0].current_entry_point[0] == (5, 6)
     assert env.agents[0].state == TrainState.STOPPED
 
     # design: disallow entering the map stopped

--- a/tests/test_rewards.py
+++ b/tests/test_rewards.py
@@ -434,11 +434,11 @@ def test_energy_efficiency_smoothniss_in_morl():
         # design: actions applied at cell entry
         (BaseDefaultRewards(), (-1724.0,)),
         # design: actions applied at cell entry
-        (BasicMultiObjectiveRewards(), (-1724.0, -637.0, -182.625)),
+        (BasicMultiObjectiveRewards(), (-1724.0, -629.0, -172.375)),
         # design: actions applied at cell entry
-        (ECML2026Rewards(), (-15786.5,)),
+        (ECML2026Rewards(), (-18786.5,)),
         # design: actions applied at cell entry
-        (BaseECML2026Rewards(), (-15786.5,)),
+        (BaseECML2026Rewards(), (-18786.5,)),
     ],
 )
 def test_rewards_via_policy_runner(rewards, expected_sums):


### PR DESCRIPTION


## Changes

* fix: let STOP_MOVING complete an in-flight cell-boundary crossing. 
  * Previously, braking to zero speed via STOP_MOVING on the tick a MOVING agent's momentum already carried it past a cell boundary would discard that crossing, leaving the agent one cell short of where DO_NOTHING at the same speed would land it. STOP_MOVING now completes the crossing like every other action, contesting the target cell's resource via the same conflict-resolution path.

  * Updates test fixtures and golden values across the suite for the newly exercised crossing-completion behavior, and bumps CI/notebook references to the regenerated v7 benchmark-episode archive on flatland-scenarios' 178-agents-living-on-the-edge-9 branch.

### Carried out (not covered by the note above)

| ID | Description | Category | Severity | Commit(s) |
|---|---|---|---|---|
| — | Strengthen the entry-point configuration invariant via a new `TransitionMap.is_successor()` (default impl over `get_successor_entry_points()`) - the invariant previously only asserted current/next entry points differ, not that next is actually reachable from current in one action | refactor | moderate | 32d0bef2 |
| — | Update the post speed and distance invariant check (no commit body) | refactor | minor | 83391920 |

### Remaining

| ID | Description | Category | Severity | Commit message |
|---|---|---|---|---|
| — | This PR's own diff still carries (relocated, not resolved) the TODO #280 "very dodgy - when does this happen? ... agent be allowed to accelerate?" in the post-step speed/distance invariant check - later confirmed genuinely unreachable dead code and removed in PR #511 this session, so no action needed here beyond noting it was still open as of this PR | Dead code (later resolved) | Minor | n/a - already resolved in #511 |

Note: this PR's "Related issues" says "Closes #178", but issue #178 is confirmed still **open** upstream as of this writing - worth double-checking whether that's intentional (partial close?) before merge.

## Related issues

Closes https://github.com/flatland-association/flatland-rl/issues/178

## Checklist

- [ ] Tests are included for relevant behavior changes.
- [ ] Documentation is added in the [flatland-book](https://github.com/flatland-association/flatland-book) repo for relevant behavior changes.
- [ ] If you made important user-facing changes, describe them under the `[Unreleased]` tag in `CHANGELOG.md`.
- [ ] New package dependencies are declared in the `pyproject.toml` file.
  Requirement files have been updated by running `tox -e requirements`.
- [ ] Code works with all supported Python versions (3.10, 3.11, 3.12 and 3.13). Checks run with all supported version and are
  required to run successfully.
- [ ] Code is formatted according to PEP 8 (an IDE like PyCharm can do this for you).
- [ ] Technical guidelines listed in `CONTRIBUTING.md` are followed.

