### PR TITLE
fix!: D4. make malfunction handler consistent with state by decrementing at beginning of step().

### DIFF
--- a/benchmarks/benchmark_episodes.py
+++ b/benchmarks/benchmark_episodes.py
@@ -150,7 +150,7 @@ def test_episode(data_sub_dir: str, ep_id: str, skip_rewards_dones_infos: bool, 
 
 
 def run_episode(data_dir: str, ep_id: str, rendering=False, snapshot_interval=0, start_step=None, skip_rewards_dones_infos: bool = False,
-                skip_rewards: bool = False):
+                skip_rewards: bool = False, shifted_malfunction: bool = False):
     """
     The data is structured as follows:
         -30x30 map
@@ -181,10 +181,15 @@ def run_episode(data_dir: str, ep_id: str, rendering=False, snapshot_interval=0,
             skip verification of rewards/dones/infos
     skip_rewards : bool
             skip verification of rewards
+    shifted_malfunction : bool
+            recorded episodes predate decrementing the malfunction counter at the start of step() - while an
+            actual malfunction is active, expect the recorded info's `malfunction` one lower than freshly computed.
+            # TODO remove this option once the malfunction episodes are regenerated
     """
     TrajectoryEvaluator(Trajectory.load_existing(data_dir=data_dir, ep_id=ep_id)).evaluate(
         start_step=start_step,
         snapshot_interval=snapshot_interval,
         skip_rewards_dones_infos=skip_rewards_dones_infos,
         skip_rewards=skip_rewards,
+        shifted_malfunction=shifted_malfunction,
     )

--- a/flatland/envs/rail_env.py
+++ b/flatland/envs/rail_env.py
@@ -434,6 +434,12 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
 
         self.resource_check = ac.MotionCheck()  # reset the motion check
 
+        for agent in self.agents:
+            # (0a) UPDATE MALFUNCTION COUNTER
+            # N.B. in order to keep malfunction counter and agent state in sync
+            agent.malfunction_handler.update_counter()
+
+        # (0b) GENERATE NEW MALFUNCTIONS AND OTHER RANDOM EFFECTS
         self.effects_generator.on_episode_step_start(self)
 
         for agent in self.agents:
@@ -705,10 +711,6 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
                     elapsed_steps=self._elapsed_steps
                 )
             )
-
-            # (13) UPDATE MALFUNCTION COUNTER
-            # TODO https://github.com/flatland-association/flatland-rl/issues/280 revise design: updating the malfunction counter after the state transition leaves ugly situation that malfunction_counter == 0 but state is in malfunction - move to begining of step function?
-            agent.malfunction_handler.update_counter()
 
             # Off map or on map state and position should match
             if not self._fast_state_position_sync_check(agent.state, agent.current_entry_point, self.remove_agents_at_target):
@@ -1119,11 +1121,23 @@ class RailEnv(AbstractRailEnv[GridTransitionMap, GridResourceMap, Tuple[Tuple[in
         obs, rewards, dones, info = super().step(action_dict=action_dict)
         # TODO https://github.com/flatland-association/flatland-rl/issues/195 add idiomatic wrapper instead of override
         self._update_agent_positions_map()
+        self._check_malfunction_state_invariant()
         if self.check_step_pre_post_conditions:
             self._verify_mutually_exclusive_resource_allocation()
             self._check_post_speed_distance_invariants(action_dict, pre_step_snapshot)
             self._check_post_position_invariants(action_dict, pre_step_snapshot)
         return obs, rewards, dones, info
+
+    def _check_malfunction_state_invariant(self):
+        """
+        Guards against the malfunction_down_counter reaching 0 (in_malfunction False) one step before
+        the state machine has transitioned agent.state off MALFUNCTION/MALFUNCTION_OFF_MAP - eliminated
+        by decrementing the counter at the start of step(), before state_machine.step() runs.
+        """
+        for agent in self.agents:
+            if agent.state == TrainState.DONE:
+                continue
+            assert (agent.state in (TrainState.MALFUNCTION, TrainState.MALFUNCTION_OFF_MAP)) == agent.malfunction_handler.in_malfunction
 
     def _infrastructure_representation(self, entry_point: Tuple[Tuple[int, int], int]) -> str:
         return RailEnvTransitionsEnum(self.rail.get_full_transitions(*entry_point[0])).name

--- a/flatland/envs/rail_env.py
+++ b/flatland/envs/rail_env.py
@@ -430,6 +430,9 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
         if self.dones["__all__"]:
             raise Exception("Episode is done, cannot call step()")
 
+        pre_step_snapshot = self._check_pre_step_invariants_and_capture_snapshot() \
+            if self.check_step_pre_post_conditions else None
+
         self.clear_rewards_dict()
 
         self.resource_check = ac.MotionCheck()  # reset the motion check
@@ -721,7 +724,24 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
 
         self.effects_generator.on_episode_step_end(self, action_dict=action_dict)
 
+        if self.check_step_pre_post_conditions:
+            self._check_malfunction_state_invariant()
+            self._verify_mutually_exclusive_resource_allocation()
+            self._check_post_speed_distance_invariants(action_dict, pre_step_snapshot)
+            self._check_post_position_invariants(action_dict, pre_step_snapshot)
+
         return self._get_observations(), self.rewards_dict, self.dones, self.get_info_dict()
+
+    def _check_malfunction_state_invariant(self):
+        """
+        Guards against the malfunction_down_counter reaching 0 (in_malfunction False) one step before
+        the state machine has transitioned agent.state off MALFUNCTION/MALFUNCTION_OFF_MAP - eliminated
+        by decrementing the counter at the start of step(), before state_machine.step() runs.
+        """
+        for agent in self.agents:
+            if agent.state == TrainState.DONE:
+                continue
+            assert (agent.state in (TrainState.MALFUNCTION, TrainState.MALFUNCTION_OFF_MAP)) == agent.malfunction_handler.in_malfunction
 
     @lru_cache()
     def _is_speed_zero(self, candidate_speed: Fraction) -> bool:
@@ -1115,29 +1135,10 @@ class RailEnv(AbstractRailEnv[GridTransitionMap, GridResourceMap, Tuple[Tuple[in
         RailEnvPersister.load(self, env_dict=env_dict, obs_builder=obs_builder)
 
     def step(self, action_dict: Dict[int, RailEnvActions]):
-        # TODO move up to AbstractRailEnv, invariants should independent of graph/grid implementation.
-        pre_step_snapshot = self._check_pre_step_invariants_and_capture_snapshot() \
-            if self.check_step_pre_post_conditions else None
         obs, rewards, dones, info = super().step(action_dict=action_dict)
         # TODO https://github.com/flatland-association/flatland-rl/issues/195 add idiomatic wrapper instead of override
         self._update_agent_positions_map()
-        self._check_malfunction_state_invariant()
-        if self.check_step_pre_post_conditions:
-            self._verify_mutually_exclusive_resource_allocation()
-            self._check_post_speed_distance_invariants(action_dict, pre_step_snapshot)
-            self._check_post_position_invariants(action_dict, pre_step_snapshot)
         return obs, rewards, dones, info
-
-    def _check_malfunction_state_invariant(self):
-        """
-        Guards against the malfunction_down_counter reaching 0 (in_malfunction False) one step before
-        the state machine has transitioned agent.state off MALFUNCTION/MALFUNCTION_OFF_MAP - eliminated
-        by decrementing the counter at the start of step(), before state_machine.step() runs.
-        """
-        for agent in self.agents:
-            if agent.state == TrainState.DONE:
-                continue
-            assert (agent.state in (TrainState.MALFUNCTION, TrainState.MALFUNCTION_OFF_MAP)) == agent.malfunction_handler.in_malfunction
 
     def _infrastructure_representation(self, entry_point: Tuple[Tuple[int, int], int]) -> str:
         return RailEnvTransitionsEnum(self.rail.get_full_transitions(*entry_point[0])).name

--- a/flatland/evaluators/trajectory_evaluator.py
+++ b/flatland/evaluators/trajectory_evaluator.py
@@ -33,6 +33,7 @@ class TrajectoryEvaluator:
         rewards: Rewards = None,
         obs_builder: Optional[ObservationBuilder[Any, RailEnv]] = None,
         effects_generator: Optional[EffectsGenerator[RailEnv]] = None,
+        shifted_malfunction: bool = False,
     ) -> RailEnv:
         """
          Parameters
@@ -53,6 +54,11 @@ class TrajectoryEvaluator:
             obs builder for the restored env, forwarded to `Trajectory.load_env`. If not provided, defaults to `DummyObservationBuilder`.
         effects_generator : EffectsGenerator
             if given, forwarded to `Trajectory.load_env` and replaces the restored env's persisted effects generator instead of being discarded.
+        shifted_malfunction : bool
+            # TODO remove this option once the malfunction episodes are regenerated
+            recorded episodes predate decrementing the malfunction counter at the start of step() -
+            while an actual malfunction is active, expect the recorded info's `malfunction` one lower
+            than freshly computed.
         """
         if tqdm_kwargs is None:
             tqdm_kwargs = {}
@@ -109,6 +115,9 @@ class TrajectoryEvaluator:
                     actual_done = dones[agent_id]
                     actual_info = {k: v[agent_id] for k, v in infos.items()}
                     expected_reward, expected_done, expected_info = trains_rewards_dones_infos_cache[elapsed_after_step][agent_id]
+                    if shifted_malfunction and actual_info.get("malfunction", 0) > 0:
+                        # TODO remove this option once the malfunction episodes are regenerated
+                        expected_info = {**expected_info, "malfunction": expected_info["malfunction"] + 1}
                     if not skip_rewards:
                         assert np.allclose(actual_reward, expected_reward), (elapsed_after_step, agent_id, actual_reward, expected_reward)
                     assert actual_done == expected_done, (elapsed_after_step, agent_id, actual_done, expected_done)

--- a/tests/test_envs_malfunction_effects_generator.py
+++ b/tests/test_envs_malfunction_effects_generator.py
@@ -151,7 +151,8 @@ def test_conditional_earliest_and_max_num_malfunction(rendering: bool = False):
     assert conditional_malfunction_effects_generator._num_malfunctions == 2
     assert len(in_malfunction) == 2
     for agent in in_malfunction:
-        assert agent.malfunction_handler.malfunction_down_counter == duration - (num_steps_run - earliest)
+        # design: malfunction counter decremented at start of step(), before new malfunctions are generated
+        assert agent.malfunction_handler.malfunction_down_counter == duration - (num_steps_run - earliest) + 1
 
 
 # TODO https://github.com/flatland-association/flatland-rl/issues/386 use ShortestPathPolicy instead

--- a/tests/test_flatland_envs_rail_env.py
+++ b/tests/test_flatland_envs_rail_env.py
@@ -1061,21 +1061,24 @@ def test_malfunction_off_map_state_transitions_to_moving():
     assert agent.state == TrainState.MALFUNCTION_OFF_MAP
 
     # MALFUNCTION_OFF_MAP: off map, still malfunctioning - no speed/distance progress.
+    # design: malfunction counter decremented at start of step(), before new malfunctions are generated,
+    # so the MALFUNCTION_OFF_MAP -> MOVING transition merges into the last loop iteration below (no
+    # separate transition step needed) - guard the malfunction-only assertions accordingly.
     while agent.malfunction_handler.in_malfunction:
         env.step({agent.handle: RailEnvActions.MOVE_FORWARD})
-        assert agent.state == TrainState.MALFUNCTION_OFF_MAP
-        assert agent.current_entry_point is None
-        assert agent.speed_counter.speed == speed
-        assert agent.speed_counter.distance is None
+        if agent.state == TrainState.MALFUNCTION_OFF_MAP:
+            assert agent.current_entry_point is None
+            assert agent.speed_counter.speed == speed
+            assert agent.speed_counter.distance is None
 
     # MALFUNCTION_OFF_MAP -> MOVING: agent appears at its initial entry point this very step, but
     # the speed_counter is not stepped yet (N.B. no movement in the first time step after
     # MALFUNCTION_OFF_MAP, same as after READY_TO_DEPART).
-    env.step({agent.handle: RailEnvActions.MOVE_FORWARD})
     assert agent.state == TrainState.MOVING
     assert agent.current_entry_point == agent.initial_entry_point
     assert agent.speed_counter.speed == speed
     assert agent.speed_counter.distance == Fraction(0)
+    env.step({agent.handle: RailEnvActions.MOVE_FORWARD})
 
     first_entry_point = agent.current_entry_point
     second_entry_point = env.rail.apply_action_independent(RailEnvActions.MOVE_FORWARD, first_entry_point)
@@ -1120,12 +1123,16 @@ def test_malfunction_off_map_state_transitions_to_ready_to_depart():
     assert agent.state == TrainState.MALFUNCTION_OFF_MAP
 
     # MALFUNCTION_OFF_MAP: off map, still malfunctioning - no speed/distance progress.
+    # design: malfunction counter decremented at start of step(), before new malfunctions are generated,
+    # so the MALFUNCTION_OFF_MAP -> READY_TO_DEPART transition merges into the last loop iteration below
+    # (no separate transition step needed) - guard the malfunction-only assertions accordingly.
     while agent.malfunction_handler.in_malfunction:
         env.step({agent.handle: RailEnvActions.DO_NOTHING})
-        assert agent.state == TrainState.MALFUNCTION_OFF_MAP
-        assert agent.current_entry_point is None
-        assert agent.speed_counter.speed == speed
-        assert agent.speed_counter.distance is None
+        if agent.state == TrainState.MALFUNCTION_OFF_MAP:
+            assert agent.current_entry_point is None
+            assert agent.speed_counter.speed == speed
+            assert agent.speed_counter.distance is None
+    assert agent.state == TrainState.READY_TO_DEPART
 
     # MALFUNCTION_OFF_MAP -> READY_TO_DEPART: malfunction cleared and earliest departure already
     # reached, but no movement/stop action given - the agent stays off map, ready to depart.
@@ -1161,13 +1168,17 @@ def test_malfunction_off_map_state_transitions_to_ready_to_depart_with_stop_acti
     assert agent.state == TrainState.MALFUNCTION_OFF_MAP
 
     # MALFUNCTION_OFF_MAP: off map, still malfunctioning - no speed/distance progress.
+    # design: malfunction counter decremented at start of step(), before new malfunctions are generated,
+    # so the MALFUNCTION_OFF_MAP -> READY_TO_DEPART transition merges into the last loop iteration below
+    # (no separate transition step needed) - guard the malfunction-only assertions accordingly.
     while agent.malfunction_handler.in_malfunction:
         env.step({agent.handle: RailEnvActions.STOP_MOVING})
-        assert agent.state == TrainState.MALFUNCTION_OFF_MAP
-        assert agent.current_entry_point is None
-        # TODO revise design: in contrast to MALFUNCTION, speed not set to 0!
-        assert agent.speed_counter.speed == speed
-        assert agent.speed_counter.distance is None
+        if agent.state == TrainState.MALFUNCTION_OFF_MAP:
+            assert agent.current_entry_point is None
+            # TODO revise design: in contrast to MALFUNCTION, speed not set to 0!
+            assert agent.speed_counter.speed == speed
+            assert agent.speed_counter.distance is None
+    assert agent.state == TrainState.READY_TO_DEPART
 
     # design: disallow entering the map stopped
     for _ in range(3):
@@ -1208,15 +1219,15 @@ def test_malfunction_state_transitions_to_moving():
     distance = agent.speed_counter.distance
 
     # MOVING -> MALFUNCTION: speed is reset to 0 and distance freezes at whatever it was when the malfunction hit.
+    # design: malfunction counter decremented at start of step(), before new malfunctions are generated,
+    # so the MALFUNCTION -> MOVING transition (re-acceleration with pre-step speed 0) merges into the last
+    # loop iteration below - guard the malfunction-only assertions accordingly.
     while agent.malfunction_handler.in_malfunction:
         env.step({agent.handle: RailEnvActions.MOVE_FORWARD})
-        assert agent.state == TrainState.MALFUNCTION
-        assert agent.current_entry_point == malfunction_entry_point
-        assert agent.speed_counter.speed == Fraction(0)
-        assert agent.speed_counter.distance == distance
-
-    # design: distance update with pre-step speed - MALFUNCTION -> MOVING.
-    env.step({agent.handle: RailEnvActions.MOVE_FORWARD})
+        if agent.state == TrainState.MALFUNCTION:
+            assert agent.current_entry_point == malfunction_entry_point
+            assert agent.speed_counter.speed == Fraction(0)
+            assert agent.speed_counter.distance == distance
     assert agent.state == TrainState.MOVING
     assert agent.current_entry_point == malfunction_entry_point
     assert agent.speed_counter.speed == Fraction(1, 2)
@@ -1278,12 +1289,16 @@ def test_malfunction_state_transitions_to_stopped():
     distance = agent.speed_counter.distance
 
     # MOVING -> MALFUNCTION: speed is reset to 0 and distance freezes at whatever it was when the malfunction hit.
+    # design: malfunction counter decremented at start of step(), before new malfunctions are generated,
+    # so the MALFUNCTION -> STOPPED transition merges into the last loop iteration below (no separate
+    # transition step needed) - guard the malfunction-only assertions accordingly.
     while agent.malfunction_handler.in_malfunction:
         env.step({agent.handle: RailEnvActions.STOP_MOVING})
-        assert agent.state == TrainState.MALFUNCTION
-        assert agent.current_entry_point == malfunction_entry_point
-        assert agent.speed_counter.speed == Fraction(0)
-        assert agent.speed_counter.distance == distance
+        if agent.state == TrainState.MALFUNCTION:
+            assert agent.current_entry_point == malfunction_entry_point
+            assert agent.speed_counter.speed == Fraction(0)
+            assert agent.speed_counter.distance == distance
+    assert agent.state == TrainState.STOPPED
 
     # MALFUNCTION -> STOPPED: malfunction cleared but no movement action given - the agent stops in
     # place rather than resuming.
@@ -1326,12 +1341,16 @@ def test_malfunction_state_transitions_to_stopped_do_nothing():
     distance = agent.speed_counter.distance
 
     # MOVING -> MALFUNCTION: speed is reset to 0 and distance freezes at whatever it was when the malfunction hit.
+    # design: malfunction counter decremented at start of step(), before new malfunctions are generated,
+    # so the MALFUNCTION -> STOPPED transition merges into the last loop iteration below (no separate
+    # transition step needed) - guard the malfunction-only assertions accordingly.
     while agent.malfunction_handler.in_malfunction:
         env.step({agent.handle: RailEnvActions.DO_NOTHING})
-        assert agent.state == TrainState.MALFUNCTION
-        assert agent.current_entry_point == malfunction_entry_point
-        assert agent.speed_counter.speed == Fraction(0)
-        assert agent.speed_counter.distance == distance
+        if agent.state == TrainState.MALFUNCTION:
+            assert agent.current_entry_point == malfunction_entry_point
+            assert agent.speed_counter.speed == Fraction(0)
+            assert agent.speed_counter.distance == distance
+    assert agent.state == TrainState.STOPPED
 
     # MALFUNCTION -> STOPPED: malfunction cleared but DO_NOTHING is not a movement action either -
     # the agent stops in place rather than resuming.

--- a/tests/test_flatland_envs_rail_env_effects_generator.py
+++ b/tests/test_flatland_envs_rail_env_effects_generator.py
@@ -26,7 +26,9 @@ def test_rail_env_effects_generator_on_episode_step_start():
     env, _, _ = env_generator(seed=42, effects_generator=TestMalfunctionEffectsGenerator())
     assert env.agents[0].malfunction_handler.malfunction_down_counter == 0
     env.step({i: RailEnvActions.MOVE_FORWARD for i in env.get_agent_handles()})
-    assert env.agents[0].malfunction_handler.malfunction_down_counter == 999998
+    # design: malfunction counter decremented at start of step(), before new malfunctions are generated,
+    # so a malfunction set by on_episode_step_start() this same step is not yet decremented
+    assert env.agents[0].malfunction_handler.malfunction_down_counter == 999999
 
 
 def test_rail_env_effects_generator_on_episode_step_end():

--- a/tests/test_flatland_malfunction.py
+++ b/tests/test_flatland_malfunction.py
@@ -167,8 +167,14 @@ def test_malfunction_process_statistically():
             # For generating tests only:
             # agent_malfunction_list[agent_idx].append(
             # env.agents[agent_idx].malfunction_handler.malfunction_down_counter)
-            assert env.agents[agent_idx].malfunction_handler.malfunction_down_counter == \
-                   agent_malfunction_list[agent_idx][step]
+            # design: malfunction counter decremented at start of step(), before new malfunctions are generated -
+            # shift by 1 while a malfunction is active or just ended (previous entry nonzero); a value that is 0
+            # both here and in the previous entry is a genuine steady idle step and must stay 0.
+            expected = agent_malfunction_list[agent_idx][step]
+            prev = agent_malfunction_list[agent_idx][step - 1] if step > 0 else 0
+            if expected > 0 or prev > 0:
+                expected += 1
+            assert env.agents[agent_idx].malfunction_handler.malfunction_down_counter == expected
         env.step(action_dict)
 
 
@@ -235,7 +241,8 @@ def test_malfunction_values_and_behavior():
         # Move in the env
         _, _, dones, _ = env.step(action_dict)
         # Check that next_step decreases as expected
-        assert env.agents[0].malfunction_handler.malfunction_down_counter == assert_list[time_step]
+        # design: malfunction counter decremented at start of step(), before new malfunctions are generated
+        assert env.agents[0].malfunction_handler.malfunction_down_counter == assert_list[time_step] + 1
         if dones['__all__']:
             break
 

--- a/tests/test_flatland_malfunction.py
+++ b/tests/test_flatland_malfunction.py
@@ -272,11 +272,14 @@ def test_initial_malfunction():
     set_penalties_for_replay(env)
     replay_config = ReplayConfig(
         replay=[
+            # design: malfunction counter decremented at start of step(), before new malfunctions are generated -
+            # injected duration bumped by 1 so the observed state/position sequence below is unaffected (only the
+            # malfunction countdown values shift by 1 while the malfunction is active)
             Replay(  # 0
                 position=(3, 2),
                 direction=Grid4TransitionsEnum.EAST,
-                set_malfunction=3,
-                malfunction=3,
+                set_malfunction=4,
+                malfunction=4,
                 distance=0.0,
                 speed=1.0,
                 state=TrainState.MOVING,
@@ -291,7 +294,7 @@ def test_initial_malfunction():
                 state=TrainState.MALFUNCTION,
                 distance=0.0,
                 speed=0.0,
-                malfunction=2,
+                malfunction=3,
 
                 action=RailEnvActions.MOVE_FORWARD,  # SM: MALFUNCTION -> MOVING needs move action
 
@@ -303,7 +306,7 @@ def test_initial_malfunction():
                 position=(3, 2),
                 direction=Grid4TransitionsEnum.EAST,
                 state=TrainState.MALFUNCTION,
-                malfunction=1,
+                malfunction=2,
 
                 action=RailEnvActions.MOVE_FORWARD,
 
@@ -314,7 +317,7 @@ def test_initial_malfunction():
                 position=(3, 2),
                 direction=Grid4TransitionsEnum.EAST,
                 state=TrainState.MALFUNCTION,
-                malfunction=0,
+                malfunction=1,
 
                 action=RailEnvActions.MOVE_FORWARD,  # SM: MALFUNCTION -> MOVING needs move action
 
@@ -357,6 +360,9 @@ def test_initial_malfunction_stop_moving():
     set_penalties_for_replay(env)
     replay_config = ReplayConfig(
         replay=[
+            # design: malfunction counter decremented at start of step(), before new malfunctions are generated -
+            # injected duration bumped by 1 so the observed state/position sequence below is unaffected (only the
+            # malfunction countdown values shift by 1 while the malfunction is active)
             Replay(  # 0
                 position=None,
                 direction=None,
@@ -364,8 +370,8 @@ def test_initial_malfunction_stop_moving():
 
                 action=RailEnvActions.MOVE_FORWARD,
 
-                set_malfunction=3,
-                malfunction=3,
+                set_malfunction=4,
+                malfunction=4,
                 reward=env.step_penalty,  # full step penalty when stopped
             ),
             Replay(  # 1
@@ -375,7 +381,7 @@ def test_initial_malfunction_stop_moving():
 
                 action=RailEnvActions.DO_NOTHING,
 
-                malfunction=2,
+                malfunction=3,
                 reward=env.step_penalty,  # full step penalty when stopped
 
             ),
@@ -389,7 +395,7 @@ def test_initial_malfunction_stop_moving():
 
                 action=RailEnvActions.STOP_MOVING,
 
-                malfunction=1,
+                malfunction=2,
                 reward=env.step_penalty,  # full step penalty while stopped
             ),
             # need valid movement action to enter the grid
@@ -400,7 +406,7 @@ def test_initial_malfunction_stop_moving():
 
                 action=RailEnvActions.MOVE_FORWARD,  # SM: MALFUNCTION_OFF_MAP -> MOVING needs move action
 
-                malfunction=0,
+                malfunction=1,
                 reward=env.step_penalty,  # full step penalty while stopped
 
             ),
@@ -586,12 +592,15 @@ def test_initial_malfunction_do_nothing():
     set_penalties_for_replay(env)
     replay_config = ReplayConfig(
         replay=[
+            # design: malfunction counter decremented at start of step(), before new malfunctions are generated -
+            # injected duration bumped by 1 so the observed state/position sequence below is unaffected (only the
+            # malfunction countdown values shift by 1 while the malfunction is active)
             Replay(  # 0
                 position=None,
                 direction=None,
                 action=RailEnvActions.MOVE_FORWARD,
-                set_malfunction=3,
-                malfunction=3,
+                set_malfunction=4,
+                malfunction=4,
                 reward=env.step_penalty,  # full step penalty while malfunctioning
                 state=TrainState.READY_TO_DEPART
             ),
@@ -599,14 +608,14 @@ def test_initial_malfunction_do_nothing():
                 position=None,
                 direction=None,
                 action=None,
-                malfunction=2,
+                malfunction=3,
                 reward=env.step_penalty,  # full step penalty while malfunctioning
                 state=TrainState.MALFUNCTION_OFF_MAP
             ),
             Replay(  # 2
                 position=None,
                 direction=None,
-                malfunction=1,
+                malfunction=2,
                 state=TrainState.MALFUNCTION_OFF_MAP,
 
                 action=None,
@@ -616,7 +625,7 @@ def test_initial_malfunction_do_nothing():
             Replay(  # 3
                 position=None,
                 direction=None,
-                malfunction=0,
+                malfunction=1,
                 # design: distance is None when off map
                 distance=None,
                 speed=1,  # irrelevant

--- a/tests/test_flatland_regression_episodes.py
+++ b/tests/test_flatland_regression_episodes.py
@@ -15,30 +15,32 @@ from flatland.trajectories.policy_runner import PolicyRunner
 from flatland.trajectories.trajectories import EVENT_LOGS_SUBDIR, OUTPUTS_SUBDIR, Trajectory
 
 
-@pytest.mark.parametrize("data_sub_dir,ep_id,run_from_intermediate,skip_rewards_dones_infos,skip_rewards", [
+@pytest.mark.parametrize("data_sub_dir,ep_id,run_from_intermediate,skip_rewards_dones_infos,skip_rewards,shifted_malfunction", [
     # trajectories do not contain rewards/dones/info: https://github.com/flatland-association/flatland-rl/pull/222 -> skip_rewards_dones_infos=True
 
-    ("30x30 map/10_trains", "1649ef98-e3a8-4dd3-a289-bbfff12876ce", True, True, True),
-    ("30x30 map/10_trains", "4affa89b-72f6-4305-aeca-e5182efbe467", True, True, True),
+    ("30x30 map/10_trains", "1649ef98-e3a8-4dd3-a289-bbfff12876ce", True, True, True, False),
+    ("30x30 map/10_trains", "4affa89b-72f6-4305-aeca-e5182efbe467", True, True, True, False),
 
-    ("30x30 map/15_trains", "a61843e8-b550-407b-9348-5029686cc967", True, True, True),
-    ("30x30 map/15_trains", "9845da2f-2366-44f6-8b25-beca522495b4", True, True, True),
+    ("30x30 map/15_trains", "a61843e8-b550-407b-9348-5029686cc967", True, True, True, False),
+    ("30x30 map/15_trains", "9845da2f-2366-44f6-8b25-beca522495b4", True, True, True, False),
 
-    ("30x30 map/20_trains", "57e1ebc5-947c-4314-83c7-0d6fd76b2bd3", True, True, True),
-    ("30x30 map/20_trains", "56a78985-588b-42d0-a972-7f8f2514c665", True, True, True),
+    ("30x30 map/20_trains", "57e1ebc5-947c-4314-83c7-0d6fd76b2bd3", True, True, True, False),
+    ("30x30 map/20_trains", "56a78985-588b-42d0-a972-7f8f2514c665", True, True, True, False),
 
     # remaining 30x30 map episodes do not verify cleanly under the shift-and-replay transform (see
     # regenerate_30x30_scenarios_with_shift below) - regenerating those would need to actually resolve
     # the new emergent deadlocks, not just retime actions, so they stay unregenerated for now.
 
-    ("malfunction_deadlock_avoidance_heuristics/Test_00/Level_8", "Test_00_Level_8", True, False, False),
-    ("malfunction_deadlock_avoidance_heuristics/Test_01/Level_3", "Test_01_Level_3", True, False, False),
-    ("malfunction_deadlock_avoidance_heuristics/Test_02/Level_6", "Test_02_Level_6", True, False, False),
-    ("malfunction_deadlock_avoidance_heuristics/Test_02/Level_8", "Test_02_Level_8", False, False, False),
-    ("malfunction_deadlock_avoidance_heuristics/Test_03/Level_1", "Test_03_Level_1", False, False, False),
-    ("malfunction_deadlock_avoidance_heuristics/Test_03/Level_2", "Test_03_Level_2", False, False, False),
+    # shifted_malfunction=True: TODO remove once these episodes are regenerated
+    ("malfunction_deadlock_avoidance_heuristics/Test_00/Level_8", "Test_00_Level_8", True, False, False, True),
+    ("malfunction_deadlock_avoidance_heuristics/Test_01/Level_3", "Test_01_Level_3", True, False, False, True),
+    ("malfunction_deadlock_avoidance_heuristics/Test_02/Level_6", "Test_02_Level_6", True, False, False, True),
+    ("malfunction_deadlock_avoidance_heuristics/Test_02/Level_8", "Test_02_Level_8", False, False, False, True),
+    ("malfunction_deadlock_avoidance_heuristics/Test_03/Level_1", "Test_03_Level_1", False, False, False, True),
+    ("malfunction_deadlock_avoidance_heuristics/Test_03/Level_2", "Test_03_Level_2", False, False, False, True),
 ])
-def test_episode(data_sub_dir: str, ep_id: str, run_from_intermediate: bool, skip_rewards_dones_infos: bool, skip_rewards: bool):
+def test_episode(data_sub_dir: str, ep_id: str, run_from_intermediate: bool, skip_rewards_dones_infos: bool, skip_rewards: bool,
+                 shifted_malfunction: bool):
     """
     Run a subset of episodes for regression in unit testing, comparing only positions.
     Protects against breaking changes in flatland-rl.
@@ -54,7 +56,8 @@ def test_episode(data_sub_dir: str, ep_id: str, run_from_intermediate: bool, ski
         # run with snapshots to outputs/serialised_state directory
         run_episode(Path(tmpdirname), ep_id, snapshot_interval=1 if run_from_intermediate else 0,
                     skip_rewards_dones_infos=skip_rewards_dones_infos,
-                    skip_rewards=skip_rewards)
+                    skip_rewards=skip_rewards,
+                    shifted_malfunction=shifted_malfunction)
 
         if run_from_intermediate:
             # copy actions etc. to outputs subfolder, so outputs subfolder becomes a proper trajectory data dir.
@@ -63,7 +66,8 @@ def test_episode(data_sub_dir: str, ep_id: str, run_from_intermediate: bool, ski
             # start episode from a snapshot to ensure snapshot contains full state!
             run_episode(Path(tmpdirname) / OUTPUTS_SUBDIR, ep_id, start_step=np.random.randint(0, 50),
                         skip_rewards_dones_infos=skip_rewards_dones_infos,
-                        skip_rewards=skip_rewards)
+                        skip_rewards=skip_rewards,
+                        shifted_malfunction=shifted_malfunction)
 
 
 def test_restore_episode():

--- a/tests/test_flatland_states_edge_cases.py
+++ b/tests/test_flatland_states_edge_cases.py
@@ -150,7 +150,10 @@ def test_malfunction_off_map_not_on_map_with_stop_action_after_malfunction():
     env.agents[1].initial_entry_point = ((6, 6), Grid4TransitionsEnum.SOUTH)
     env.agents[1].targets = {((0, 3), d) for d in Grid4TransitionsEnum}
     env.agents[1].earliest_departure = 0
-    env.agents[1].malfunction_handler._set_malfunction_down_counter(2)
+    # design: malfunction counter decremented at start of step(), before new malfunctions are generated -
+    # injected duration bumped by 1 so the state sequence below is unaffected (only the malfunction countdown
+    # values shift by 1 while the malfunction is active)
+    env.agents[1].malfunction_handler._set_malfunction_down_counter(3)
 
     # step 1
     env.step({0: RailEnvActions.MOVE_FORWARD, 1: RailEnvActions.MOVE_FORWARD})
@@ -160,7 +163,7 @@ def test_malfunction_off_map_not_on_map_with_stop_action_after_malfunction():
     assert env.agents[1].current_entry_point is None
     assert env.agents[1].state == TrainState.MALFUNCTION_OFF_MAP
 
-    assert env.agents[1].malfunction_handler.malfunction_down_counter == 1
+    assert env.agents[1].malfunction_handler.malfunction_down_counter == 2
 
     # step 2
     env.step({0: RailEnvActions.MOVE_FORWARD, 1: RailEnvActions.MOVE_FORWARD})
@@ -170,7 +173,7 @@ def test_malfunction_off_map_not_on_map_with_stop_action_after_malfunction():
 
     assert env.agents[1].current_entry_point is None
     assert env.agents[1].state == TrainState.MALFUNCTION_OFF_MAP
-    assert env.agents[1].malfunction_handler.malfunction_down_counter == 0
+    assert env.agents[1].malfunction_handler.malfunction_down_counter == 1
 
     # step 3
     env.step({0: RailEnvActions.STOP_MOVING, 1: RailEnvActions.STOP_MOVING})
@@ -210,7 +213,10 @@ def test_malfunction_motion_check_order_when_earliest_departure_is_not_reached()
     env.agents[0].initial_entry_point = ((6, 6), Grid4TransitionsEnum.SOUTH)
     env.agents[0].targets = {((0, 3), d) for d in Grid4TransitionsEnum}
     env.agents[0].earliest_departure = 55
-    env.agents[0].malfunction_handler._set_malfunction_down_counter(1)
+    # design: malfunction counter decremented at start of step(), before new malfunctions are generated -
+    # injected duration bumped by 1 so the state sequence below is unaffected (only the malfunction countdown
+    # values shift by 1 while the malfunction is active)
+    env.agents[0].malfunction_handler._set_malfunction_down_counter(2)
 
     env.agents[1].initial_entry_point = ((6, 6), Grid4TransitionsEnum.SOUTH)
     env.agents[1].targets = {((0, 3), d) for d in Grid4TransitionsEnum}
@@ -221,7 +227,7 @@ def test_malfunction_motion_check_order_when_earliest_departure_is_not_reached()
 
     assert env.agents[0].current_entry_point is None
     assert env.agents[0].state == TrainState.MALFUNCTION_OFF_MAP
-    assert env.agents[0].malfunction_handler.malfunction_down_counter == 0
+    assert env.agents[0].malfunction_handler.malfunction_down_counter == 1
 
     assert env.agents[1].current_entry_point is None
     assert env.agents[1].state == TrainState.WAITING
@@ -273,7 +279,10 @@ def test_malfunction_motion_check_order_when_earliest_departure_reached_but_not_
     env.agents[0].initial_entry_point = ((6, 6), Grid4TransitionsEnum.SOUTH)
     env.agents[0].targets = {((0, 3), d) for d in Grid4TransitionsEnum}
     env.agents[0].earliest_departure = 3
-    env.agents[0].malfunction_handler._set_malfunction_down_counter(1)
+    # design: malfunction counter decremented at start of step(), before new malfunctions are generated -
+    # injected duration bumped by 1 so the state sequence below is unaffected (only the malfunction countdown
+    # values shift by 1 while the malfunction is active)
+    env.agents[0].malfunction_handler._set_malfunction_down_counter(2)
 
     env.agents[1].initial_entry_point = ((6, 6), Grid4TransitionsEnum.SOUTH)
     env.agents[1].targets = {((0, 3), d) for d in Grid4TransitionsEnum}
@@ -284,7 +293,7 @@ def test_malfunction_motion_check_order_when_earliest_departure_reached_but_not_
 
     assert env.agents[0].current_entry_point is None
     assert env.agents[0].state == TrainState.MALFUNCTION_OFF_MAP
-    assert env.agents[0].malfunction_handler.malfunction_down_counter == 0
+    assert env.agents[0].malfunction_handler.malfunction_down_counter == 1
 
     assert env.agents[1].current_entry_point is None
     assert env.agents[1].state == TrainState.WAITING
@@ -355,11 +364,14 @@ def test_malfunction_to_moving_instead_of_stopped():
     assert np.isclose(float(env.agents[0].speed_counter.distance), 0.0)
 
     # step 3
-    env.agents[0].malfunction_handler._set_malfunction_down_counter(1)
+    # design: malfunction counter decremented at start of step(), before new malfunctions are generated -
+    # injected duration bumped by 1 so the state sequence below is unaffected (only the malfunction countdown
+    # values shift by 1 while the malfunction is active)
+    env.agents[0].malfunction_handler._set_malfunction_down_counter(2)
     env.step({0: RailEnvActions.MOVE_FORWARD, 1: RailEnvActions.MOVE_FORWARD})
     assert env.agents[0].current_entry_point[0] == (6, 6)
     assert env.agents[0].state == TrainState.MALFUNCTION
-    assert env.agents[0].malfunction_handler.malfunction_down_counter == 0
+    assert env.agents[0].malfunction_handler.malfunction_down_counter == 1
     assert np.isclose(float(env.agents[0].speed_counter.speed), 0.0)
     # design: distance update with pre-step speed.
     assert np.isclose(float(env.agents[0].speed_counter.distance), 0.0)

--- a/tests/test_known_flatland_bugs.py
+++ b/tests/test_known_flatland_bugs.py
@@ -152,10 +152,8 @@ def test_earliest_departure_zero_bug_BYDESIGN() -> None:
     # Thus we showed that train 0 could be dispatched at it's earliest departure and train 1 could not
 
 
-def test_train_can_move_when_malfunction_counter_is_0_off_map_BYDESIGN():
+def test_train_can_move_when_malfunction_counter_is_0_off_map_FIXED():
     """
-    TODO https://github.com/flatland-association/flatland-rl/issues/280 revise design: updating the malfunction counter after the state transition leaves ugly situation that malfunction_counter == 0 but state is in malfunction - move to begining of step function?
-
     When a train goes into a malfunction off-map then in the last ts of the malfunction the agent can actually
     take an action and move (in the next ts). The malfunction_handler specifies that the agent is not in a malfunction
     but the state is still saying the agent is in a malfunction."""
@@ -179,26 +177,29 @@ def test_train_can_move_when_malfunction_counter_is_0_off_map_BYDESIGN():
     # After performing one action the agent should go into a malfunction.
     rail_env.step({0: RailEnvActions.DO_NOTHING})
     assert agent.state == TrainState.MALFUNCTION_OFF_MAP
-    assert agent.malfunction_handler.malfunction_down_counter == 5
+    # design: malfunction counter decremented at start of step(), before new malfunctions are generated
+    assert agent.malfunction_handler.malfunction_down_counter == 5 + 1
 
     for _ in range(5):
-        rail_env.step({0: RailEnvActions.DO_NOTHING})
+        rail_env.step({0: RailEnvActions.MOVE_FORWARD})
 
-    # Here we can see the contradiction
+    # Here we can see the bug is fixed
     assert agent.state == TrainState.MALFUNCTION_OFF_MAP
-    assert not agent.malfunction_handler.in_malfunction
-    assert agent.malfunction_handler.malfunction_down_counter == 0
+    assert agent.malfunction_handler.in_malfunction
+    # design: malfunction counter decremented at start of step(), before new malfunctions are generated
+    assert agent.malfunction_handler.malfunction_down_counter == 0 + 1
+    # Train is not dispatched during malfunction
+    assert agent.current_entry_point is None
 
-    # Even though the train is in a malfunction state we can dispatch it.
     rail_env.step({0: RailEnvActions.MOVE_FORWARD})
     assert agent.state == TrainState.MOVING
+    assert not agent.malfunction_handler.in_malfunction
+    # Train is dispatched in the step the malfunction terminates
     assert agent.current_entry_point is not None
 
 
-def test_train_can_move_when_malfunction_counter_is_0_on_map_BYDESIGN():
+def test_train_can_move_when_malfunction_counter_is_0_on_map_FIXED():
     """
-    TODO https://github.com/flatland-association/flatland-rl/issues/280 revise design: updating the malfunction counter after the state transition leaves ugly situation that malfunction_counter == 0 but state is in malfunction - move to begining of step function?
-
     When a train goes into a malfunction on-map then in the last ts of the malfunction the agent can actually
     take an action and move (in the next ts). The malfunction_handler specifies that the agent is not in a malfunction
     but the state is still saying the agent is in a malfunction."""
@@ -222,29 +223,35 @@ def test_train_can_move_when_malfunction_counter_is_0_on_map_BYDESIGN():
     # After performing one action the agent should go into a malfunction.
     rail_env.step({0: RailEnvActions.MOVE_FORWARD})
     assert agent.state == TrainState.MALFUNCTION
-    assert agent.malfunction_handler.malfunction_down_counter == 5
-    org_pos = agent.current_entry_point[0]
+    # design: malfunction counter decremented at start of step(), before new malfunctions are generated
+    assert agent.malfunction_handler.malfunction_down_counter == 5 + 1
+    old_pos = agent.current_entry_point[0]
+    old_entry_point = agent.current_entry_point
 
     for _ in range(5):
         rail_env.step({0: RailEnvActions.DO_NOTHING})
 
-    # Here we can see the contradiction
+    # Here we can see the bug is fixed
     assert agent.state == TrainState.MALFUNCTION
-    assert not agent.malfunction_handler.in_malfunction
-    assert agent.malfunction_handler.malfunction_down_counter == 0
+    assert agent.malfunction_handler.in_malfunction
+    # design: malfunction counter decremented at start of step(), before new malfunctions are generated
+    assert agent.malfunction_handler.malfunction_down_counter == 0 + 1
+    # Train is not moved during malfunction
+    assert agent.current_entry_point == old_entry_point
 
-    # Even though the train is in a malfunction state we can dispatch it
-    # design: distance update with pre-step speed.
+    assert agent.speed_counter.speed == 0
     rail_env.step({0: RailEnvActions.MOVE_FORWARD})
     assert agent.state == TrainState.MOVING
-    assert agent.current_entry_point[0] == (org_pos[0], org_pos[1])
+    assert agent.current_entry_point[0] == (old_pos[0], old_pos[1])
     assert agent.speed_counter.speed == 1
+    # design: distance update with pre-step speed.
     assert agent.speed_counter.distance == 0
 
-    #
     rail_env.step({0: RailEnvActions.MOVE_FORWARD})
     assert agent.state == TrainState.MOVING
-    assert agent.current_entry_point[0] == (org_pos[0] + 1, org_pos[1])
+    # Train is moved in the step after the step where the malfunction terminates
+    assert agent.current_entry_point != old_entry_point
+    assert agent.current_entry_point[0] == (old_pos[0] + 1, old_pos[1])
     assert agent.speed_counter.speed == 1
     assert agent.speed_counter.distance == 0
 
@@ -272,7 +279,8 @@ def test_spawning_cell_not_reserved_if_id_is_lower_SANITYCHECK():
     assert rail_env.agents[3].state == TrainState.READY_TO_DEPART
     rail_env.step({3: RailEnvActions.MOVE_FORWARD})
     assert rail_env.agents[3].state == TrainState.MALFUNCTION_OFF_MAP
-    assert rail_env.agents[3].malfunction_handler.malfunction_down_counter == 5
+    # design: malfunction counter decremented at start of step(), before new malfunctions are generated
+    assert rail_env.agents[3].malfunction_handler.malfunction_down_counter == 5 + 1
 
     assert rail_env.agents[0].state == TrainState.READY_TO_DEPART
     rail_env.step({0: RailEnvActions.MOVE_FORWARD})
@@ -301,7 +309,8 @@ def test_spawning_cell_reserved_if_id_is_higher_FIXED():
     assert rail_env.agents[1].state == TrainState.READY_TO_DEPART
     rail_env.step({1: RailEnvActions.MOVE_FORWARD})
     assert rail_env.agents[1].state == TrainState.MALFUNCTION_OFF_MAP
-    assert rail_env.agents[1].malfunction_handler.malfunction_down_counter == 5
+    # design: malfunction counter decremented at start of step(), before new malfunctions are generated
+    assert rail_env.agents[1].malfunction_handler.malfunction_down_counter == 5 + 1
 
     assert rail_env.agents[3].state == TrainState.READY_TO_DEPART
     rail_env.step({3: RailEnvActions.MOVE_FORWARD})
@@ -309,7 +318,6 @@ def test_spawning_cell_reserved_if_id_is_higher_FIXED():
     # FIXED: the train with higher ID can move:
     assert rail_env.agents[3].state == TrainState.MOVING
     assert rail_env.agents[3].state.is_on_map_state()
-
 
 
 def test_two_trains_on_same_cell_bug_FIXED():

--- a/tests/test_multi_speed.py
+++ b/tests/test_multi_speed.py
@@ -481,13 +481,16 @@ def test_multispeed_actions_malfunction_no_blocking():
                 reward=env.step_penalty * 0.5  # running at speed 0.5
             ),
             # add additional step in the cell
+            # design: malfunction counter decremented at start of step(), before new malfunctions are generated -
+            # injected duration bumped by 1 so the state sequence below is unaffected (only the malfunction countdown
+            # values shift by 1 while the malfunction is active)
             Replay(  # 3
                 position=(3, 8),
                 direction=Grid4TransitionsEnum.WEST,
                 state=TrainState.MOVING,
                 action=None,
-                set_malfunction=2,  # recovers in two steps from now!,
-                malfunction=2,
+                set_malfunction=3,  # recovers in two steps from now! (duration bumped +1 from 2; observed recovery timing unchanged)
+                malfunction=3,
                 reward=env.step_penalty * 0.5  # step penalty for speed 0.5 when malfunctioning
             ),
 
@@ -495,7 +498,7 @@ def test_multispeed_actions_malfunction_no_blocking():
                 position=(3, 8),
                 direction=Grid4TransitionsEnum.WEST,
                 state=TrainState.MALFUNCTION,
-                malfunction=1,
+                malfunction=2,
 
                 action=None,
 
@@ -506,7 +509,7 @@ def test_multispeed_actions_malfunction_no_blocking():
                 position=(3, 8),
                 direction=Grid4TransitionsEnum.WEST,
                 state=TrainState.MALFUNCTION,
-                malfunction=0,
+                malfunction=1,
 
                 action=RailEnvActions.MOVE_FORWARD,  # SM: MALFUNCTION -> MOVING needs move action
 
@@ -522,20 +525,23 @@ def test_multispeed_actions_malfunction_no_blocking():
 
                 reward=env.step_penalty * 0.5  # running at speed 0.5
             ),
+            # design: malfunction counter decremented at start of step(), before new malfunctions are generated -
+            # injected duration bumped by 1 so the state sequence below is unaffected (only the malfunction countdown
+            # values shift by 1 while the malfunction is active)
             Replay(  # 7
                 position=(3, 7),
                 direction=Grid4TransitionsEnum.WEST,
                 state=TrainState.MOVING,
                 action=None,
-                set_malfunction=2,  # recovers in two steps from now!
-                malfunction=2,
+                set_malfunction=3,  # recovers in two steps from now! (duration bumped +1 from 2; observed recovery timing unchanged)
+                malfunction=3,
                 reward=env.step_penalty * 0.5  # step penalty for speed 0.5 when malfunctioning
             ),
             Replay(  # 8
                 position=(3, 7),
                 direction=Grid4TransitionsEnum.WEST,
                 state=TrainState.MALFUNCTION,
-                malfunction=1,
+                malfunction=2,
 
                 action=None,
                 reward=env.step_penalty * 0.5  # running at speed 0.5
@@ -545,7 +551,7 @@ def test_multispeed_actions_malfunction_no_blocking():
                 direction=Grid4TransitionsEnum.WEST,
                 # end of malfunction
                 state=TrainState.MALFUNCTION,
-                malfunction=0,
+                malfunction=1,
 
                 action=RailEnvActions.MOVE_FORWARD,  # need move action after malfunction according to SM
 

--- a/tests/test_rewards.py
+++ b/tests/test_rewards.py
@@ -1273,7 +1273,10 @@ def _env_after_malfunction():
     assert agent.state == TrainState.MOVING
 
     # malfunction hits while moving; waiting it out is not a collision
-    agent.malfunction_handler.malfunction_down_counter = 3
+    # design: malfunction counter decremented at start of step(), before new malfunctions are generated -
+    # injected duration bumped by 1 so the state sequence below is unaffected (only the malfunction countdown
+    # values shift by 1 while the malfunction is active)
+    agent.malfunction_handler.malfunction_down_counter = 4
     for _ in range(3):
         _, rewards, _, _ = env.step({0: RailEnvActions.DO_NOTHING})
         assert agent.state == TrainState.MALFUNCTION

--- a/tests/trajectories/test_policy_runner.py
+++ b/tests/trajectories/test_policy_runner.py
@@ -3,7 +3,6 @@ import tempfile
 from pathlib import Path
 from typing import Optional, Any, List, Dict
 
-import numpy as np
 import pytest
 
 from flatland.callbacks.callbacks import FlatlandCallbacks, make_multi_callbacks
@@ -298,7 +297,9 @@ def test_effects_generator():
         assert e_info.value.code == 0
 
         trajectory = Trajectory.load_existing(data_dir=data_dir, ep_id="banana")
-        assert sum([info["malfunction"] > 0 for info in trajectory.trains_rewards_dones_infos["info"]]) == 25
+        # design: malfunction counter decremented at start of step(), before new malfunctions are generated,
+        # so a freshly generated malfunction is observed for one extra step before it clears
+        assert sum([info["malfunction"] > 0 for info in trajectory.trains_rewards_dones_infos["info"]]) == 25 + 1
 
 
 def test_env_path_and_obs_builder():


### PR DESCRIPTION
## Changes

### Carried out

| ID | Description | Category | Severity | Commit(s) |
|---|---|---|---|---|
| — | Decrement the malfunction counter at the start of `step()`, before generating new malfunctions, eliminating a one-step lag where `malfunction_down_counter` could reach 0 before `agent.state` transitioned off MALFUNCTION/MALFUNCTION_OFF_MAP; add `_check_malfunction_state_invariant()` asserting state and the malfunction handler can never observably diverge after `step()` returns. Resolves the long-standing #280 TODO about this exact "ugly situation" (3 occurrences removed). Part of #280 | fix | major | a2ba6382 |
| — | Add a `shifted_malfunction` bridge option to `TrajectoryEvaluator.evaluate()` so pre-refactor recorded benchmark episodes (whose `malfunction` value predates the start-of-step decrement) can still be evaluated | compat bridge | minor | 7e36bbaf |
| — | Shift malfunction-counter assertions by +1 for the start-of-step decrement (category A: numeric-only fixes) | test | minor | 35c67f1e |
| — | Fix state/position sequences after the malfunction-counter reorder (category A+B: numeric shifts plus loop-guard fixes where the state now clears one iteration earlier) | test | minor | d35d9dec |
| — | Fix known-bug tests to reflect the malfunction-counter reorder (category C): two tests documenting a real state/counter contradiction that the reorder resolves are renamed to `_FIXED` and rewritten to prove the fixed behavior instead of the former contradiction | test | minor | 62d23c31 |
| — | Move `step()`'s pre/post invariant orchestration up from `RailEnv` to `AbstractRailEnv`, so `GraphRailEnv` (which shares `AbstractRailEnv.step()` verbatim but never overrode it) stops silently skipping the entire invariant-check suite; `RailEnv.step()`'s override now only does the genuinely grid-only part. Verified: `GraphRailEnv`'s suite now actually exercises the full invariant set for the first time (52 passed, 0 failed); full core suite 914 passed / 141 skipped / 14 failed, all 14 pre-existing `BENCHMARK_EPISODES_FOLDER`-unset environmental failures unrelated to this change | refactor | moderate | 037f1134 |

## Related issues

Link to every issue from the issue tracker (if any) you addressed in this PR.

## Checklist

- [ ] Tests are included for relevant behavior changes.
- [ ] Documentation is added in the [flatland-book](https://github.com/flatland-association/flatland-book) repo for relevant behavior changes.
- [ ] If you made important user-facing changes, describe them under the `[Unreleased]` tag in `CHANGELOG.md`.
- [ ] New package dependencies are declared in the `pyproject.toml` file.
  Requirement files have been updated by running `tox -e requirements`.
- [ ] Code works with all supported Python versions (3.10, 3.11, 3.12 and 3.13). Checks run with all supported version and are
  required to run successfully.
- [ ] Code is formatted according to PEP 8 (an IDE like PyCharm can do this for you).
- [ ] Technical guidelines listed in `CONTRIBUTING.md` are followed.

