### PR TITLE
refactor!: D5/6 map entering cleanup (malfunction or no malfunction).

### DIFF
--- a/flatland/envs/rail_env.py
+++ b/flatland/envs/rail_env.py
@@ -465,8 +465,18 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
             # (1) STATE TRANSITION SIGNALS
             stop_action_given = action == RailEnvActions.STOP_MOVING
             in_malfunction = agent.malfunction_handler.in_malfunction
+            # design (issue #280): an earliest_departure=0 agent never goes through a state_machine.step()
+            # call before the very first step() runs - tweak state directly here, before this step's own
+            # state read below, so it already sees READY_TO_DEPART instead of stale WAITING (symmetric
+            # with MALFUNCTION_OFF_MAP's own straight-to-MOVING shortcut in _handle_malfunction_off_map).
+            if self._elapsed_steps == 1 and agent.earliest_departure == 0 and not in_malfunction and agent.state == TrainState.WAITING:
+                agent.state_machine.set_state(TrainState.READY_TO_DEPART)
             movement_action_given = RailEnvActions.is_moving_action(action)
-            earliest_departure_reached = agent.earliest_departure <= self._elapsed_steps
+            # design (issue #280): earliest_departure_reached is signalled one step earlier,
+            # so the WAITING -> READY_TO_DEPART transition it drives in
+            # the state machine completes in N-1, so the agens is READY_TO_DEPART in step N and can enter
+            # the grid in step N
+            earliest_departure_reached = agent.earliest_departure <= self._elapsed_steps + 1
             state = agent.state
 
             # (2) CANDIDATE ENTRY POINT: action validity - need both by speed update (3a) and position update (3b) below
@@ -540,7 +550,9 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
             #  (3b.3) map entry
             elif action_valid and (
                 (state == TrainState.READY_TO_DEPART and movement_action_given)
-                # TODO https://github.com/flatland-association/flatland-rl/issues/280 revise design: weirdly, MALFUNCTION_OFF_MAP does not go via READY_TO_DEPART, but STOP_MOVING and MOVE_* adds to map if possible
+                # design (issue #280): MALFUNCTION_OFF_MAP intentionally does not go via READY_TO_DEPART -
+                # STOP_MOVING and MOVE_* both add to map directly if possible, same as MOVING's own
+                # straight-to-MOVING shortcut in _handle_malfunction_off_map.
                 or (state == TrainState.MALFUNCTION_OFF_MAP and earliest_departure_reached
                     and (movement_action_given or stop_action_given))
             ):
@@ -583,7 +595,7 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
             # Malfunction starts when in_malfunction is set to true (inverse of malfunction_counter_complete)
             self.temp_transition_data[i_agent].state_transition_signal.in_malfunction = agent.malfunction_handler.in_malfunction
             # Earliest departure reached - Train is allowed to move now
-            self.temp_transition_data[i_agent].state_transition_signal.earliest_departure_reached = self._elapsed_steps >= agent.earliest_departure
+            self.temp_transition_data[i_agent].state_transition_signal.earliest_departure_reached = self._elapsed_steps + 1 >= agent.earliest_departure
             # Stop action given
             self.temp_transition_data[i_agent].state_transition_signal.stop_action_given = stop_action_given
             # Movement action given

--- a/flatland/envs/step_utils/state_machine.py
+++ b/flatland/envs/step_utils/state_machine.py
@@ -55,7 +55,6 @@ class TrainStateMachine:
         """
         if not self.st_signals.in_malfunction:
             if self.st_signals.earliest_departure_reached:
-                # TODO https://github.com/flatland-association/flatland-rl/issues/280 revise design: should we not go to the READY_TO_DEPART first instead of directly to MOVING?
                 # design: disallow entering the map stopped
                 if self.st_signals.movement_action_given and self.st_signals.movement_allowed:
                     self.next_state = TrainState.MOVING
@@ -140,7 +139,109 @@ class TrainStateMachine:
             raise ValueError(f"Got unexpected state {current_state}")
 
     def step(self):
-        """ Steps the state machine to the next state """
+        """
+        Steps the state machine to the next state.
+
+        By the time this call returns, self.state is the settled outcome of this very step() call -
+        callers reading agent.state right after env.step() returns are seeing "what happened this
+        step", not a preview of the next one. MALFUNCTION/MALFUNCTION_OFF_MAP transitions honor this:
+        rail_env.py's step() decrements malfunction_handler's down-counter and rolls any new
+        malfunction (MalfunctionEffectsGenerator.on_episode_step_start) at the very start of the same
+        env.step() call (see rail_env.py's _check_malfunction_state_invariant).
+
+        This still leaves an asymmetry worth knowing about: the counter itself is genuinely external to
+        this step()-then-reflect contract - it is mutated by an outside generator as an *input* to this
+        step's transition, not produced as this step's *output* the way self.state is. A controller can
+        read agent.malfunction_handler.malfunction_down_counter/in_malfunction directly (plain public
+        attributes, no special access contract), and doing so exposes this step's already-updated
+        counter value - but neither that counter nor self.state can tell the controller that the
+        *next* env.step() call is about to end the malfunction, since the decrement/roll that decides
+        that only happens at the start of that next call, not this one.
+
+        RailEnv.action_required() (rail_env.py) is neither purely state-derived nor purely
+        distance/speed-derived - self.state gates which of four cases applies, and only one of them
+        actually consults distance/speed:
+        - WAITING / MALFUNCTION_OFF_MAP (off map, not yet eligible to move): always False, regardless
+          of anything else.
+        - READY_TO_DEPART (off map, eligible to move): always True, regardless of anything else.
+        - MOVING / STOPPED / MALFUNCTION (on map): collapses to SpeedCounter.is_cell_exit() alone
+          (distance + speed >= SEGMENT_LENGTH) - identical for all three on-map states, with no special
+          case for MALFUNCTION. This is where a "malfunctioning agents never need an action" assumption
+          comes from: ordinarily a malfunction freezes distance mid-cell and speed at 0, so
+          is_cell_exit() stays False (see test_action_required_false_during_malfunction in
+          test_flatland_envs_rail_env.py). But it is not a state-level guarantee - an agent already
+          banked exactly at a cell boundary (distance == SEGMENT_LENGTH, e.g. after a denied crossing)
+          satisfies is_cell_exit() from distance alone even at speed 0, so action_required reads True
+          there whether or not the agent also happens to be malfunctioning at that same position (see
+          test_action_required_at_full_segment_length in the same file).
+        - DONE (terminal - neither on map nor off map per TrainState.is_on_map_state()/
+          is_off_map_state()): always False, even with remove_agents_at_target=False leaving the agent
+          parked at a real, banked-at-boundary position (is_cell_exit() would read True there too, but
+          is never consulted - DONE is excluded from the on-map branch above).
+
+        Either way, action_required only ever reports this step's already-settled outcome, never a
+        lookahead onto the next step's malfunction-counter mutation.
+
+        TODO revise design: MALFUNCTION and MALFUNCTION_OFF_MAP are asymmetric here even when
+        earliest_departure is already reached for both - both transition straight into MOVING on the
+        very step their malfunction ends (given a movement action that same step, see
+        _handle_malfunction/_handle_malfunction_off_map above), but action_required disagrees about the
+        steps leading up to that while still malfunctioning: an on-map MALFUNCTION banked at a cell
+        boundary (distance == SEGMENT_LENGTH from a denied crossing before the malfunction hit) reads
+        action_required True for every remaining malfunctioning step, not just the one where the
+        malfunction actually ends - misleadingly, since movement_action_given has no effect while
+        in_malfunction is still True regardless of what action_required says. MALFUNCTION_OFF_MAP never
+        has this problem: an off-map agent has no distance/speed to bank against SEGMENT_LENGTH, so it
+        reads action_required False for the entire malfunction, only flipping True once the transition
+        into MOVING/READY_TO_DEPART has already happened. Confirmed empirically: with earliest_departure
+        already reached (0) going in, a MALFUNCTION_OFF_MAP agent reports action_required
+        False/False/True across a 3-step malfunction (last step already MOVING), while an on-map
+        MALFUNCTION agent banked at a boundary reports True/True/True across the same shape of
+        malfunction (last step STOPPED, since MOVE_FORWARD is invalid at that particular switch - see
+        test_action_required_at_full_segment_length's malfunction variant for the on-map side).
+
+        Three revise-design options were considered:
+
+        Position-based definitions used below (matching this codebase's convention of deriving on/off-map
+        and done-ness from position rather than state, see CLAUDE.md's post-step invariant checks):
+        on_map := agent.current_entry_point is not None; off_map := not on_map; not_done :=
+        agent.target_entry_point is None (set exactly once, permanently, the first step agent.state
+        becomes DONE - see handle_done_state() in rail_env.py - so it is a reliable done/not-done proxy
+        for the whole episode without reading agent.state at all; the only gap is a same-iteration,
+        intra-step window between update_if_reached() flipping state to DONE and handle_done_state()
+        setting target_entry_point a few lines later - never observable across a step() call boundary,
+        so irrelevant to action_required, which is only ever read from get_info_dict() after step()
+        returns).
+
+        - (a) Add one rule for the malfunctioning case only: while in_malfunction, action_required =
+          earliest_departure_reached and (is_cell_exit or off_map) and not_done; otherwise
+          state == TrainState.READY_TO_DEPART or (state.is_on_map_state() and is_cell_exit) - today's
+          formula, unchanged. The `and not_done` guard is needed because a DONE agent can still have
+          in_malfunction True (see _handle_done's docstring above) and earliest_departure_reached is
+          trivially True long after departure - without it, the malfunction branch would wrongly
+          evaluate to True for a terminal agent.
+        - (b) (is_cell_exit and on_map and not_done) or (earliest_departure_reached and off_map and
+          not_done). Resolves the asymmetry above the same way (a) does: MALFUNCTION_OFF_MAP starts
+          reading action_required True once earliest_departure_reached, instead of being hardcoded False
+          for the entire malfunction, exactly like READY_TO_DEPART already does. Verified equivalent to
+          guarded (a) over every state-machine-reachable input (0 mismatches), but not as unconstrained
+          boolean formulas: of all 112 raw (state, in_malfunction, earliest_departure_reached, is_cell_exit,
+          on_map) combinations ignoring reachability, 24 disagree - every one of them an input the state
+          machine can never actually produce (e.g. WAITING with earliest_departure_reached=True while not
+          malfunctioning - synchronously transitions to READY_TO_DEPART the same step, per _handle_waiting,
+          so never externally observable; or an on-map state with a None position, which violates the
+          position/state sync invariant). (a) is the more defensive of the two here: its non-malfunctioning
+          branch is keyed directly to `state == READY_TO_DEPART` (an enum identity check), while (b) is
+          keyed to earliest_departure_reached/on_map (recomputed booleans) for every off-map state - if the
+          state machine's own synchronization were ever violated elsewhere (a bug, or a bypass like
+          `_set_state()`), (a) would stay correct while (b) could drift.
+        - (c) action_required = is_cell_exit if (on_map and not_done) else False.
+          Relative to today this only drops READY_TO_DEPART's unconditional True and fixes the DONE case
+          - it does not fix the MALFUNCTION/MALFUNCTION_OFF_MAP asymmetry (MALFUNCTION_OFF_MAP stays
+          hardcoded False, on-map MALFUNCTION stays exactly as is_cell_exit-quirky as today), but gives
+          action_required simpler on-map-only semantics (position and speed/distance only, ignoring
+          earliest_departure/malfunction/state entirely).
+        """
 
         current_state = self._state
 

--- a/tests/test_flatland_envs_persistence.py
+++ b/tests/test_flatland_envs_persistence.py
@@ -159,8 +159,8 @@ def test_legacy_envs():
     [
         ("env_data.tests.service_test.Test_0", "Level_0.pkl", -593),
         ("env_data.tests.service_test.Test_1", "Level_0.pkl", -593),
-        ("env_data.tests.service_test.Test_0", "Level_1.pkl", -561.0),
-        ("env_data.tests.service_test.Test_1", "Level_1.pkl", -561.0),
+        ("env_data.tests.service_test.Test_0", "Level_1.pkl", -555.0),
+        ("env_data.tests.service_test.Test_1", "Level_1.pkl", -555.0),
     ])
 def test_regression_forward(package, resource, expected):
     env, _ = RailEnvPersister.load_new(resource, load_from_package=package)

--- a/tests/test_flatland_envs_rail_env.py
+++ b/tests/test_flatland_envs_rail_env.py
@@ -22,6 +22,7 @@ from flatland.envs.predictions import ShortestPathPredictorForRailEnv
 from flatland.envs.rail_env import RailEnv, RailEnvActions
 from flatland.envs.rail_generators import rail_from_grid_transition_map
 from flatland.envs.rail_generators import sparse_rail_generator, rail_from_file
+from flatland.envs.rail_grid_transition_map import RailGridTransitionMap
 from flatland.envs.rewards import BaseDefaultRewards, DefaultPenalties
 from flatland.envs.step_utils.speed_counter import SpeedCounter, _cap_speed
 from flatland.envs.step_utils.states import TrainState
@@ -914,7 +915,11 @@ def test_earliest_departure_state_transitions_full_acceleration():
         assert agent.current_entry_point is None
         assert agent.speed_counter.speed is None
         assert agent.speed_counter.distance is None
-    assert env._elapsed_steps == 3  # _elapsed_steps +3 (3 WAITING steps)
+    # design (issue #280): earliest_departure_reached is signalled one step earlier than
+    # elapsed_steps itself reaches earliest_departure,
+    # agent goes to READY_TO_DEPART at the end of the step it reaches earliest_departure
+    # (e.g. when earliest_departure==0, agent is READY_TO_DEPART before the first step (where _elapsed_steps 0->1)
+    assert env._elapsed_steps == 2  # _elapsed_steps +2 (2 WAITING steps)
 
     # READY_TO_DEPART: still off map, waiting for a valid MOVE_FORWARD to actually depart.
     assert agent.state == TrainState.READY_TO_DEPART
@@ -923,7 +928,7 @@ def test_earliest_departure_state_transitions_full_acceleration():
     # READY_TO_DEPART -> MOVING: agent appears at its initial entry point this very step. Full
     # acceleration delta reaches max speed immediately (acceleration_delta equals max_speed here).
     env.step({agent.handle: RailEnvActions.MOVE_FORWARD})
-    assert env._elapsed_steps == 4  # _elapsed_steps +1
+    assert env._elapsed_steps == 3  # _elapsed_steps +1
     assert agent.state == TrainState.MOVING
     assert agent.current_entry_point == agent.initial_entry_point
     assert agent.speed_counter.speed == Fraction(1)
@@ -938,150 +943,121 @@ def test_earliest_departure_state_transitions_full_acceleration():
     # distance resetting to 0 cleanly (unlike a fractional acceleration delta, see
     # test_earliest_departure_state_transitions_initial_speed_zero's 1/2 cruise offset).
     env.step({agent.handle: RailEnvActions.MOVE_FORWARD})
-    assert env._elapsed_steps == 5  # _elapsed_steps +1
+    assert env._elapsed_steps == 4  # _elapsed_steps +1
     assert agent.state == TrainState.MOVING
     assert agent.current_entry_point == second_entry_point
     assert agent.speed_counter.speed == Fraction(1)
     assert agent.speed_counter.distance == Fraction(0)
 
     env.step({agent.handle: RailEnvActions.MOVE_FORWARD})
-    assert env._elapsed_steps == 6  # _elapsed_steps +1
+    assert env._elapsed_steps == 5  # _elapsed_steps +1
     assert agent.state == TrainState.MOVING
     assert agent.current_entry_point == third_entry_point
     assert agent.speed_counter.speed == Fraction(1)
     assert agent.speed_counter.distance == Fraction(0)
 
     env.step({agent.handle: RailEnvActions.MOVE_FORWARD})
-    assert env._elapsed_steps == 7  # _elapsed_steps +1
+    assert env._elapsed_steps == 6  # _elapsed_steps +1
     assert agent.state == TrainState.MOVING
     assert agent.current_entry_point == fourth_entry_point
     assert agent.speed_counter.speed == Fraction(1)
     assert agent.speed_counter.distance == Fraction(0)
 
 
-def test_map_entry_no_malfunction():
+@pytest.mark.parametrize("earliest_departure", [0, 1, 2, 5])
+@pytest.mark.parametrize("with_malfunction", [False, True], ids=["no_malfunction", "malfunction_off_map"])
+def test_map_entry(with_malfunction, earliest_departure):
     """
-    Single agent, no malfunction, earliest_departure=0, max speed 1, acceleration delta equal to
-    max speed. Same WAITING -> READY_TO_DEPART -> MOVING map entry as
-    test_earliest_departure_state_transitions_full_acceleration, but earliest_departure=0 means the
-    very first step already reaches READY_TO_DEPART, so no WAITING loop is needed.
+    Single agent, max speed 1, acceleration delta equal to max speed, earliest_departure parametrized
+    over 0/1/2/5. Parametrized over whether a malfunction is injected right as earliest_departure is
+    reached. Design (issue #280): both WAITING and MALFUNCTION_OFF_MAP go straight to MOVING on a
+    movement action once earliest_departure is reached, never observably visiting READY_TO_DEPART
+    first - see _handle_malfunction_off_map's docstring and rail_env.py's step() first-step
+    earliest_departure=0 tweak. Apart from the malfunction variant's extra delay, the two variants'
+    assertions are identical from the departure step onward.
 
-    - Setup: agent off map, speed and distance both None.
-    - Step 1 (elapsed_steps=1 >= earliest_departure=0): WAITING -> READY_TO_DEPART, still off map,
-      speed and distance still None.
-    - Step 2 (MOVE_FORWARD): map entry - position becomes the agent's initial entry point, state ->
-      MOVING, distance resets to 0, speed reaches max speed immediately.
-    - Step 3 (MOVE_FORWARD): already at max speed, so the agent crosses into the next entry point,
-      distance wraps back to 0 completing the crossing, speed stays at max speed.
-    """
-    env, _, _ = env_generator(seed=42, n_agents=1)
-    env.acceleration_delta = Fraction(1)
-    agent = env.agents[0]
-    agent.speed_counter = SpeedCounter(max_speed=Fraction(1))
-    agent.earliest_departure = 0
-
-    assert agent.state == TrainState.WAITING
-    assert agent.current_entry_point is None
-    assert agent.speed_counter.speed is None
-    assert agent.speed_counter.distance is None
-
-    env.step({agent.handle: RailEnvActions.MOVE_FORWARD})
-    assert env._elapsed_steps == 1
-    assert agent.state == TrainState.READY_TO_DEPART
-    assert agent.current_entry_point is None
-    assert agent.speed_counter.speed is None
-    assert agent.speed_counter.distance is None
-
-
-    env.step({agent.handle: RailEnvActions.MOVE_FORWARD})
-    # on-map after step 2, although elapased_steps says 0! TODO #280 revise design twirk: agent enters map only at earliest_depature+1 (in step earliest_departure + 1 + 1).
-    assert env._elapsed_steps == 2
-    assert agent.state == TrainState.MOVING
-    first_entry_point = agent.current_entry_point
-    assert first_entry_point == agent.initial_entry_point
-    assert agent.speed_counter.speed == Fraction(1)
-    assert agent.speed_counter.distance == Fraction(0)
-
-    second_entry_point = env.rail.apply_action_independent(RailEnvActions.MOVE_FORWARD, first_entry_point)
-    env.step({agent.handle: RailEnvActions.MOVE_FORWARD})
-    assert env._elapsed_steps == 3
-    assert agent.state == TrainState.MOVING
-    assert agent.current_entry_point == second_entry_point
-    assert agent.speed_counter.speed == Fraction(1)
-    assert agent.speed_counter.distance == Fraction(0)
-
-
-def test_map_entry_with_malfunction():
-    """
-    Same setup as test_map_entry_no_malfunction (earliest_departure=0, max speed 1, acceleration
-    delta equal to max speed), but with a malfunction injected before the agent ever reaches
-    READY_TO_DEPART: malfunction_down_counter starts at 3. The state machine decrements it on the
-    same step it reads in_malfunction (see TrainStateMachine's handlers), so it is observed True for
-    2 steps and reaches 0 on the 3rd. MOVE_FORWARD is given from the very first step, so on that 3rd
-    step the agent enters the map directly from MALFUNCTION_OFF_MAP, never visiting READY_TO_DEPART
-    (design quirk tracked as issue #280: MALFUNCTION_OFF_MAP goes straight to MOVING on a movement
-    action once earliest_departure is reached and the malfunction has just ended, rather than via
-    READY_TO_DEPART - see _handle_malfunction_off_map's docstring).
-
-    - Setup: agent off map, WAITING, malfunction_down_counter set to 3. malfunction_interval=0
-      disables env_generator's own random malfunction generation, so only this injected malfunction
-      is in play.
-    - Step 1 (elapsed_steps=1 >= earliest_departure=0, but in_malfunction after this step's
-      decrement): WAITING -> MALFUNCTION_OFF_MAP, still off map, speed/distance None,
+    - Setup: agent off map, WAITING, speed and distance both None. Stepped earliest_departure times
+      with DO_NOTHING first - this withholds the movement action so the agent cannot depart yet, but
+      still lets the earliest_departure-driven WAITING -> READY_TO_DEPART transition happen on
+      schedule, landing the agent exactly at the point earliest_departure is considered reached: for
+      earliest_departure == 0 this is zero steps (still WAITING, _elapsed_steps == 0); for
+      earliest_departure >= 1 the agent is already READY_TO_DEPART after those steps, at
+      _elapsed_steps == earliest_departure (the earliest_departure_reached signal fires one step ahead
+      of when it becomes externally visible, so earliest_departure 1 and 2 both resolve to
+      READY_TO_DEPART already by _elapsed_steps == 1 - see state_machine.py's step() docstring).
+    - With malfunction: malfunction_down_counter is set to 3 right at this point (malfunction_interval=0
+      disables env_generator's own random malfunction generation, so only this injected malfunction is
+      in play) - i.e. triggered exactly as earliest_departure is reached, not before. The state machine
+      decrements the counter on the same step it reads in_malfunction, so it is observed True for 2
+      steps and reaches 0 on the 3rd, from whichever state (WAITING or READY_TO_DEPART) the agent was
+      in at injection time.
+    - [malfunction only] First MOVE_FORWARD step after injection (in_malfunction after this step's
+      decrement): WAITING or READY_TO_DEPART -> MALFUNCTION_OFF_MAP, still off map,
       malfunction_down_counter == 2.
-    - Step 2 (still in_malfunction): stays MALFUNCTION_OFF_MAP, still off map,
-      malfunction_down_counter == 1.
-    - Step 3 (malfunction_down_counter decrements to 0, in_malfunction False, earliest_departure
-      already reached, MOVE_FORWARD given): map entry directly from MALFUNCTION_OFF_MAP - position
-      becomes the agent's initial entry point, state -> MOVING, distance resets to 0, speed reaches
-      max speed immediately, malfunction_down_counter == 0.
-    - Step 4: already at max speed, so the agent crosses into the next entry point, distance wraps
-      back to 0 completing the crossing, speed stays at max speed.
+    - [malfunction only] Second MOVE_FORWARD step (still in_malfunction): stays MALFUNCTION_OFF_MAP,
+      still off map, malfunction_down_counter == 1.
+    - Departure step (MOVE_FORWARD; the 1st post-injection step without malfunction, the 3rd with): map
+      entry directly into MOVING - position becomes the agent's initial entry point, distance resets to
+      0, speed reaches max speed immediately (with malfunction: malfunction_down_counter == 0). This
+      lands at _elapsed_steps == earliest_departure + 1 without malfunction, or
+      earliest_departure + 3 with malfunction (the 3-step malfunction length contributing 2 extra steps
+      beyond the no-malfunction departure step).
+    - Final step (MOVE_FORWARD): already at max speed, so the agent crosses into the next entry
+      point, distance wraps back to 0 completing the crossing, speed stays at max speed.
     """
     env, _, _ = env_generator(seed=42, n_agents=1, malfunction_interval=0)
     env.acceleration_delta = Fraction(1)
     agent = env.agents[0]
     agent.speed_counter = SpeedCounter(max_speed=Fraction(1))
-    agent.earliest_departure = 0
-    agent.malfunction_handler._set_malfunction_down_counter(3)
+    agent.earliest_departure = earliest_departure
 
     assert agent.state == TrainState.WAITING
     assert agent.current_entry_point is None
     assert agent.speed_counter.speed is None
     assert agent.speed_counter.distance is None
-    # 2 malfunction steps, but make it 2+1 as decremented at start of step(), right after malfunction generators are called.
-    assert agent.malfunction_handler.malfunction_down_counter == 3
 
-    env.step({agent.handle: RailEnvActions.MOVE_FORWARD})
-    assert env._elapsed_steps == 1
-    assert agent.state == TrainState.MALFUNCTION_OFF_MAP
+    for _ in range(earliest_departure):
+        env.step({agent.handle: RailEnvActions.DO_NOTHING})
+    assert env._elapsed_steps == earliest_departure  # N
+    assert agent.state == (TrainState.WAITING if earliest_departure == 0 else TrainState.READY_TO_DEPART)
     assert agent.current_entry_point is None
     assert agent.speed_counter.speed is None
     assert agent.speed_counter.distance is None
-    assert agent.malfunction_handler.malfunction_down_counter == 2
+
+    MALFUNCTION_DURATION = 0
+    if with_malfunction:
+        MALFUNCTION_DURATION = 2  # M
+        agent.malfunction_handler._set_malfunction_down_counter(MALFUNCTION_DURATION + 1)  # as decrement in step after malfunction generator runs!
+
+        env.step({agent.handle: RailEnvActions.MOVE_FORWARD})
+        assert env._elapsed_steps == earliest_departure + 1
+        assert agent.state == TrainState.MALFUNCTION_OFF_MAP
+        assert agent.current_entry_point is None
+        assert agent.speed_counter.speed is None
+        assert agent.speed_counter.distance is None
+        assert agent.malfunction_handler.malfunction_down_counter == 2
+
+        env.step({agent.handle: RailEnvActions.MOVE_FORWARD})
+        assert env._elapsed_steps == earliest_departure + 2
+        assert agent.state == TrainState.MALFUNCTION_OFF_MAP
+        assert agent.current_entry_point is None
+        assert agent.speed_counter.speed is None
+        assert agent.speed_counter.distance is None
+        assert agent.malfunction_handler.malfunction_down_counter == 1
 
     env.step({agent.handle: RailEnvActions.MOVE_FORWARD})
-    assert env._elapsed_steps == 2
-    assert agent.state == TrainState.MALFUNCTION_OFF_MAP
-    assert agent.current_entry_point is None
-    assert agent.speed_counter.speed is None
-    assert agent.speed_counter.distance is None
-    assert agent.malfunction_handler.malfunction_down_counter == 1
-
-    # malfunction terminates at start of this next step()
-    # on-map after step 3, although 2 malfunction steps, not at 2+2 (2 as without malfunction + 2 malfunction steps), highlighting  TODO #280 revise design twirk: #280 WAITING bypass with malfunction_off_map
-    env.step({agent.handle: RailEnvActions.MOVE_FORWARD})
-    assert env._elapsed_steps == 3
+    assert env._elapsed_steps == earliest_departure + 1 + MALFUNCTION_DURATION  # w/o malfunction: N+1 / w malfunction (N+1) + M
     assert agent.state == TrainState.MOVING
     first_entry_point = agent.current_entry_point
     assert first_entry_point == agent.initial_entry_point
     assert agent.speed_counter.speed == Fraction(1)
     assert agent.speed_counter.distance == Fraction(0)
-    assert agent.malfunction_handler.malfunction_down_counter == 0
+    if with_malfunction:
+        assert agent.malfunction_handler.malfunction_down_counter == 0
 
     second_entry_point = env.rail.apply_action_independent(RailEnvActions.MOVE_FORWARD, first_entry_point)
     env.step({agent.handle: RailEnvActions.MOVE_FORWARD})
-    assert env._elapsed_steps == 4
+    assert env._elapsed_steps == earliest_departure + (4 if with_malfunction else 2)
     assert agent.state == TrainState.MOVING
     assert agent.current_entry_point == second_entry_point
     assert agent.speed_counter.speed == Fraction(1)
@@ -1107,7 +1083,11 @@ def test_earliest_departure_state_transitions_partial_acceleration():
         assert agent.current_entry_point is None
         assert agent.speed_counter.speed is None
         assert agent.speed_counter.distance is None
-    assert env._elapsed_steps == 3  # _elapsed_steps +3 (3 WAITING steps)
+    # design (issue #280): earliest_departure_reached is signalled one step earlier than
+    # elapsed_steps itself reaches earliest_departure,
+    # agent goes to READY_TO_DEPART at the end of the step it reaches earliest_departure
+    # (e.g. when earliest_departure==0, agent is READY_TO_DEPART before the first step (where _elapsed_steps 0->1)
+    assert env._elapsed_steps == 2  # _elapsed_steps +2 (2 WAITING steps)
 
     # READY_TO_DEPART: still off map, waiting for a valid MOVE_FORWARD to actually depart.
     assert agent.state == TrainState.READY_TO_DEPART
@@ -1116,7 +1096,7 @@ def test_earliest_departure_state_transitions_partial_acceleration():
     # READY_TO_DEPART -> MOVING: agent appears at its initial entry point this very step, distance
     # resets to 0 and speed reaches the acceleration delta immediately.
     env.step({agent.handle: RailEnvActions.MOVE_FORWARD})
-    assert env._elapsed_steps == 4  # _elapsed_steps +1
+    assert env._elapsed_steps == 3  # _elapsed_steps +1
     assert agent.state == TrainState.MOVING
     assert agent.current_entry_point == agent.initial_entry_point
     assert agent.speed_counter.speed == Fraction(3, 10)
@@ -1130,14 +1110,14 @@ def test_earliest_departure_state_transitions_partial_acceleration():
     # design: distance update with pre-step speed. Ramping 0.3 -> 0.6 -> 0.9, distance
     # accumulating the pre-step speed each time, staying in the initial entry point throughout.
     env.step({agent.handle: RailEnvActions.MOVE_FORWARD})
-    assert env._elapsed_steps == 5  # _elapsed_steps +1
+    assert env._elapsed_steps == 4  # _elapsed_steps +1
     assert agent.state == TrainState.MOVING
     assert agent.current_entry_point == first_entry_point
     assert agent.speed_counter.speed == Fraction(6, 10)
     assert agent.speed_counter.distance == Fraction(3, 10)
 
     env.step({agent.handle: RailEnvActions.MOVE_FORWARD})
-    assert env._elapsed_steps == 6  # _elapsed_steps +1
+    assert env._elapsed_steps == 5  # _elapsed_steps +1
     assert agent.state == TrainState.MOVING
     assert agent.current_entry_point == first_entry_point
     assert agent.speed_counter.speed == Fraction(9, 10)
@@ -1146,7 +1126,7 @@ def test_earliest_departure_state_transitions_partial_acceleration():
     # distance(0.9) + speed(0.9) = 1.8 >= 1: crosses into the second entry point, wraps to 0.8, and
     # speed finally saturates at max speed (0.9 + 0.3 capped at 1).
     env.step({agent.handle: RailEnvActions.MOVE_FORWARD})
-    assert env._elapsed_steps == 7  # _elapsed_steps +1
+    assert env._elapsed_steps == 6  # _elapsed_steps +1
     assert agent.state == TrainState.MOVING
     assert agent.current_entry_point == second_entry_point
     assert agent.speed_counter.speed == Fraction(1)
@@ -1155,14 +1135,14 @@ def test_earliest_departure_state_transitions_partial_acceleration():
     # At max speed, the agent advances exactly one entry point per step from here on, cruising at
     # a steady 0.8 offset (0.8 + 1 = 1.8, wraps to 0.8 again).
     env.step({agent.handle: RailEnvActions.MOVE_FORWARD})
-    assert env._elapsed_steps == 8  # _elapsed_steps +1
+    assert env._elapsed_steps == 7  # _elapsed_steps +1
     assert agent.state == TrainState.MOVING
     assert agent.current_entry_point == third_entry_point
     assert agent.speed_counter.speed == Fraction(1)
     assert agent.speed_counter.distance == Fraction(8, 10)
 
     env.step({agent.handle: RailEnvActions.MOVE_FORWARD})
-    assert env._elapsed_steps == 9  # _elapsed_steps +1
+    assert env._elapsed_steps == 8  # _elapsed_steps +1
     assert agent.state == TrainState.MOVING
     assert agent.current_entry_point == fourth_entry_point
     assert agent.speed_counter.speed == Fraction(1)
@@ -1241,6 +1221,175 @@ def test_malfunction_off_map_state_transitions_to_moving():
     assert agent.current_entry_point == fourth_entry_point
     assert agent.speed_counter.speed == Fraction(1)
     assert agent.speed_counter.distance == Fraction(1, 2)
+
+
+def test_action_required_false_during_malfunction():
+    """
+    Single agent, max speed 1/2, acceleration delta equal to max speed, earliest_departure=0. Design:
+    info['action_required'] (RailEnv.action_required()) is False for a malfunctioning agent, both off
+    map (MALFUNCTION_OFF_MAP) and on map (MALFUNCTION) - contrasted here against the same agent's
+    action_required alternating True/False while genuinely MOVING, to show the malfunction periods
+    aren't just incidentally False for some unrelated reason (e.g. always being mid-cell).
+
+    - Setup: malfunction_down_counter=3 injected before the very first step - the agent malfunctions
+      off map before it ever gets a chance to depart.
+    - Steps 1-2 (MOVE_FORWARD, in_malfunction): MALFUNCTION_OFF_MAP, still off map, action_required False.
+    - Step 3 (malfunction clears): dispatches straight into MOVING at distance 0 - at half max speed,
+      distance 0 does not yet reach the cell boundary, so action_required is False here too (not yet
+      due to malfunction - genuinely not at a cell exit).
+    - Step 4 (MOVE_FORWARD): distance reaches 1/2, the cell boundary - action_required True, contrasting
+      with the malfunction periods above and below.
+    - A second malfunction (down_counter=3) is injected right at this boundary (distance 1/2).
+    - Steps 5-6 (MOVE_FORWARD, in_malfunction): MALFUNCTION, distance frozen at 1/2 with speed forced to
+      0 - is_cell_exit() no longer holds (1/2 + 0 < 1), so action_required is False throughout, even
+      though the agent was sitting exactly at the boundary the instant the malfunction hit.
+    - Step 7 (malfunction clears): resumes MOVING from the frozen distance 1/2 at half speed again -
+      distance + speed reaches the boundary again this same step, action_required True.
+    - Step 8 (MOVE_FORWARD): crosses into the next cell, distance wraps to 0, action_required False again.
+    """
+    env, _, _ = env_generator(seed=42, n_agents=1, malfunction_interval=0)
+    env.acceleration_delta = Fraction(1)
+    agent = env.agents[0]
+    agent.speed_counter = SpeedCounter(max_speed=Fraction(1, 2))
+    agent.earliest_departure = 0
+    agent.malfunction_handler._set_malfunction_down_counter(3)
+
+    _, _, _, info = env.step({agent.handle: RailEnvActions.MOVE_FORWARD})
+    assert agent.state == TrainState.MALFUNCTION_OFF_MAP
+    assert info['action_required'][agent.handle] is False
+
+    _, _, _, info = env.step({agent.handle: RailEnvActions.MOVE_FORWARD})
+    assert agent.state == TrainState.MALFUNCTION_OFF_MAP
+    assert info['action_required'][agent.handle] is False
+
+    _, _, _, info = env.step({agent.handle: RailEnvActions.MOVE_FORWARD})
+    assert agent.state == TrainState.MOVING
+    assert agent.speed_counter.distance == Fraction(0)
+    assert agent.speed_counter.is_cell_exit() is False
+    assert info['action_required'][agent.handle] is False
+
+    _, _, _, info = env.step({agent.handle: RailEnvActions.MOVE_FORWARD})
+    assert agent.state == TrainState.MOVING
+    assert agent.speed_counter.distance == Fraction(1, 2)
+    assert agent.speed_counter.is_cell_exit() is True
+    assert info['action_required'][agent.handle] is True
+
+    agent.malfunction_handler._set_malfunction_down_counter(3)
+
+    _, _, _, info = env.step({agent.handle: RailEnvActions.MOVE_FORWARD})
+    assert agent.state == TrainState.MALFUNCTION
+    assert agent.speed_counter.distance == Fraction(1, 2)
+    assert agent.speed_counter.speed == 0
+    assert agent.speed_counter.is_cell_exit() is False
+    assert info['action_required'][agent.handle] is False
+
+    _, _, _, info = env.step({agent.handle: RailEnvActions.MOVE_FORWARD})
+    assert agent.state == TrainState.MALFUNCTION
+    assert agent.speed_counter.is_cell_exit() is False
+    assert info['action_required'][agent.handle] is False
+
+    _, _, _, info = env.step({agent.handle: RailEnvActions.MOVE_FORWARD})
+    assert agent.state == TrainState.MOVING
+    assert agent.speed_counter.distance == Fraction(1, 2)
+    assert agent.speed_counter.is_cell_exit() is True
+    assert info['action_required'][agent.handle] is True
+
+    _, _, _, info = env.step({agent.handle: RailEnvActions.MOVE_FORWARD})
+    assert agent.state == TrainState.MOVING
+    assert agent.speed_counter.distance == Fraction(0)
+    assert info['action_required'][agent.handle] is False
+
+
+@pytest.mark.parametrize("with_malfunction", [False, True], ids=["stopped_only", "malfunction_while_stopped"])
+def test_action_required_at_full_segment_length(with_malfunction):
+    """
+    Single agent departs at (2,3) heading WEST towards a symmetric switch at (2,1) whose only valid
+    exits are north/south - continuing MOVE_FORWARD (straight through) is invalid there, so the agent
+    is force-stopped one cell short, banked exactly at the (2,2) cell boundary: distance ==
+    SEGMENT_LENGTH (1), speed == 0. Design: for an on-map state, info['action_required'] depends purely
+    on SpeedCounter.is_cell_exit() (distance + speed >= SEGMENT_LENGTH), not on which on-map state
+    (MOVING/STOPPED/MALFUNCTION) the agent is actually in - distance alone already satisfies that
+    threshold here, so action_required reads True even at speed 0, and stays True whether or not the
+    agent also happens to be malfunctioning at that same banked position - contradicting a naive
+    "malfunctioning agents never need an action" assumption.
+
+    Layout (train departs at (2,3) heading WEST, rolls towards the symmetric switch at (2,1) whose only
+    valid exits are north and south -- continuing west is invalid):
+
+        (0,1) dead-end
+              |
+        (2,1) switch <- (2,2) <- (2,3) start
+              |
+        (4,1) dead-end
+
+    - Steps 1-2 (MOVE_FORWARD): departs and crosses one full cell at max speed - MOVING, is_cell_exit
+      True every step (a fresh cell's full speed always reaches the boundary the same step),
+      action_required True.
+    - Step 3 (MOVE_FORWARD, invalid at the symmetric switch): force-stopped at the (2,2) boundary - STOPPED,
+      distance == 1, speed == 0, is_cell_exit still True purely from distance, action_required True.
+    - [malfunction_while_stopped only] malfunction_down_counter=3 injected right at this banked
+      position; steps 4-5 (still MOVE_FORWARD, in_malfunction): MALFUNCTION, distance/speed unchanged,
+      is_cell_exit and action_required both remain True.
+    - Final step (MOVE_FORWARD): [malfunction_while_stopped] malfunction clears back to STOPPED (the
+      action is still invalid at the switch); [stopped_only] still STOPPED as before either way -
+      distance/speed unchanged, is_cell_exit and action_required remain True throughout.
+    """
+    transitions = RailEnvTransitions()
+    grid = np.zeros((5, 6), dtype=np.uint16)
+    grid[2, 1] = RailEnvTransitionsEnum.symmetric_switch_from_east  # heading west forks N/S
+    grid[2, 2] = RailEnvTransitionsEnum.horizontal_straight
+    grid[2, 3] = RailEnvTransitionsEnum.horizontal_straight
+    grid[2, 4] = RailEnvTransitionsEnum.dead_end_from_east
+    grid[1, 1] = RailEnvTransitionsEnum.vertical_straight
+    grid[0, 1] = RailEnvTransitionsEnum.dead_end_from_north
+    grid[3, 1] = RailEnvTransitionsEnum.vertical_straight
+    grid[4, 1] = RailEnvTransitionsEnum.dead_end_from_south
+
+    rail = RailGridTransitionMap(width=6, height=5, transitions=transitions)
+    rail.grid = grid
+    optionals = {'agents_hints': {'city_positions': [(2, 4), (0, 1)],
+                                  'train_stations': [[((2, 4), 0)], [((0, 1), 0)]],
+                                  'city_orientations': [3, 0]}}
+    env = RailEnv(width=6, height=5,
+                  rail_generator=rail_from_grid_transition_map(rail, optionals),
+                  line_generator=sparse_line_generator(), number_of_agents=1)
+    env.reset(random_seed=42)
+    env._max_episode_steps = 100
+
+    agent = env.agents[0]
+    agent.initial_entry_point = ((2, 3), Grid4TransitionsEnum.WEST)
+    agent.current_entry_point = None
+    agent.earliest_departure = 0
+    agent.latest_arrival = 50
+    agent.targets = {((0, 1), d) for d in Grid4TransitionsEnum}
+
+    for _ in range(2):
+        _, _, _, info = env.step({agent.handle: RailEnvActions.MOVE_FORWARD})
+        assert agent.state == TrainState.MOVING
+        assert agent.speed_counter.is_cell_exit() is True
+        assert info['action_required'][agent.handle] is True
+
+    _, _, _, info = env.step({agent.handle: RailEnvActions.MOVE_FORWARD})
+    assert agent.state == TrainState.STOPPED
+    assert agent.speed_counter.distance == Fraction(1)
+    assert agent.speed_counter.speed == 0
+    assert agent.speed_counter.is_cell_exit() is True
+    assert info['action_required'][agent.handle] is True
+
+    if with_malfunction:
+        agent.malfunction_handler._set_malfunction_down_counter(3)
+        for _ in range(2):
+            _, _, _, info = env.step({agent.handle: RailEnvActions.MOVE_FORWARD})
+            assert agent.state == TrainState.MALFUNCTION
+            assert agent.speed_counter.distance == Fraction(1)
+            assert agent.speed_counter.is_cell_exit() is True
+            assert info['action_required'][agent.handle] is True
+
+    _, _, _, info = env.step({agent.handle: RailEnvActions.MOVE_FORWARD})
+    assert agent.state == TrainState.STOPPED
+    assert agent.speed_counter.distance == Fraction(1)
+    assert agent.speed_counter.is_cell_exit() is True
+    assert info['action_required'][agent.handle] is True
 
 
 def test_malfunction_off_map_state_transitions_to_ready_to_depart():
@@ -1529,8 +1678,11 @@ def test_agent_blocked_at_boundary_cannot_accelerate_nor_advance_into_stopped_ne
     R = ((3, 7), Grid4TransitionsEnum.WEST)
     agent_a.initial_entry_point = L
     agent_b.initial_entry_point = R
-    agent_a.earliest_departure = 0
-    agent_b.earliest_departure = 0
+    # design (issue #280): earliest_departure=1, not 0 - an earliest_departure=0 agent now dispatches
+    # directly on the very first movement action (see rail_env.py's step()), which would make the "two
+    # steps of MOVE_FORWARD to get onto the map" below only one; =1 keeps the original timing.
+    agent_a.earliest_departure = 1
+    agent_b.earliest_departure = 1
     # B's own max speed is lower than A's (still off map, so only _max_speed needs overriding - see
     # test_blocked_agent_cannot_redirect_via_later_action for why _speed must stay None here): this
     # keeps it mid-cell (distance < 1) rather than already at the cell boundary when it is braked
@@ -1846,7 +1998,7 @@ def test_platoon_of_four_agents_starting_mid_cell_moves_in_lockstep_without_forc
     (Fraction(1), [(Fraction(0), 1), (Fraction(0), 2)], 3, [Fraction(0)], Fraction(0)),
 ], ids=["speed-0.2", "speed-0.5", "speed-1.0"])
 def test_platoon_all_stop_together_once_leader_stops_and_stays_stopped(
-        max_speed, lockstep_steps, after_stop_offset, post_stop_distances, leader_distance):
+    max_speed, lockstep_steps, after_stop_offset, post_stop_distances, leader_distance):
     """
     Four agents A, B, C, D nose-to-tail on four consecutive cells C1, C2, C3, C4 of make_simple_rail's
     row-3 corridor, all heading the same direction, cruising together at a shared max speed (0.2, 0.5 or

--- a/tests/test_flatland_states_edge_cases.py
+++ b/tests/test_flatland_states_edge_cases.py
@@ -8,6 +8,7 @@ from flatland.envs.line_generators import sparse_line_generator
 from flatland.envs.malfunction_generators import malfunction_from_params, MalfunctionParameters
 from flatland.envs.rail_env import RailEnv, RailEnvActions
 from flatland.envs.rail_generators import rail_from_grid_transition_map
+from flatland.envs.rewards import DefaultRewards
 from flatland.envs.step_utils.states import TrainState
 from flatland.utils.simple_rail import make_simple_rail
 
@@ -115,11 +116,14 @@ def test_malfunction_no_phase_through():
 
     env.agents[1].malfunction_handler._set_malfunction_down_counter(10)
 
-    for _ in range(3):
+    # design (issue #280): both agents depart one step earlier than before (default earliest_departure=0
+    # for this seed), so agent 0 is one cell further along by the time it catches up to agent 1 - one more
+    # step is needed here to land on the same STOPPED-behind-a-malfunctioning-train outcome.
+    for _ in range(4):
         env.step({0: RailEnvActions.MOVE_FORWARD, 1: RailEnvActions.DO_NOTHING})
 
     assert env.agents[0].state == TrainState.STOPPED
-    assert env.agents[0].current_entry_point[0] == (3, 5)
+    assert env.agents[0].current_entry_point[0] == (3, 6)
 
 
 def test_malfunction_off_map_not_on_map_with_stop_action_after_malfunction():
@@ -145,11 +149,14 @@ def test_malfunction_off_map_not_on_map_with_stop_action_after_malfunction():
 
     env.agents[0].initial_entry_point = ((6, 6), Grid4TransitionsEnum.SOUTH)
     env.agents[0].targets = {((0, 3), d) for d in Grid4TransitionsEnum}
-    env.agents[0].earliest_departure = 0
+    # design (issue #280): earliest_departure=1, not 0 - an earliest_departure=0 agent now dispatches
+    # directly on the very first movement action (see rail_env.py's step()), which isn't the point of
+    # this test; =1 keeps the original two-real-steps-to-depart timing this test relies on.
+    env.agents[0].earliest_departure = 1
 
     env.agents[1].initial_entry_point = ((6, 6), Grid4TransitionsEnum.SOUTH)
     env.agents[1].targets = {((0, 3), d) for d in Grid4TransitionsEnum}
-    env.agents[1].earliest_departure = 0
+    env.agents[1].earliest_departure = 1
     # design: malfunction counter decremented at start of step(), before new malfunctions are generated -
     # injected duration bumped by 1 so the state sequence below is unaffected (only the malfunction countdown
     # values shift by 1 while the malfunction is active)
@@ -192,6 +199,11 @@ def test_malfunction_off_map_not_on_map_with_stop_action_after_malfunction():
 def test_malfunction_motion_check_order_when_earliest_departure_is_not_reached():
     """
     Avoid adding agent to motion check as it can hinder other agents having earliest_departure_reached to start.
+
+    Two agents share initial entry point (6, 6). Agent 0 has earliest_departure=55 (far off) and starts
+    malfunctioning off map; agent 1 has earliest_departure=0. Design (issue #280): agent 0 is never
+    registered in the motion check while off map and ineligible to depart, so it can't block agent 1 from
+    dispatching on agent 1's very first step, regardless of which agent has the lower index.
     """
     stochastic_data = MalfunctionParameters(malfunction_rate=0,  # Rate of malfunction occurence
                                             min_duration=0,  # Minimal duration of malfunction
@@ -220,7 +232,9 @@ def test_malfunction_motion_check_order_when_earliest_departure_is_not_reached()
 
     env.agents[1].initial_entry_point = ((6, 6), Grid4TransitionsEnum.SOUTH)
     env.agents[1].targets = {((0, 3), d) for d in Grid4TransitionsEnum}
-    env.agents[1].earliest_departure = 2
+    # design (issue #280): earliest_departure=0 - agent 1 now dispatches straight into MOVING on its own
+    # very first step, collapsing what used to be a 3-step scenario into a single step.
+    env.agents[1].earliest_departure = 0
 
     # step 1
     env.step({0: RailEnvActions.MOVE_FORWARD, 1: RailEnvActions.MOVE_FORWARD})
@@ -228,36 +242,18 @@ def test_malfunction_motion_check_order_when_earliest_departure_is_not_reached()
     assert env.agents[0].current_entry_point is None
     assert env.agents[0].state == TrainState.MALFUNCTION_OFF_MAP
     assert env.agents[0].malfunction_handler.malfunction_down_counter == 1
-
-    assert env.agents[1].current_entry_point is None
-    assert env.agents[1].state == TrainState.WAITING
-
-    # step 2
-    env.step({0: RailEnvActions.MOVE_FORWARD, 1: RailEnvActions.MOVE_FORWARD})
-
-    assert env.agents[0].current_entry_point is None
-    assert env.agents[0].state == TrainState.WAITING
-    # this is the root cause: the motion check for agent 0 returns OK, the action preprocessing converts to DO_NOTHING only in state WAITING, but not MALFUNCTION_OFF_MAP
-    assert env.agents[1].current_entry_point is None
-    assert env.agents[1].state == TrainState.READY_TO_DEPART
-
-    # step 3
-    env.step({0: RailEnvActions.MOVE_FORWARD, 1: RailEnvActions.MOVE_FORWARD})
-    assert env.agents[0].current_entry_point is None
-    assert env.agents[0].state == TrainState.WAITING
-
-    # / TEMPORARY FIX as adding agent to motion check can hinder other agents having earliest_departure_reached to start
-    # WITHOUT FIX: both agents are inserted into motion check, and the one with lower index wins:
-    # - agent 0 with the lower index wins, despite not having reached earliest departure
-    # - agent 1 is blocked, despite having reached earliest departure
     assert env.agents[1].current_entry_point[0] == (6, 6)
     assert env.agents[1].state == TrainState.MOVING
-    # \ TEMPORARY FIX
 
 
 def test_malfunction_motion_check_order_when_earliest_departure_reached_but_not_moving_action():
     """
     Avoid adding agent to motion check as it can hinder other agents having earliest_departure_reached to start.
+
+    Two agents share initial entry point (6, 6). Agent 0 has earliest_departure=3 and starts malfunctioning
+    off map; agent 1 has earliest_departure=0. Design (issue #280): agent 1 dispatches into MOVING on the
+    step it finally sends MOVE_FORWARD, unblocked by agent 0 sitting at the same entry point in
+    READY_TO_DEPART/MALFUNCTION_OFF_MAP with a movement action of its own pending.
     """
     stochastic_data = MalfunctionParameters(malfunction_rate=0,  # Rate of malfunction occurence
                                             min_duration=0,  # Minimal duration of malfunction
@@ -286,39 +282,199 @@ def test_malfunction_motion_check_order_when_earliest_departure_reached_but_not_
 
     env.agents[1].initial_entry_point = ((6, 6), Grid4TransitionsEnum.SOUTH)
     env.agents[1].targets = {((0, 3), d) for d in Grid4TransitionsEnum}
-    env.agents[1].earliest_departure = 2
+    # design (issue #280): earliest_departure=0 - agent 1 is READY_TO_DEPART already on its own first step
+    # (DO_NOTHING here, so it doesn't yet dispatch), collapsing what used to be a 3-step scenario into 2.
+    env.agents[1].earliest_departure = 0
 
     # step 1
-    env.step({0: RailEnvActions.MOVE_FORWARD, 1: RailEnvActions.MOVE_FORWARD})
+    env.step({0: RailEnvActions.MOVE_FORWARD, 1: RailEnvActions.DO_NOTHING})
 
     assert env.agents[0].current_entry_point is None
     assert env.agents[0].state == TrainState.MALFUNCTION_OFF_MAP
     assert env.agents[0].malfunction_handler.malfunction_down_counter == 1
 
     assert env.agents[1].current_entry_point is None
-    assert env.agents[1].state == TrainState.WAITING
-
-    # step 2
-    env.step({0: RailEnvActions.MOVE_FORWARD, 1: RailEnvActions.MOVE_FORWARD})
-
-    assert env.agents[0].current_entry_point is None
-    assert env.agents[0].state == TrainState.WAITING
-    # this is the root cause: the motion check for agent 0 returns OK, the action preprocessing converts to DO_NOTHING only in state WAITING, but not MALFUNCTION_OFF_MAP
-    assert env.agents[1].current_entry_point is None
     assert env.agents[1].state == TrainState.READY_TO_DEPART
 
-    # step 3
+    # step 2
     env.step({0: RailEnvActions.DO_NOTHING, 1: RailEnvActions.MOVE_FORWARD})
     assert env.agents[0].current_entry_point is None
     assert env.agents[0].state == TrainState.READY_TO_DEPART
+    assert env.agents[0].malfunction_handler.malfunction_down_counter == 0
 
-    # / TEMPORARY FIX as adding agent to motion check can hinder other agents having earliest_departure_reached to start
-    # WITHOUT FIX:
-    # - agent 0 with the lower index wins, despite sending DO_NOTHING
-    # - agent 1 is blocked, despite having reached earliest departure
     assert env.agents[1].current_entry_point[0] == (6, 6)
     assert env.agents[1].state == TrainState.MOVING
-    # \ TEMPORARY FIX
+
+
+@pytest.mark.parametrize("malfunctioning", ["none", "agent_0", "agent_1", "both"])
+def test_same_cell_same_earliest_departure_dispatch_conflict(malfunctioning):
+    """
+    Two agents share both initial entry point (6, 6) and earliest_departure=2. Design: when both are
+    simultaneously eligible to depart into the same cell, the motion check resolves the conflict by
+    agent index - agent 0 wins regardless of the tie being genuinely symmetric (unlike the
+    motion-check-order tests above, where a lower-index agent winning is the bug being guarded against,
+    here both agents are equally eligible, so index order is the actual, intended tie-break). The loser
+    incurs no collision penalty: the collision penalty (see BaseDefaultRewards.step_reward) only fires
+    on a MOVING -> STOPPED demotion, and a denied READY_TO_DEPART agent never was MOVING to begin with.
+
+    Parametrized over which agent(s) malfunction right at the departure step: a malfunctioning agent is
+    excluded from the motion check entirely (see rail_env.py's (3b.2), which takes priority over (3b.3)'s
+    map-entry branch), so it can never block the other agent - whichever agent does NOT malfunction
+    dispatches into (6, 6) unblocked, exactly as agent 0 would in the unparametrized "none" case.
+
+    - Setup: malfunction_down_counter=2 injected (for the malfunctioning agent(s)) right before the
+      departure step - observed in_malfunction=True for that one step.
+    - Step 1 (both MOVE_FORWARD): both agents reach READY_TO_DEPART, still off map.
+    - Step 2 (both MOVE_FORWARD, the departure step): outcome depends on malfunctioning:
+      - "none": agent 0 dispatches into MOVING at (6, 6); agent 1 stays READY_TO_DEPART, denied.
+      - "agent_0": agent 0 goes to MALFUNCTION_OFF_MAP instead of contesting the cell; agent 1
+        dispatches into MOVING at (6, 6) unblocked.
+      - "agent_1": symmetric - agent 1 goes to MALFUNCTION_OFF_MAP; agent 0 dispatches unblocked.
+      - "both": neither contests the cell; both go to MALFUNCTION_OFF_MAP.
+      In every variant, neither agent's reward carries a collision penalty this step.
+    """
+    stochastic_data = MalfunctionParameters(malfunction_rate=0,  # Rate of malfunction occurence
+                                            min_duration=0,  # Minimal duration of malfunction
+                                            max_duration=0  # Max duration of malfunction
+                                            )
+
+    rail, _, optionals = make_simple_rail()
+
+    env = RailEnv(width=25,
+                  height=30,
+                  rail_generator=rail_from_grid_transition_map(rail, optionals),
+                  line_generator=sparse_line_generator(seed=10),
+                  number_of_agents=2,
+                  malfunction_generator_and_process_data=malfunction_from_params(stochastic_data),
+                  rewards=DefaultRewards(collision_factor=2.0),
+                  )
+
+    env.reset(False, False, random_seed=10)
+
+    for a in range(2):
+        env.agents[a].initial_entry_point = ((6, 6), Grid4TransitionsEnum.SOUTH)
+        env.agents[a].targets = {((0, 3), d) for d in Grid4TransitionsEnum}
+        env.agents[a].earliest_departure = 2
+
+    # step 1
+    env.step({0: RailEnvActions.MOVE_FORWARD, 1: RailEnvActions.MOVE_FORWARD})
+    assert env.agents[0].state == TrainState.READY_TO_DEPART
+    assert env.agents[1].state == TrainState.READY_TO_DEPART
+
+    if malfunctioning in ("agent_0", "both"):
+        env.agents[0].malfunction_handler._set_malfunction_down_counter(2)
+    if malfunctioning in ("agent_1", "both"):
+        env.agents[1].malfunction_handler._set_malfunction_down_counter(2)
+
+    # step 2 (the departure step)
+    _, rewards, _, _ = env.step({0: RailEnvActions.MOVE_FORWARD, 1: RailEnvActions.MOVE_FORWARD})
+
+    # no collision penalty for either agent, regardless of malfunctioning: the penalty only fires on a
+    # MOVING -> STOPPED demotion, never on a READY_TO_DEPART agent denied map entry.
+    assert rewards[0] == 0
+    assert rewards[1] == 0
+
+    if malfunctioning == "none":
+        assert env.agents[0].state == TrainState.MOVING
+        assert env.agents[0].current_entry_point[0] == (6, 6)
+        assert env.agents[1].state == TrainState.READY_TO_DEPART
+        assert env.agents[1].current_entry_point is None
+    elif malfunctioning == "agent_0":
+        assert env.agents[0].state == TrainState.MALFUNCTION_OFF_MAP
+        assert env.agents[0].current_entry_point is None
+        assert env.agents[1].state == TrainState.MOVING
+        assert env.agents[1].current_entry_point[0] == (6, 6)
+    elif malfunctioning == "agent_1":
+        assert env.agents[0].state == TrainState.MOVING
+        assert env.agents[0].current_entry_point[0] == (6, 6)
+        assert env.agents[1].state == TrainState.MALFUNCTION_OFF_MAP
+        assert env.agents[1].current_entry_point is None
+    else:  # both
+        assert env.agents[0].state == TrainState.MALFUNCTION_OFF_MAP
+        assert env.agents[0].current_entry_point is None
+        assert env.agents[1].state == TrainState.MALFUNCTION_OFF_MAP
+        assert env.agents[1].current_entry_point is None
+
+
+@pytest.mark.parametrize("malfunctioning", ["none", "agent_0", "agent_1", "both"])
+def test_same_cell_same_earliest_departure_dispatch_conflict_malfunction_ends_on_departure(malfunctioning):
+    """
+    Same setup as test_same_cell_same_earliest_departure_dispatch_conflict (two agents sharing initial
+    entry point (6, 6) and earliest_departure=2), but here the parametrized agent(s) are already
+    malfunctioning before ever departing, with the malfunction timed to end exactly on the departure
+    step (earliest_departure=2) rather than starting on it. Design (issue #280): a malfunction ending
+    with earliest_departure already reached goes straight from MALFUNCTION_OFF_MAP into MOVING on a
+    movement action - or, if the cell is contested, into READY_TO_DEPART instead of back into
+    MALFUNCTION_OFF_MAP, since the malfunction has genuinely already ended by then (see
+    _handle_malfunction_off_map above). Same asserted properties as the sibling test: agent 0 (lower
+    index) always wins the departure conflict regardless of which agent(s) were malfunctioning, and
+    neither agent's reward carries a collision penalty.
+
+    - Setup: malfunction_down_counter=2 injected (for the parametrized agent(s)) before step 1 -
+      in_malfunction=True for step 1 only, already False again by step 2, the departure step.
+    - Step 1 (both MOVE_FORWARD): a malfunctioning agent goes WAITING -> MALFUNCTION_OFF_MAP
+      (malfunction_down_counter == 1 afterwards); a non-malfunctioning agent goes WAITING ->
+      READY_TO_DEPART as usual.
+    - Step 2 (both MOVE_FORWARD, the departure step - malfunction already ended for any parametrized
+      agent): agent 0 dispatches into MOVING at (6, 6); agent 1 is denied and lands in READY_TO_DEPART -
+      never back in MALFUNCTION_OFF_MAP, regardless of whether agent 1 itself was one of the
+      malfunctioning agents. Neither agent's reward carries a collision penalty this step.
+    """
+    stochastic_data = MalfunctionParameters(malfunction_rate=0,  # Rate of malfunction occurence
+                                            min_duration=0,  # Minimal duration of malfunction
+                                            max_duration=0  # Max duration of malfunction
+                                            )
+
+    rail, _, optionals = make_simple_rail()
+
+    env = RailEnv(width=25,
+                  height=30,
+                  rail_generator=rail_from_grid_transition_map(rail, optionals),
+                  line_generator=sparse_line_generator(seed=10),
+                  number_of_agents=2,
+                  malfunction_generator_and_process_data=malfunction_from_params(stochastic_data),
+                  rewards=DefaultRewards(collision_factor=2.0),
+                  )
+
+    env.reset(False, False, random_seed=10)
+
+    for a in range(2):
+        env.agents[a].initial_entry_point = ((6, 6), Grid4TransitionsEnum.SOUTH)
+        env.agents[a].targets = {((0, 3), d) for d in Grid4TransitionsEnum}
+        env.agents[a].earliest_departure = 2
+
+    if malfunctioning in ("agent_0", "both"):
+        env.agents[0].malfunction_handler._set_malfunction_down_counter(2)
+    if malfunctioning in ("agent_1", "both"):
+        env.agents[1].malfunction_handler._set_malfunction_down_counter(2)
+
+    # step 1
+    env.step({0: RailEnvActions.MOVE_FORWARD, 1: RailEnvActions.MOVE_FORWARD})
+    if malfunctioning in ("agent_0", "both"):
+        assert env.agents[0].state == TrainState.MALFUNCTION_OFF_MAP
+        assert env.agents[0].malfunction_handler.malfunction_down_counter == 1
+    else:
+        assert env.agents[0].state == TrainState.READY_TO_DEPART
+    if malfunctioning in ("agent_1", "both"):
+        assert env.agents[1].state == TrainState.MALFUNCTION_OFF_MAP
+        assert env.agents[1].malfunction_handler.malfunction_down_counter == 1
+    else:
+        assert env.agents[1].state == TrainState.READY_TO_DEPART
+
+    # step 2 (the departure step - malfunction already ended for any parametrized agent)
+    _, rewards, _, _ = env.step({0: RailEnvActions.MOVE_FORWARD, 1: RailEnvActions.MOVE_FORWARD})
+
+    # no collision penalty for either agent, regardless of malfunctioning: the penalty only fires on a
+    # MOVING -> STOPPED demotion, never on a denied off-map agent (READY_TO_DEPART or MALFUNCTION_OFF_MAP).
+    assert rewards[0] == 0
+    assert rewards[1] == 0
+
+    # agent 0 always wins, regardless of which agent(s) were malfunctioning - agent 1 is denied and
+    # lands in READY_TO_DEPART, never back in MALFUNCTION_OFF_MAP.
+    assert env.agents[0].state == TrainState.MOVING
+    assert env.agents[0].current_entry_point[0] == (6, 6)
+    assert env.agents[1].state == TrainState.READY_TO_DEPART
+    assert env.agents[1].current_entry_point is None
 
 
 def test_malfunction_to_moving_instead_of_stopped():
@@ -344,7 +500,10 @@ def test_malfunction_to_moving_instead_of_stopped():
 
     env.agents[0].initial_entry_point = ((6, 6), Grid4TransitionsEnum.SOUTH)
     env.agents[0].targets = {((0, 3), d) for d in Grid4TransitionsEnum}
-    env.agents[0].earliest_departure = 0
+    # design (issue #280): earliest_departure=1, not 0 - an earliest_departure=0 agent now dispatches
+    # directly on the very first movement action (see rail_env.py's step()), which isn't the point of
+    # this test; =1 keeps the original two-real-steps-to-depart timing this test relies on.
+    env.agents[0].earliest_departure = 1
     # design: speed is None while off map (agent hasn't departed yet) - only _max_speed applies here,
     # departure always (re-)accelerates from 0 regardless of any pre-set speed (see design D3).
     env.agents[0].speed_counter._max_speed = Fraction(1, 5)
@@ -379,15 +538,11 @@ def test_malfunction_to_moving_instead_of_stopped():
 
     # step 4
     env.step({0: RailEnvActions.MOVE_FORWARD, 1: RailEnvActions.MOVE_FORWARD})
-
-    # / TEMPORARY FIX avoid setting agent to STOPPED after malfunction unnecessarily
-    # WITHOUT FIX: agent is STOPPED
     assert env.agents[0].current_entry_point[0] == (6, 6)
     assert env.agents[0].state == TrainState.MOVING
     assert np.isclose(float(env.agents[0].speed_counter.speed), 0.2)
     # design: distance update with pre-step speed.
     assert np.isclose(float(env.agents[0].speed_counter.distance), 0.0)
-    # \ TEMPORARY FIX
 
 
 def test_stop_and_go():
@@ -413,7 +568,10 @@ def test_stop_and_go():
 
     env.agents[0].initial_entry_point = ((6, 6), Grid4TransitionsEnum.SOUTH)
     env.agents[0].targets = {((0, 3), d) for d in Grid4TransitionsEnum}
-    env.agents[0].earliest_departure = 0
+    # design (issue #280): earliest_departure=1, not 0 - an earliest_departure=0 agent now dispatches
+    # directly on the very first movement action (see rail_env.py's step()), which isn't the point of
+    # this test; =1 keeps the original two-real-steps-to-depart timing this test relies on.
+    env.agents[0].earliest_departure = 1
     # design: speed is None while off map (agent hasn't departed yet) - only _max_speed applies here,
     # departure always (re-)accelerates from 0 regardless of any pre-set speed (see design D3).
     env.agents[0].speed_counter._max_speed = Fraction(1, 5)

--- a/tests/test_known_flatland_bugs.py
+++ b/tests/test_known_flatland_bugs.py
@@ -107,15 +107,19 @@ def test_min_distance_for_off_map_trains_speed_of_half_REVISEDESIGN() -> None:
 
 
 # pylint: disable=protected-access
-def test_earliest_departure_zero_bug_BYDESIGN() -> None:
+def test_earliest_departure_zero_bug_FIXED() -> None:
     """
-    TODO https://github.com/flatland-association/flatland-rl/issues/280 revise design: by design of
-         https://flatland-association.github.io/flatland-book/environment/environment/agent.html#state-machine,
-         an agent can go from WAITING to READY_TO_DEPART only after the first step transition. However, the design may be questioned:
-         we could drop ready_to_depart by adding condition earliest_departure_reached to transition from WAITING to MOVING.
+    Trains that have earliest_departure=0 are dispatched directly into MOVING on the very first step() call
+    given a movement action - they never observably visit READY_TO_DEPART first. Design (issue #280):
+    rail_env.py's step() forces WAITING -> READY_TO_DEPART for such an agent before that same first step's
+    own state read, so it is already READY_TO_DEPART by the time the (3b.3) map-entry branch looks at it -
+    symmetric with MALFUNCTION_OFF_MAP's own straight-to-MOVING shortcut in _handle_malfunction_off_map.
 
-    Trains that have the earliest departure at ts 0 cannot be dispatched at ts 0 but only at ts 1. It seems like
-    every train starts with train state Waiting no matter the earliest departure.
+    - Setup: two agents, both WAITING. Agent 1 has earliest_departure=0, agent 0 has earliest_departure=1.
+    - Step 1 (agent 0 DO_NOTHING, agent 1 MOVE_FORWARD): agent 0 reaches only READY_TO_DEPART (still off
+      map); agent 1 is dispatched straight into MOVING, at its initial entry point.
+    - Step 2 (both MOVE_FORWARD): agent 0 is now dispatched into MOVING too - one step later than agent 1,
+      matching the one-step gap between their earliest_departure values.
     """
 
     env = init_test_rail_env(1)
@@ -124,32 +128,28 @@ def test_earliest_departure_zero_bug_BYDESIGN() -> None:
     agent_0, agent_1 = env.agents[0], env.agents[1]
 
     assert agent_1.earliest_departure == 0
-    # Since agent 1s earliest departure is 0, we should be able to dispatch it, however
     assert agent_1.state == TrainState.WAITING
-    # the train state is waiting
 
-    # other train.
     assert agent_0.earliest_departure == 1
     assert agent_0.state == TrainState.WAITING
 
-    # Now if we try to dispatch train 1 and do not dispatch train 0 ---> both end up being in ready to depart!
+    # Dispatch train 1 (earliest_departure=0) but not train 0 (earliest_departure=1).
     env.step({0: RailEnvActions.DO_NOTHING, 1: RailEnvActions.MOVE_FORWARD})
     agent_0, agent_1 = env.agents[0], env.agents[1]
     assert agent_0.state == TrainState.READY_TO_DEPART
-    assert agent_1.state == TrainState.READY_TO_DEPART
     assert agent_0.current_entry_point is None
-    assert agent_1.current_entry_point is None
+    assert agent_1.state == TrainState.MOVING
+    assert np.all(agent_1.current_entry_point[0] == agent_1.initial_entry_point[0])
 
-    # If we now try to dispatch both trains they will be dispatched.
+    # Now dispatch train 0 too.
     env.step({0: RailEnvActions.MOVE_FORWARD, 1: RailEnvActions.MOVE_FORWARD})
     agent_0, agent_1 = env.agents[0], env.agents[1]
     assert agent_0.state == TrainState.MOVING
     assert agent_1.state == TrainState.MOVING
 
     assert np.all(agent_0.current_entry_point[0] == agent_0.initial_entry_point[0])
-    assert np.all(agent_1.current_entry_point[0] == agent_1.initial_entry_point[0])
 
-    # Thus we showed that train 0 could be dispatched at it's earliest departure and train 1 could not
+    # Thus train 1 (earliest_departure=0) was dispatched one step earlier than train 0 (earliest_departure=1).
 
 
 def test_train_can_move_when_malfunction_counter_is_0_off_map_FIXED():

--- a/tests/test_rewards.py
+++ b/tests/test_rewards.py
@@ -1210,20 +1210,22 @@ def test_env_collision_penalty_on_head_on_conflict():
     agent_0, agent_1 = env.agents
 
     forward = {0: RailEnvActions.MOVE_FORWARD, 1: RailEnvActions.MOVE_FORWARD}
-    for _ in range(3):
+    # design (issue #280): earliest_departure=0 agents now dispatch one step earlier (straight into
+    # MOVING on the very first step), so only 2 warm-up steps are needed here instead of 3.
+    for _ in range(2):
         _, rewards, _, _ = env.step(forward)
         assert rewards[0][DefaultPenalties.COLLISION.value] == 0
         assert rewards[1][DefaultPenalties.COLLISION.value] == 0
         assert rewards[0][DefaultPenalties.INVALID_ACTION.value] == 0
         assert rewards[1][DefaultPenalties.INVALID_ACTION.value] == 0
 
-    # before 4th step: agent 0 at (3,2) east, agent 1 at (3,4) west, one free cell (3,3) between them
+    # before 3rd step: agent 0 at (3,2) east, agent 1 at (3,4) west, one free cell (3,3) between them
     assert agent_0.current_entry_point == ((3, 2), Grid4TransitionsEnum.EAST)
     assert agent_0.speed_counter.distance == 0
     assert agent_1.current_entry_point == ((3, 4), Grid4TransitionsEnum.WEST)
     assert agent_1.speed_counter.distance == 0
 
-    # 4th step: both request entry into (3,3) -> motion check awards the cell to agent 0 and force-stops agent 1
+    # 3rd step: both request entry into (3,3) -> motion check awards the cell to agent 0 and force-stops agent 1
     _, rewards, _, _ = env.step(forward)
     assert agent_1.state_machine.previous_state == TrainState.MOVING
     assert agent_1.state == TrainState.STOPPED
@@ -1235,13 +1237,13 @@ def test_env_collision_penalty_on_head_on_conflict():
     assert agent_0.state == TrainState.MOVING
     assert rewards[0][DefaultPenalties.COLLISION.value] == 0
     assert rewards[0][DefaultPenalties.INVALID_ACTION.value] == 0
-    # after 4th step: agent 0 has moved into the contested cell, agent 1 stayed put (force-stopped)
+    # after 3rd step: agent 0 has moved into the contested cell, agent 1 stayed put (force-stopped)
     assert agent_0.current_entry_point == ((3, 3), Grid4TransitionsEnum.EAST)
     assert agent_0.speed_counter.distance == 0
     assert agent_1.current_entry_point == ((3, 4), Grid4TransitionsEnum.WEST)
     assert agent_1.speed_counter.distance == 1
 
-    # 5th step: agents now face each other on adjacent cells (3,3)/(3,4); agent 0's move would
+    # 4th step: agents now face each other on adjacent cells (3,3)/(3,4); agent 0's move would
     # make it collide with agent 1, which the motion check forbids -> agent 0 force-stopped
     _, rewards, _, _ = env.step(forward)
     assert agent_0.state_machine.previous_state == TrainState.MOVING
@@ -1261,7 +1263,7 @@ def test_env_collision_penalty_on_head_on_conflict():
     # persisting deadlock now keeps accruing a collision penalty every step, alternating between the
     # two agents, rather than just the one time each incurred above.
 
-    # 6th step: agent 1 (STOPPED since the 5th step) is promoted back to MOVING optimistically -
+    # 5th step: agent 1 (STOPPED since the 4th step) is promoted back to MOVING optimistically -
     # its real attempt into (3,3) is denied for real this same step (still held by agent 0, which is
     # itself mid-settling this step, protecting its cell via self-loop) -> a fresh penalty for agent 1.
     _, rewards, _, _ = env.step(forward)
@@ -1273,7 +1275,7 @@ def test_env_collision_penalty_on_head_on_conflict():
     assert rewards[0][DefaultPenalties.INVALID_ACTION.value] == 0
     assert rewards[1][DefaultPenalties.INVALID_ACTION.value] == 0
 
-    # 7th step: agent 0 now has genuine pre-step speed and makes its own real attempt into (3,4),
+    # 6th step: agent 0 now has genuine pre-step speed and makes its own real attempt into (3,4),
     # denied for real (agent 1 is now mid-settling, holding (3,4) via self-loop) -> a fresh penalty
     # for agent 0 instead - and so on, alternating forever for as long as the deadlock persists.
     _, rewards, _, _ = env.step(forward)
@@ -1370,10 +1372,9 @@ def _make_platoon_env(n_agents: int, start_columns, lead_max_speed: float = 1.0)
 
 
 def _depart(env):
-    """Two steps to move all agents from WAITING through READY_TO_DEPART onto the rail."""
+    """One step to move all earliest_departure=0 agents from WAITING straight onto the rail."""
     forward = {i: RailEnvActions.MOVE_FORWARD for i in range(len(env.agents))}
-    for _ in range(2):
-        env.step(forward)
+    env.step(forward)
 
 
 @pytest.mark.parametrize("start_columns", [(3, 2, 1), (1, 2, 3)], ids=["front-is-agent-0", "front-is-agent-2"])


### PR DESCRIPTION
## Changes

### Carried out

| ID | Description | Category | Severity | Commit(s) |
|---|---|---|---|---|
| — | Dispatch a WAITING agent with `earliest_departure=0` straight into MOVING on the very first `step()` call instead of stalling one step in READY_TO_DEPART, and shift `earliest_departure_reached`'s signal one step earlier so a WAITING→READY_TO_DEPART agent can depart in the very step that transition becomes visible (issue #280); updates affected regression/reward/persistence tests for the new one-step-earlier timing, and adds tests covering `action_required`'s behavior during malfunction, dispatch conflicts between agents sharing `earliest_departure`/a start cell, and map entry timing across a range of `earliest_departure` values | fix! | High | e08607b5 |
| — | Document `action_required`'s state/malfunction-counter timing in `state_machine.py`: `agent.state` reflects step()'s settled outcome while the malfunction counter is decremented separately before the per-agent loop runs; records the MALFUNCTION vs MALFUNCTION_OFF_MAP `action_required` asymmetry plus three verified design options to resolve it (issue #280) | docs | Low | fc50d4b1 |

### Remaining

| ID | Description | Category | Severity | Commit message |
|---|---|---|---|---|
| — | Resolve the MALFUNCTION vs MALFUNCTION_OFF_MAP `action_required` asymmetry documented by fc50d4b1 - three design options were verified but none chosen/implemented yet | Design decision | Medium | fix(envs): resolve MALFUNCTION/MALFUNCTION_OFF_MAP action_required asymmetry (issue #280) |

## Related issues

Part of #280.

## Checklist

- [ ] Tests are included for relevant behavior changes.
- [ ] Documentation is added in the [flatland-book](https://github.com/flatland-association/flatland-book) repo for relevant behavior changes.
- [ ] If you made important user-facing changes, describe them under the `[Unreleased]` tag in `CHANGELOG.md`.
- [ ] New package dependencies are declared in the `pyproject.toml` file.
  Requirement files have been updated by running `tox -e requirements`.
- [ ] Code works with all supported Python versions (3.10, 3.11, 3.12 and 3.13). Checks run with all supported version and are
  required to run successfully.
- [ ] Code is formatted according to PEP 8 (an IDE like PyCharm can do this for you).
- [ ] Technical guidelines listed in `CONTRIBUTING.md` are followed.