### PR TITLE
refactor!: D6* cleanup collect and distribute in step().

### DIFF
--- a/flatland/envs/rail_env.py
+++ b/flatland/envs/rail_env.py
@@ -999,10 +999,15 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
                     else:
                         assert agent.speed_counter.distance == SpeedCounter.distance_without_crossing(
                             pre_step.pre_offsets[h], pre_speed)
-                # off map (stayed off map)
+                # off map (stayed off map) / map entry - genuinely post-hoc: whether map entry actually
+                # happened isn't decided by resource_check/in_malfunction alone, it also needs the state
+                # machine to have promoted to MOVING (e.g. a MALFUNCTION_OFF_MAP/READY_TO_DEPART agent
+                # given STOP_MOVING can get an optimistic non-None candidate_entry_point from loop 1's
+                # (3b.3) yet never be promoted - see issue #280) - so this can't be dedup'd against
+                # self.temp_transition_data[h].candidate_entry_point the way the discarded/malfunction
+                # branches above/below are.
                 elif pre_step.pre_offsets[h] is None and agent.current_entry_point is None:
                     assert agent.speed_counter.distance is None
-                # map entry
                 elif pre_step.pre_offsets[h] is None and agent.current_entry_point is not None:
                     assert agent.speed_counter.distance == 0
                 # malfunction
@@ -1035,7 +1040,7 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
 
             # candidates discarded in distribute phase -> speed 0 and distance updated with pre-speed
             if not self.temp_transition_data[h].resource_check:
-                if agent.current_entry_point is None:
+                if pre_step.pre_current_entry_points[h] is None:
                     # rejected map entry - agent stays off map, speed stays None
                     assert agent.speed_counter.speed is None
                 else:
@@ -1055,11 +1060,14 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
                         assert agent.speed_counter.speed == Fraction(0)
                 # malfunction
                 elif agent.malfunction_handler.in_malfunction:
-                    if agent.current_entry_point is None:
+                    if pre_step.pre_current_entry_points[h] is None:
                         assert agent.speed_counter.speed is None
                     else:
                         assert agent.speed_counter.speed == 0
-                # map entry
+                # map entry - genuinely post-hoc, same reason as the distance-update loop's "map entry"
+                # branch above: can't be dedup'd against self.temp_transition_data[h].candidate_entry_point,
+                # since that candidate can be optimistically non-None (loop 1's (3b.3)) without the state
+                # machine ever actually promoting to MOVING this step (see issue #280).
                 elif pre_step.pre_current_entry_points[h] is None and agent.current_entry_point is not None:
                     assert agent.speed_counter.speed == _cap_speed(agent.speed_counter.max_speed,
                                                                     self.acceleration_delta)

--- a/flatland/envs/rail_env.py
+++ b/flatland/envs/rail_env.py
@@ -945,7 +945,7 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
                     assert agent.current_entry_point == pre_step.pre_current_entry_points[h]
                     assert agent.next_entry_point == pre_step.pre_next_entry_points[h]
                 # map entry
-                elif pre_step.pre_current_entry_points[h] is None and agent.current_entry_point is not None:
+                elif pre_step.pre_current_entry_points[h] is None and candidate_entry_point is not None:
                     assert agent.current_entry_point == agent.initial_entry_point
                     assert agent.current_entry_point == candidate_entry_point
                     assert agent.next_entry_point == candidate_next_entry_point

--- a/flatland/envs/rail_env.py
+++ b/flatland/envs/rail_env.py
@@ -905,13 +905,6 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
                 assert agent.next_entry_point == pre_step.pre_next_entry_points[h]
             # candidates accepted in distribute phase
             else:
-                # re-derive step()'s (3b.3)/(3b.5) candidate_entry_point/candidate_next_entry_point from
-                # the pre-step snapshot + action alone, instead of reading temp_transition_data. A genuine
-                # crossing (map entry, or an on-map cell transition) requires pre_speed > 0 and the
-                # boundary already reached (same (D1) test as below), plus - on-map - a valid action
-                # (candidate_entry_point_independent is not None); an invalid action at the boundary is
-                # denied by (3b.6), same as not having reached the boundary at all, so the candidate is
-                # just the unchanged pre-step position in every other case.
                 action = RailEnvActions.from_value(action_dict.get(h, RailEnvActions.DO_NOTHING))
                 pre_current_entry_point = pre_step.pre_current_entry_points[h]
                 pre_next_entry_point = pre_step.pre_next_entry_points[h]
@@ -927,8 +920,9 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
                     # (3b.3) map entry
                     candidate_entry_point = agent.initial_entry_point
                     candidate_next_entry_point = candidate_entry_point_independent
-                elif is_on_map and is_cell_exit and candidate_entry_point_independent is not None:
-                    # (3b.5) on-map cell transition
+                elif is_on_map and is_cell_exit:
+                    # (3b.5) on-map cell transition - candidate_next_entry_point stays None here exactly
+                    # when the action was invalid at the boundary (denied by (3b.6)); guarded for below.
                     candidate_entry_point = pre_next_entry_point
                     candidate_next_entry_point = candidate_entry_point_independent
                 else:
@@ -956,9 +950,6 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
                     assert agent.current_entry_point == candidate_entry_point
                     assert agent.next_entry_point == candidate_next_entry_point
                 # target reached
-                # design (D1): pre_speeds[h] > 0 required - a pre-speed-0 (STOPPED/MALFUNCTION) agent
-                # must never be read as completing a transition here, even if banked pre_offsets[h]
-                # alone would satisfy the boundary check (see (10a)/(10b)'s matching deferral in step()).
                 elif candidate_entry_point in agent.targets and (
                     pre_step.pre_speeds[h] > 0 and pre_step.pre_offsets[h] + pre_step.pre_speeds[h] >= SEGMENT_LENGTH):
                     assert agent.target_entry_point == candidate_entry_point
@@ -971,8 +962,7 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
                         assert agent.next_entry_point == candidate_next_entry_point
                         assert agent.current_entry_point == agent.target_entry_point
                 # on-map cell transition
-                # design (D1): pre_speeds[h] > 0 required, same reasoning as "target reached" above.
-                elif agent.current_entry_point is not None and (
+                elif candidate_next_entry_point is not None and (
                     pre_step.pre_speeds[h] > 0 and pre_step.pre_offsets[h] + pre_step.pre_speeds[h] >= SEGMENT_LENGTH):
                     assert agent.current_entry_point is not None
                     assert agent.current_entry_point == candidate_entry_point

--- a/flatland/envs/rail_env.py
+++ b/flatland/envs/rail_env.py
@@ -520,7 +520,8 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
                 candidate_speed = agent.speed_counter.speed
             candidate_speed = _cap_speed(agent_max_speed, candidate_speed)
 
-            # (3b) POSITION UPDATE
+            # (3b) POSITION UPDATE - mirrors _check_post_position_invariants's "candidates accepted"
+            # derivation: done/malfunction/map-entry/on-map-transition/stay.
             # (3b.1) done
             if state == TrainState.DONE:
                 # design: for remove_agents_at_target=True, agent.current_entry_point is already
@@ -529,15 +530,13 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
                 # both its current and candidate resource
                 candidate_entry_point = agent.current_entry_point
                 candidate_next_entry_point = agent.next_entry_point
-            # (3b.2) malfunction (continued)
+            # (3b.2) malfunction - takes priority over (3b.3)/(3b.5) below: in_malfunction is resolved
+            # before this loop runs (see (0a)/(0b)), so it can be True while `state` (read above, still
+            # the pre-transition value) hasn't caught up to MALFUNCTION/MALFUNCTION_OFF_MAP yet -
+            # without this priority, a same-step malfunction onset could let a genuine crossing through.
             elif in_malfunction:
                 candidate_entry_point = agent.current_entry_point
                 candidate_next_entry_point = agent.next_entry_point
-            # (3b.2bis) start moving: from STOPPED (or a just-recovered MALFUNCTION)
-            elif agent.speed_counter.speed == 0 and candidate_speed > 0:
-                candidate_entry_point = agent.current_entry_point
-                candidate_next_entry_point = agent.next_entry_point
-                assert agent.current_entry_point is not None
             #  (3b.3) map entry
             elif action_valid and (
                 (state == TrainState.READY_TO_DEPART and movement_action_given)
@@ -547,28 +546,20 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
             ):
                 candidate_entry_point = initial_entry_point
                 candidate_next_entry_point = candidate_entry_point_independent
-            # (3b.4) off map
-            elif not is_on_map:
-                # current_entry_point candidate_next_entry_point both None off map - a no-op.
-                candidate_entry_point = agent.current_entry_point
-                candidate_next_entry_point = agent.next_entry_point
-            # (3b.5) cell transition
+            # (3b.5) on-map cell transition
             elif is_on_map and is_cell_exit and candidate_entry_point_independent is not None and state == TrainState.MOVING:
-                assert agent.current_entry_point is not None
                 # design: actions applied at cell entry -- attempt the already-decided target
-                # (guaranteed by the assert above); this step's action instead decides the
+                # (guaranteed on-map by is_on_map above); this step's action instead decides the
                 # look-ahead beyond it (candidate_entry_point_independent, computed above in (2)).
                 candidate_entry_point = agent.next_entry_point
                 candidate_next_entry_point = candidate_entry_point_independent
-            # (3b.6) cell stay: mid-cell (not attempting this step), attempted but denied, or a
-            # STOPPED agent not (yet) given a movement action (candidate_speed stays 0, see (3b.2bis)
-            # above for the case where it does) -
+            # (3b.2bis/3b.4/3b.6) unchanged - start-moving-from-stop, off-map-stay, and cell-stay
+            # (mid-cell / attempted-but-denied) all set the identical "keep current" candidate - a
+            # pure identity copy of already-valid current/next_entry_point, so it can't violate the
+            # off/on-map invariant that already held.
             else:
-                # design: self-loop default - see (3b.1) above for why candidate_next_entry_point
-                # mirroring agent.next_entry_point unchanged is safe (never read as entering_new_cell).
                 candidate_entry_point = agent.current_entry_point
                 candidate_next_entry_point = agent.next_entry_point
-                assert agent.current_entry_point is not None
 
             if self.check_step_pre_post_conditions:
                 self._check_off_on_map_invariant(candidate_entry_point, candidate_next_entry_point)

--- a/flatland/envs/rail_env.py
+++ b/flatland/envs/rail_env.py
@@ -905,6 +905,37 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
                 assert agent.next_entry_point == pre_step.pre_next_entry_points[h]
             # candidates accepted in distribute phase
             else:
+                # re-derive step()'s (3b.3)/(3b.5) candidate_entry_point/candidate_next_entry_point from
+                # the pre-step snapshot + action alone, instead of reading temp_transition_data. A genuine
+                # crossing (map entry, or an on-map cell transition) requires pre_speed > 0 and the
+                # boundary already reached (same (D1) test as below), plus - on-map - a valid action
+                # (candidate_entry_point_independent is not None); an invalid action at the boundary is
+                # denied by (3b.6), same as not having reached the boundary at all, so the candidate is
+                # just the unchanged pre-step position in every other case.
+                action = RailEnvActions.from_value(action_dict.get(h, RailEnvActions.DO_NOTHING))
+                pre_current_entry_point = pre_step.pre_current_entry_points[h]
+                pre_next_entry_point = pre_step.pre_next_entry_points[h]
+                pre_speed = pre_step.pre_speeds[h]
+                is_on_map = pre_next_entry_point is not None
+                is_cell_exit = pre_speed is not None and pre_speed > 0 and pre_step.pre_offsets[h] + pre_speed >= SEGMENT_LENGTH
+                if is_on_map:
+                    candidate_entry_point_independent = self.rail.apply_action_independent(action, pre_next_entry_point)
+                else:
+                    candidate_entry_point_independent = self.rail.apply_action_independent(action, agent.initial_entry_point)
+
+                if not is_on_map and agent.current_entry_point is not None:
+                    # (3b.3) map entry
+                    candidate_entry_point = agent.initial_entry_point
+                    candidate_next_entry_point = candidate_entry_point_independent
+                elif is_on_map and is_cell_exit and candidate_entry_point_independent is not None:
+                    # (3b.5) on-map cell transition
+                    candidate_entry_point = pre_next_entry_point
+                    candidate_next_entry_point = candidate_entry_point_independent
+                else:
+                    # (3b.1/3b.2/3b.2bis/3b.4/3b.6) unchanged
+                    candidate_entry_point = pre_current_entry_point
+                    candidate_next_entry_point = pre_next_entry_point
+
                 # done
                 if pre_step.pre_dones[h]:
                     if self.remove_agents_at_target:
@@ -922,30 +953,30 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
                 # map entry
                 elif pre_step.pre_current_entry_points[h] is None and agent.current_entry_point is not None:
                     assert agent.current_entry_point == agent.initial_entry_point
-                    assert agent.current_entry_point == self.temp_transition_data[h].candidate_entry_point
-                    assert agent.next_entry_point == self.temp_transition_data[h].candidate_next_entry_point
+                    assert agent.current_entry_point == candidate_entry_point
+                    assert agent.next_entry_point == candidate_next_entry_point
                 # target reached
                 # design (D1): pre_speeds[h] > 0 required - a pre-speed-0 (STOPPED/MALFUNCTION) agent
                 # must never be read as completing a transition here, even if banked pre_offsets[h]
                 # alone would satisfy the boundary check (see (10a)/(10b)'s matching deferral in step()).
-                elif self.temp_transition_data[h].candidate_entry_point in agent.targets and (
+                elif candidate_entry_point in agent.targets and (
                     pre_step.pre_speeds[h] > 0 and pre_step.pre_offsets[h] + pre_step.pre_speeds[h] >= SEGMENT_LENGTH):
-                    assert agent.target_entry_point == self.temp_transition_data[h].candidate_entry_point
+                    assert agent.target_entry_point == candidate_entry_point
                     if self.remove_agents_at_target:
                         assert agent.current_entry_point is None
                         assert agent.next_entry_point is None
                     else:
                         assert agent.current_entry_point is not None
-                        assert agent.current_entry_point == self.temp_transition_data[h].candidate_entry_point
-                        assert agent.next_entry_point == self.temp_transition_data[h].candidate_next_entry_point
+                        assert agent.current_entry_point == candidate_entry_point
+                        assert agent.next_entry_point == candidate_next_entry_point
                         assert agent.current_entry_point == agent.target_entry_point
                 # on-map cell transition
                 # design (D1): pre_speeds[h] > 0 required, same reasoning as "target reached" above.
                 elif agent.current_entry_point is not None and (
                     pre_step.pre_speeds[h] > 0 and pre_step.pre_offsets[h] + pre_step.pre_speeds[h] >= SEGMENT_LENGTH):
                     assert agent.current_entry_point is not None
-                    assert agent.current_entry_point == self.temp_transition_data[h].candidate_entry_point
-                    assert agent.next_entry_point == self.temp_transition_data[h].candidate_next_entry_point
+                    assert agent.current_entry_point == candidate_entry_point
+                    assert agent.next_entry_point == candidate_next_entry_point
                 # stay
                 else:
                     assert agent.current_entry_point == pre_step.pre_current_entry_points[h]

--- a/flatland/envs/step_utils/state_machine.py
+++ b/flatland/envs/step_utils/state_machine.py
@@ -41,6 +41,18 @@ class TrainStateMachine:
             self.next_state = TrainState.READY_TO_DEPART
 
     def _handle_malfunction_off_map(self):
+        """
+        Off-map counterpart to MALFUNCTION. Malfunctions are rolled for every agent every step
+        regardless of on/off-map status (see MalfunctionEffectsGenerator.on_episode_step_start,
+        which iterates all agents unconditionally) - design: if malfunctions were only rolled for
+        agents already on-map (MOVING/STOPPED/MALFUNCTION), the malfunction_rate an operator
+        configures would understate the rate actually experienced once on-map, since off-map
+        steps - WAITING for earliest_departure, or already READY_TO_DEPART but not yet moving
+        (no movement action given, or the entry cell contested by another agent) - would never
+        count against it. MALFUNCTION_OFF_MAP exists so an off-map agent can absorb that same
+        roll (with no position/speed/distance to freeze - see TrainState.is_off_map_state())
+        instead of being exempt from it.
+        """
         if not self.st_signals.in_malfunction:
             if self.st_signals.earliest_departure_reached:
                 # TODO https://github.com/flatland-association/flatland-rl/issues/280 revise design: should we not go to the READY_TO_DEPART first instead of directly to MOVING?
@@ -83,7 +95,20 @@ class TrainStateMachine:
             self.next_state = TrainState.MALFUNCTION
 
     def _handle_done(self):
-        """" Done state is terminal """
+        """"
+        Done state is terminal - unlike _handle_waiting/_handle_ready_to_depart above, this ignores
+        st_signals.in_malfunction entirely: a DONE agent can still roll a malfunction (rolled
+        unconditionally for every agent, see _handle_malfunction_off_map's docstring) and have
+        malfunction_handler.in_malfunction read True, but it never transitions to
+        MALFUNCTION/MALFUNCTION_OFF_MAP for it - the roll is silently absorbed with no state
+        consequence, since DONE is terminal. See rail_env.py's _check_malfunction_state_invariant,
+        which excludes DONE agents from its state/in_malfunction consistency check for this reason.
+
+        This holds independently of remove_agents_at_target, which only decides what DONE's position
+        looks like (current_entry_point cleared to None if True, left at the target cell if False -
+        neither is_on_map_state() nor is_off_map_state() count DONE either way, see
+        handle_done_state()) - not whether a DONE agent can still malfunction.
+        """
         self.next_state = TrainState.DONE
 
     def calculate_next_state(self, current_state):

--- a/tests/test_flatland_envs_rail_env.py
+++ b/tests/test_flatland_envs_rail_env.py
@@ -959,6 +959,135 @@ def test_earliest_departure_state_transitions_full_acceleration():
     assert agent.speed_counter.distance == Fraction(0)
 
 
+def test_map_entry_no_malfunction():
+    """
+    Single agent, no malfunction, earliest_departure=0, max speed 1, acceleration delta equal to
+    max speed. Same WAITING -> READY_TO_DEPART -> MOVING map entry as
+    test_earliest_departure_state_transitions_full_acceleration, but earliest_departure=0 means the
+    very first step already reaches READY_TO_DEPART, so no WAITING loop is needed.
+
+    - Setup: agent off map, speed and distance both None.
+    - Step 1 (elapsed_steps=1 >= earliest_departure=0): WAITING -> READY_TO_DEPART, still off map,
+      speed and distance still None.
+    - Step 2 (MOVE_FORWARD): map entry - position becomes the agent's initial entry point, state ->
+      MOVING, distance resets to 0, speed reaches max speed immediately.
+    - Step 3 (MOVE_FORWARD): already at max speed, so the agent crosses into the next entry point,
+      distance wraps back to 0 completing the crossing, speed stays at max speed.
+    """
+    env, _, _ = env_generator(seed=42, n_agents=1)
+    env.acceleration_delta = Fraction(1)
+    agent = env.agents[0]
+    agent.speed_counter = SpeedCounter(max_speed=Fraction(1))
+    agent.earliest_departure = 0
+
+    assert agent.state == TrainState.WAITING
+    assert agent.current_entry_point is None
+    assert agent.speed_counter.speed is None
+    assert agent.speed_counter.distance is None
+
+    env.step({agent.handle: RailEnvActions.MOVE_FORWARD})
+    assert env._elapsed_steps == 1
+    assert agent.state == TrainState.READY_TO_DEPART
+    assert agent.current_entry_point is None
+    assert agent.speed_counter.speed is None
+    assert agent.speed_counter.distance is None
+
+
+    env.step({agent.handle: RailEnvActions.MOVE_FORWARD})
+    # on-map after step 2, although elapased_steps says 0! TODO #280 revise design twirk: agent enters map only at earliest_depature+1 (in step earliest_departure + 1 + 1).
+    assert env._elapsed_steps == 2
+    assert agent.state == TrainState.MOVING
+    first_entry_point = agent.current_entry_point
+    assert first_entry_point == agent.initial_entry_point
+    assert agent.speed_counter.speed == Fraction(1)
+    assert agent.speed_counter.distance == Fraction(0)
+
+    second_entry_point = env.rail.apply_action_independent(RailEnvActions.MOVE_FORWARD, first_entry_point)
+    env.step({agent.handle: RailEnvActions.MOVE_FORWARD})
+    assert env._elapsed_steps == 3
+    assert agent.state == TrainState.MOVING
+    assert agent.current_entry_point == second_entry_point
+    assert agent.speed_counter.speed == Fraction(1)
+    assert agent.speed_counter.distance == Fraction(0)
+
+
+def test_map_entry_with_malfunction():
+    """
+    Same setup as test_map_entry_no_malfunction (earliest_departure=0, max speed 1, acceleration
+    delta equal to max speed), but with a malfunction injected before the agent ever reaches
+    READY_TO_DEPART: malfunction_down_counter starts at 3. The state machine decrements it on the
+    same step it reads in_malfunction (see TrainStateMachine's handlers), so it is observed True for
+    2 steps and reaches 0 on the 3rd. MOVE_FORWARD is given from the very first step, so on that 3rd
+    step the agent enters the map directly from MALFUNCTION_OFF_MAP, never visiting READY_TO_DEPART
+    (design quirk tracked as issue #280: MALFUNCTION_OFF_MAP goes straight to MOVING on a movement
+    action once earliest_departure is reached and the malfunction has just ended, rather than via
+    READY_TO_DEPART - see _handle_malfunction_off_map's docstring).
+
+    - Setup: agent off map, WAITING, malfunction_down_counter set to 3. malfunction_interval=0
+      disables env_generator's own random malfunction generation, so only this injected malfunction
+      is in play.
+    - Step 1 (elapsed_steps=1 >= earliest_departure=0, but in_malfunction after this step's
+      decrement): WAITING -> MALFUNCTION_OFF_MAP, still off map, speed/distance None,
+      malfunction_down_counter == 2.
+    - Step 2 (still in_malfunction): stays MALFUNCTION_OFF_MAP, still off map,
+      malfunction_down_counter == 1.
+    - Step 3 (malfunction_down_counter decrements to 0, in_malfunction False, earliest_departure
+      already reached, MOVE_FORWARD given): map entry directly from MALFUNCTION_OFF_MAP - position
+      becomes the agent's initial entry point, state -> MOVING, distance resets to 0, speed reaches
+      max speed immediately, malfunction_down_counter == 0.
+    - Step 4: already at max speed, so the agent crosses into the next entry point, distance wraps
+      back to 0 completing the crossing, speed stays at max speed.
+    """
+    env, _, _ = env_generator(seed=42, n_agents=1, malfunction_interval=0)
+    env.acceleration_delta = Fraction(1)
+    agent = env.agents[0]
+    agent.speed_counter = SpeedCounter(max_speed=Fraction(1))
+    agent.earliest_departure = 0
+    agent.malfunction_handler._set_malfunction_down_counter(3)
+
+    assert agent.state == TrainState.WAITING
+    assert agent.current_entry_point is None
+    assert agent.speed_counter.speed is None
+    assert agent.speed_counter.distance is None
+    # 2 malfunction steps, but make it 2+1 as decremented at start of step(), right after malfunction generators are called.
+    assert agent.malfunction_handler.malfunction_down_counter == 3
+
+    env.step({agent.handle: RailEnvActions.MOVE_FORWARD})
+    assert env._elapsed_steps == 1
+    assert agent.state == TrainState.MALFUNCTION_OFF_MAP
+    assert agent.current_entry_point is None
+    assert agent.speed_counter.speed is None
+    assert agent.speed_counter.distance is None
+    assert agent.malfunction_handler.malfunction_down_counter == 2
+
+    env.step({agent.handle: RailEnvActions.MOVE_FORWARD})
+    assert env._elapsed_steps == 2
+    assert agent.state == TrainState.MALFUNCTION_OFF_MAP
+    assert agent.current_entry_point is None
+    assert agent.speed_counter.speed is None
+    assert agent.speed_counter.distance is None
+    assert agent.malfunction_handler.malfunction_down_counter == 1
+
+    # malfunction terminates at start of this next step()
+    # on-map after step 3, although 2 malfunction steps, not at 2+2 (2 as without malfunction + 2 malfunction steps), highlighting  TODO #280 revise design twirk: #280 WAITING bypass with malfunction_off_map
+    env.step({agent.handle: RailEnvActions.MOVE_FORWARD})
+    assert env._elapsed_steps == 3
+    assert agent.state == TrainState.MOVING
+    first_entry_point = agent.current_entry_point
+    assert first_entry_point == agent.initial_entry_point
+    assert agent.speed_counter.speed == Fraction(1)
+    assert agent.speed_counter.distance == Fraction(0)
+    assert agent.malfunction_handler.malfunction_down_counter == 0
+
+    second_entry_point = env.rail.apply_action_independent(RailEnvActions.MOVE_FORWARD, first_entry_point)
+    env.step({agent.handle: RailEnvActions.MOVE_FORWARD})
+    assert env._elapsed_steps == 4
+    assert agent.state == TrainState.MOVING
+    assert agent.current_entry_point == second_entry_point
+    assert agent.speed_counter.speed == Fraction(1)
+    assert agent.speed_counter.distance == Fraction(0)
+
+
 def test_earliest_departure_state_transitions_partial_acceleration():
     """
     Same as test_earliest_departure_state_transitions_initial_speed_zero, but with acceleration


### PR DESCRIPTION
## Changes

Describe the changes you made.

### Carried out

| ID | Description | Category | Severity | Commit(s) |
|---|---|---|---|---|
| — | Derive `_check_post_position_invariants`' post-step position candidate from the captured pre-step snapshot and action_dict, mirroring step()'s (3b.3)/(3b.5) formulas directly, instead of reading step()'s own collect-phase scratch values | refactor | Medium | aaaa5c83 |
| — | Simplify redundant guards in the post-step position invariant check: guard the on-map cell-transition branch directly on `candidate_next_entry_point is None`, drop an implied `current_entry_point is not None` check | refactor | Low | b49cbcb1 |
| — | Dedupe a post-hoc `agent.current_entry_point` read in the map-entry branch condition by reusing the already-derived `candidate_entry_point` | refactor | Low | 11454b13 |
| — | Collapse step()'s 6-branch (3b) POSITION UPDATE collect phase to a 3-way split (done / malfunction / fallback) matching what `_check_post_position_invariants` already asserts, adding an explicit in_malfunction priority branch to preserve pre-collapse ordering semantics | refactor | Medium | f82d6957 |
| — | Dedupe two post-hoc `agent.current_entry_point` reads in `_check_post_speed_distance_invariants` by substituting the pre-step snapshot value where provably safe (resource_check False / in_malfunction True); keep the post-hoc read for the two map-entry branches where the substitution is not valid (issue #280's READY_TO_DEPART/MALFUNCTION_OFF_MAP + STOP_MOVING quirk), with a comment explaining why | refactor | Low | 067d7e89 |
| — | Document why malfunctions apply off-map and why DONE ignores them in `_handle_malfunction_off_map`/`_handle_done`, two easy-to-miss design points previously unexplained anywhere in the repo | docs | Low | ad994e25 |
| — | Add `test_map_entry_no_malfunction`/`test_map_entry_with_malfunction`, driving `env.step()` directly with explicit position/state/speed/distance/elapsed_steps assertions after each step, for a single agent with `earliest_departure=0` - two new TODOs added in these tests flag design quirks around map-entry timing (issue #280, not yet linked from this PR - consider adding "Relates to #280") | test | Medium | c1ec04e2 |

### Remaining

No outstanding follow-up work identified for this PR.

## Related issues

Link to every issue from the issue tracker (if any) you addressed in this PR.

## Checklist

- [ ] Tests are included for relevant behavior changes.
- [ ] Documentation is added in the [flatland-book](https://github.com/flatland-association/flatland-book) repo for relevant behavior changes.
- [ ] If you made important user-facing changes, describe them under the `[Unreleased]` tag in `CHANGELOG.md`.
- [ ] New package dependencies are declared in the `pyproject.toml` file.
  Requirement files have been updated by running `tox -e requirements`.
- [ ] Code works with all supported Python versions (3.10, 3.11, 3.12 and 3.13). Checks run with all supported version and are
  required to run successfully.
- [ ] Code is formatted according to PEP 8 (an IDE like PyCharm can do this for you).
- [ ] Technical guidelines listed in `CONTRIBUTING.md` are followed.