### PR TITLE
refactor!: D6* step() cleanup from pre-post

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -361,6 +361,10 @@ The `flatland-trajectory-*` scripts (generate-from-policy/generate-from-metadata
 
 ## Conventions (see `CONTRIBUTING.md` for full detail)
 
+- Call a method/function with more than a couple of parameters using keyword arguments at the call site
+  (`self._foo(action=action, state=state, ...)`), not positional - positional args for a long signature are
+  easy to silently mis-order (especially several same-typed/`Optional` params in a row) and a keyword mismatch
+  fails loudly instead.
 - Prefer `NamedTuple` over a plain unnamed `Tuple` or `Dict` for structured data that doesn't need methods.
 - Use `attrs` (`@attrs`/`attrib`) for classes that must keep multiple members in sync as an invariant.
 - Use `abc.ABCMeta`/`abc.abstractmethod` for extension-point base classes.

--- a/flatland/envs/rail_env.py
+++ b/flatland/envs/rail_env.py
@@ -530,6 +530,21 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
                 candidate_speed = agent.speed_counter.speed
             candidate_speed = _cap_speed(agent_max_speed, candidate_speed)
 
+            # verification: _candidate_entry_points (used by _check_post_position_invariants) should
+            # reproduce exactly the same (candidate_entry_point, candidate_next_entry_point) as the
+            # inline (3b) derivation below, given the same pre-step values - temporary cross-check
+            # while (3b.3)'s map-entry condition (only knowable from genuinely pre-step data, not from
+            # self.temp_transition_data which isn't populated yet at this point in loop 1) is reworked.
+            # _verify_candidate_entry_point, _verify_candidate_next_entry_point = self._candidate_entry_points(
+            #     action=action,
+            #     agent=agent,
+            #     pre_current_entry_point=agent.current_entry_point,
+            #     pre_next_entry_point=agent.next_entry_point,
+            #     pre_speed=agent.speed_counter.speed,
+            #     pre_offset=agent.speed_counter.distance,
+            #     pre_done=self.dones[i_agent],
+            # )
+
             # (3b) POSITION UPDATE - mirrors _check_post_position_invariants's "candidates accepted"
             # derivation: done/malfunction/map-entry/on-map-transition/stay.
             # (3b.1) done
@@ -575,6 +590,11 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
             else:
                 candidate_entry_point = agent.current_entry_point
                 candidate_next_entry_point = agent.next_entry_point
+
+            # assert (candidate_entry_point, candidate_next_entry_point) == (_verify_candidate_entry_point, _verify_candidate_next_entry_point), \
+            #     f"_candidate_entry_points diverged from inline (3b): inline={(candidate_entry_point, candidate_next_entry_point)} " \
+            #     f"_candidate_entry_points={(_verify_candidate_entry_point, _verify_candidate_next_entry_point)} agent={i_agent} state={state} " \
+            #     f"in_malfunction={in_malfunction} action={action} action_valid={action_valid}"
 
             if self.check_step_pre_post_conditions:
                 self._check_off_on_map_invariant(candidate_entry_point, candidate_next_entry_point)
@@ -797,6 +817,70 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
     def _is_speed_zero(self, candidate_speed: Fraction) -> bool:
         return candidate_speed == 0.0
 
+    def _candidate_entry_points(self, action: RailEnvActions, agent: EnvAgent,
+                                pre_current_entry_point: Optional[EntryPointT],
+                                pre_next_entry_point: Optional[EntryPointT],
+                                pre_speed: Optional[Fraction],
+                                pre_offset: Optional[Fraction],
+                                pre_done: bool) -> Tuple[Optional[EntryPointT], Optional[EntryPointT]]:
+        """
+        The expected (current, next) entry point pair for this step, given action + pre-step values -
+        verbatim-adapted from _check_post_position_invariants's own "candidates accepted in distribute
+        phase" derivation (assertions there become return statements here), so both step()'s own (3b)
+        POSITION UPDATE and the post-step check call this one, identically shaped, implementation.
+
+        N.B. known gap, to be revisited: does not yet special-case done / remove_agents_at_target
+        the way the original assertions did (dropped the `agent.current_entry_point ==
+        agent.target_entry_point` cross-check, which doesn't fit an (current, next) return shape) -
+        callers should not yet rely on this method alone for the done/target-removal distinction.
+        """
+        is_on_map = pre_next_entry_point is not None
+        is_cell_exit = pre_speed is not None and pre_speed > 0 and pre_offset + pre_speed >= SEGMENT_LENGTH
+        if is_on_map:
+            candidate_entry_point_independent = self.rail.apply_action_independent(action, pre_next_entry_point)
+        else:
+            candidate_entry_point_independent = self.rail.apply_action_independent(action, agent.initial_entry_point)
+
+        # loop 1's own (3b.3) candidate is exactly predictive of a real map entry here: the
+        # optimistic MALFUNCTION_OFF_MAP+STOP_MOVING mismatch that used to require a post-hoc
+        # agent.current_entry_point read instead was closed by excluding stop_action_given from
+        # (3b.3)'s condition (see step()'s own comment there).
+        if not is_on_map and self.temp_transition_data[agent.handle].candidate_entry_point is not None:
+            # (3b.3) map entry
+            candidate_entry_point = agent.initial_entry_point
+            candidate_next_entry_point = candidate_entry_point_independent
+        elif is_on_map and is_cell_exit:
+            # (3b.5) on-map cell transition - candidate_next_entry_point stays None here exactly
+            # when the action was invalid at the boundary (denied by (3b.6)); guarded for below.
+            candidate_entry_point = pre_next_entry_point
+            candidate_next_entry_point = candidate_entry_point_independent
+        else:
+            # (3b.1/3b.2/3b.2bis/3b.4/3b.6) unchanged
+            candidate_entry_point = pre_current_entry_point
+            candidate_next_entry_point = pre_next_entry_point
+
+        # done
+        if pre_done:
+            if self.remove_agents_at_target:
+                return None, None
+            return pre_current_entry_point, pre_next_entry_point
+        # in malfunction
+        if agent.malfunction_handler.in_malfunction:
+            return pre_current_entry_point, pre_next_entry_point
+        # map entry
+        if pre_current_entry_point is None and candidate_entry_point is not None:
+            return candidate_entry_point, candidate_next_entry_point
+        # target reached
+        if candidate_entry_point in agent.targets and (pre_speed > 0 and pre_offset + pre_speed >= SEGMENT_LENGTH):
+            if self.remove_agents_at_target:
+                return None, None
+            return candidate_entry_point, candidate_next_entry_point
+        # on-map cell transition
+        if candidate_next_entry_point is not None and (pre_speed > 0 and pre_offset + pre_speed >= SEGMENT_LENGTH):
+            return candidate_entry_point, candidate_next_entry_point
+        # stay
+        return pre_current_entry_point, pre_next_entry_point
+
     @lru_cache()
     def _fast_state_position_sync_check(self, state, entry_point, remove_agents_at_target):
         """ Check for whether on map and off map states are matching with position being None """
@@ -912,75 +996,17 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
             # candidates accepted in distribute phase
             else:
                 action = RailEnvActions.from_value(action_dict.get(h, RailEnvActions.DO_NOTHING))
-                pre_current_entry_point = pre_step.pre_current_entry_points[h]
-                pre_next_entry_point = pre_step.pre_next_entry_points[h]
-                pre_speed = pre_step.pre_speeds[h]
-                is_on_map = pre_next_entry_point is not None
-                is_cell_exit = pre_speed is not None and pre_speed > 0 and pre_step.pre_offsets[h] + pre_speed >= SEGMENT_LENGTH
-                if is_on_map:
-                    candidate_entry_point_independent = self.rail.apply_action_independent(action, pre_next_entry_point)
-                else:
-                    candidate_entry_point_independent = self.rail.apply_action_independent(action, agent.initial_entry_point)
-
-                # loop 1's own (3b.3) candidate is exactly predictive of a real map entry here: the
-                # optimistic MALFUNCTION_OFF_MAP+STOP_MOVING mismatch that used to require a post-hoc
-                # agent.current_entry_point read instead was closed by excluding stop_action_given from
-                # (3b.3)'s condition (see step()'s own comment there).
-                if not is_on_map and self.temp_transition_data[h].candidate_entry_point is not None:
-                    # (3b.3) map entry
-                    candidate_entry_point = agent.initial_entry_point
-                    candidate_next_entry_point = candidate_entry_point_independent
-                elif is_on_map and is_cell_exit:
-                    # (3b.5) on-map cell transition - candidate_next_entry_point stays None here exactly
-                    # when the action was invalid at the boundary (denied by (3b.6)); guarded for below.
-                    candidate_entry_point = pre_next_entry_point
-                    candidate_next_entry_point = candidate_entry_point_independent
-                else:
-                    # (3b.1/3b.2/3b.2bis/3b.4/3b.6) unchanged
-                    candidate_entry_point = pre_current_entry_point
-                    candidate_next_entry_point = pre_next_entry_point
-
-                # done
-                if pre_step.pre_dones[h]:
-                    if self.remove_agents_at_target:
-                        assert agent.current_entry_point is None
-                        assert agent.next_entry_point is None
-                    else:
-                        assert agent.current_entry_point is not None
-                        assert agent.current_entry_point == pre_step.pre_current_entry_points[h]
-                        assert agent.next_entry_point == pre_step.pre_next_entry_points[h]
-                        assert agent.current_entry_point == agent.target_entry_point
-                # in malfunction
-                elif agent.malfunction_handler.in_malfunction:
-                    assert agent.current_entry_point == pre_step.pre_current_entry_points[h]
-                    assert agent.next_entry_point == pre_step.pre_next_entry_points[h]
-                # map entry
-                elif pre_step.pre_current_entry_points[h] is None and candidate_entry_point is not None:
-                    assert agent.current_entry_point == agent.initial_entry_point
-                    assert agent.current_entry_point == candidate_entry_point
-                    assert agent.next_entry_point == candidate_next_entry_point
-                # target reached
-                elif candidate_entry_point in agent.targets and (
-                    pre_step.pre_speeds[h] > 0 and pre_step.pre_offsets[h] + pre_step.pre_speeds[h] >= SEGMENT_LENGTH):
-                    assert agent.target_entry_point == candidate_entry_point
-                    if self.remove_agents_at_target:
-                        assert agent.current_entry_point is None
-                        assert agent.next_entry_point is None
-                    else:
-                        assert agent.current_entry_point is not None
-                        assert agent.current_entry_point == candidate_entry_point
-                        assert agent.next_entry_point == candidate_next_entry_point
-                        assert agent.current_entry_point == agent.target_entry_point
-                # on-map cell transition
-                elif candidate_next_entry_point is not None and (
-                    pre_step.pre_speeds[h] > 0 and pre_step.pre_offsets[h] + pre_step.pre_speeds[h] >= SEGMENT_LENGTH):
-                    assert agent.current_entry_point is not None
-                    assert agent.current_entry_point == candidate_entry_point
-                    assert agent.next_entry_point == candidate_next_entry_point
-                # stay
-                else:
-                    assert agent.current_entry_point == pre_step.pre_current_entry_points[h]
-                    assert agent.next_entry_point == pre_step.pre_next_entry_points[h]
+                candidate_entry_point, candidate_next_entry_point = self._candidate_entry_points(
+                    action=action,
+                    agent=agent,
+                    pre_current_entry_point=pre_step.pre_current_entry_points[h],
+                    pre_next_entry_point=pre_step.pre_next_entry_points[h],
+                    pre_speed=pre_step.pre_speeds[h],
+                    pre_offset=pre_step.pre_offsets[h],
+                    pre_done=pre_step.pre_dones[h],
+                )
+                assert agent.current_entry_point == candidate_entry_point
+                assert agent.next_entry_point == candidate_next_entry_point
 
     def _check_post_speed_distance_invariants(self, action_dict: Dict[int, RailEnvActions],
                                               pre_step: PreStepSnapshot) -> None:

--- a/flatland/envs/rail_env.py
+++ b/flatland/envs/rail_env.py
@@ -406,13 +406,16 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
 
             self.dones["__all__"] = True
 
-    def handle_done_state(self, agent):
-        """ Any updates to agent to be made in Done state """
+    def handle_done_state(self, agent, candidate_entry_point):
+        """
+        Any updates to agent to be made in Done state.
+
+        candidate_entry_point : the entry point reached
+        """
         if agent.state == TrainState.DONE and agent.arrival_time is None:
             agent.arrival_time = self._elapsed_steps
-            # capture which specific target alternative was reached before current_entry_point is
-            # possibly cleared below - see EnvAgent.target_entry_point.
-            agent.target_entry_point = agent.current_entry_point
+            # capture which specific target alternative was reached - see EnvAgent.target_entry_point.
+            agent.target_entry_point = candidate_entry_point
             self.dones[agent.handle] = True
             if self.remove_agents_at_target:
                 agent.current_entry_point = None
@@ -592,6 +595,7 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
             # (7) FETCH THE SAVED TRANSITION DATA FOR AGENT
             agent_transition_data = self.temp_transition_data[i_agent]
             candidate_entry_point = agent_transition_data.candidate_entry_point
+            candidate_next_entry_point = agent_transition_data.candidate_next_entry_point
 
             # (8) FETCH CONFLICT RESOLUTION FOR AGENT AND FINALIZE STATE TRANSITION SIGNALS FROM MOTION_CHECK
             resource_check = self.resource_check.check_resource(i_agent)
@@ -618,31 +622,23 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
             agent.state_machine.step()
 
             # (10a) POSITION UPDATE
-            # INVARIANT: agent.current_entry_point and agent.next_entry_point are always both None
-            # (agent off-map) XOR both not None (agent on-map); while on-map, the two are always
-            # updated together, on every crossing, and next_entry_point must never equal
-            # current_entry_point - there is no "nothing pending" sentinel: entering a new cell is
-            # only ever committed together with a valid, genuinely different candidate for what lies
-            # beyond it (see (3b) above, where the crossing itself is only attempted if that candidate
-            # exists - so candidate_entry_point below is guaranteed non-None whenever entering_new_cell
-            # is True).
-            if agent.state == TrainState.MOVING and agent_transition_data.speed == 0:
-                # design (D1): pre-step speed 0 (STOPPED/MALFUNCTION promoted to MOVING this step) -
-                # this step only grants permission to move; it contributes zero speed/distance itself,
-                # so no crossing may be committed yet. Position/next_entry_point stay exactly as they
-                # were, deferred to the following (genuinely pre-speed>0) step. See (10b) below for the
-                # matching distance/speed treatment.
+            pre_done = agent.target_entry_point is not None
+
+            # candidates discarded if not resource check -> keep previous configuration (no-op)
+            if not resource_check:
                 pass
-            elif agent.state == TrainState.MOVING or (
-                agent.state == TrainState.STOPPED and agent.state_machine.previous_state == TrainState.MOVING
-                and resource_check
-            ):
-                entering_new_cell = agent.current_entry_point != candidate_entry_point
+            # target reached and removed
+            elif self.remove_agents_at_target and (pre_done or candidate_entry_point in agent.targets):
+                agent.current_entry_point = None
+                agent.next_entry_point = None
+                if not pre_done:
+                    agent.state_machine.update_if_reached(candidate_entry_point, agent.targets)
+            # candidates accepted
+            else:
                 agent.current_entry_point = _sanitize_entry_point(candidate_entry_point)
-                if entering_new_cell:
-                    assert agent_transition_data.candidate_next_entry_point is not None
-                    agent.next_entry_point = _sanitize_entry_point(agent_transition_data.candidate_next_entry_point)
-                agent.state_machine.update_if_reached(agent.current_entry_point, agent.targets)
+                agent.next_entry_point = _sanitize_entry_point(candidate_next_entry_point)
+                if not pre_done:
+                    agent.state_machine.update_if_reached(candidate_entry_point, agent.targets)
 
             # (10b) SPEED_COUNTER UPDATE (SPEED AND DISTANCE)
             if agent.state == TrainState.MOVING and agent_transition_data.speed == 0:
@@ -705,7 +701,7 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
             # and calls agent.speed_counter.step(speed=None, ...) itself.
 
             # (11) HANDLE DONE STATE ACTIONS, OPTIONALLY REMOVE AGENTS
-            self.handle_done_state(agent)
+            self.handle_done_state(agent, candidate_entry_point)
             have_all_agents_ended &= (agent.state == TrainState.DONE)
 
             # (12) UPDATE REWARDS

--- a/flatland/envs/rail_env.py
+++ b/flatland/envs/rail_env.py
@@ -495,7 +495,6 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
             # whether the action leads to a valid transition - precomputed in pre_step_snapshot so
             # self.rail.apply_action_independent() runs exactly once per agent per step (also read by
             # _candidate_entry_points/_candidate_speed/_candidate_distance below, via the post-step checks)
-            # TODO this is wrong: if done, we should not try to reservee the initial edge!
             candidate_entry_point_independent = pre_step_snapshot.pre_candidate_entry_point_independents[i_agent]
 
             # mid cell or valid transition (only invalid actions are non-L/R on symmetric switches)

--- a/flatland/envs/rail_env.py
+++ b/flatland/envs/rail_env.py
@@ -486,7 +486,6 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
             state = agent.state
 
             # (2) CANDIDATE ENTRY POINT: action validity - need both by speed update (3a) and position update (3b) below
-            is_on_map = agent.next_entry_point is not None
             # whether the action leads to a valid transition - precomputed in pre_step_snapshot so
             # self.rail.apply_action_independent() runs exactly once per agent per step (also read by
             # _candidate_entry_points/_candidate_speed/_candidate_distance below, via the post-step checks)
@@ -497,110 +496,39 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
             is_cell_exit = agent.speed_counter.is_cell_exit()
             action_valid = not is_cell_exit or candidate_entry_point_independent is not None
 
-            # (3a) SPEED UPDATE
-            # N.B. new speed is only applied if MOVING state and previous was not READY_TO_DEPART/MALFUNCTION_OFF_MAP, see below
-
-            # N.B. no acceleration if the action isn't (corrected to) MOVE_FORWARD, e.g. facing a
-            # symmetric switch with the action corrected to STOP_MOVING, or MOVE_LEFT/MOVE_RIGHT
-            # corrected to MOVE_FORWARD but not accelerated as the original action wasn't forward.
-            # get desired candidate speed independent of resource check
+            # (3a) SPEED UPDATE / (3b) POSITION UPDATE - delegated to the shared, pre-step-only
+            # candidate_ methods (also used by the post-step checks) instead of duplicating the branch
+            # logic inline here - see _candidate_entry_points/_candidate_speed's own docstrings for the
+            # branch-by-branch derivation. (3b) is computed first since (3a) needs its candidate_entry_point
+            # (the "done or target reached" branch).
             agent_max_speed = agent.speed_counter.max_speed
-            # (3a.1) done
-            if state == TrainState.DONE:
-                candidate_speed = Fraction(0)
-            # (3a.2) malfunction
-            elif in_malfunction:
-                candidate_speed = Fraction(0)
-            # (3a.3) map entry
-            elif not is_on_map and movement_action_given and earliest_departure_reached:
-                candidate_speed = self.acceleration_delta
-            # (3a.4) stay off map
-            elif not is_on_map:
-                candidate_speed = Fraction(0)
-            # (3a.5) invalid action
-            elif is_on_map and candidate_entry_point_independent is None and is_cell_exit:
-                candidate_speed = Fraction(0)
-            # (3a.6) accelerate upon forward
-            elif action == RailEnvActions.MOVE_FORWARD:
-                candidate_speed = agent.speed_counter.speed + self.acceleration_delta
-            # (3a.7) start moving
-            elif agent.speed_counter.speed == 0 and movement_action_given:
-                candidate_speed = agent.speed_counter.speed + self.acceleration_delta
-            # (3a.8) braking
-            elif stop_action_given:
-                # decelerate
-                candidate_speed = agent.speed_counter.speed + self.braking_delta
-            # (3a.9) default
-            else:
-                candidate_speed = agent.speed_counter.speed
-            candidate_speed = _cap_speed(agent_max_speed, candidate_speed)
-
-            # verification: _candidate_entry_points (used by _check_post_position_invariants) should
-            # reproduce exactly the same (candidate_entry_point, candidate_next_entry_point) as the
-            # inline (3b) derivation below, given the same pre-step values.
-            _verify_candidate_entry_point, _verify_candidate_next_entry_point = self._candidate_entry_points(
+            pre_speed = agent.speed_counter.speed
+            pre_offset = agent.speed_counter.distance
+            pre_done = agent.target_entry_point is not None
+            candidate_entry_point, candidate_next_entry_point = self._candidate_entry_points(
                 action=action,
                 agent=agent,
                 pre_current_entry_point=agent.current_entry_point,
                 pre_next_entry_point=agent.next_entry_point,
-                pre_speed=agent.speed_counter.speed,
-                pre_offset=agent.speed_counter.distance,
-                pre_done=agent.target_entry_point is not None,
+                pre_speed=pre_speed,
+                pre_offset=pre_offset,
+                pre_done=pre_done,
                 pre_in_malfunction=in_malfunction,
                 elapsed_steps=self._elapsed_steps,
                 candidate_entry_point_independent=candidate_entry_point_independent,
             )
-
-            # (3b) POSITION UPDATE - mirrors _check_post_position_invariants's "candidates accepted"
-            # derivation: done/malfunction/map-entry/on-map-transition/stay.
-            # (3b.1) done
-            if state == TrainState.DONE:
-                # design: for remove_agents_at_target=True, agent.current_entry_point is already
-                # None (handle_done_state() cleared it on removal) - a no-op. For
-                # remove_agents_at_target=False, this reserves the agent's occupied target cell as
-                # both its current and candidate resource
-                candidate_entry_point = agent.current_entry_point
-                candidate_next_entry_point = agent.next_entry_point
-            # (3b.2) malfunction - takes priority over (3b.3)/(3b.5) below: in_malfunction is resolved
-            # before this loop runs (see (0a)/(0b)), so it can be True while `state` (read above, still
-            # the pre-transition value) hasn't caught up to MALFUNCTION/MALFUNCTION_OFF_MAP yet -
-            # without this priority, a same-step malfunction onset could let a genuine crossing through.
-            elif in_malfunction:
-                candidate_entry_point = agent.current_entry_point
-                candidate_next_entry_point = agent.next_entry_point
-            #  (3b.3) map entry
-            elif action_valid and (
-                (state == TrainState.READY_TO_DEPART and movement_action_given)
-                # design (issue #280): MALFUNCTION_OFF_MAP intentionally does not go via READY_TO_DEPART -
-                # a movement action adds it to the map directly if possible, same as MOVING's own
-                # straight-to-MOVING shortcut in _handle_malfunction_off_map. A STOP_MOVING action never
-                # promotes it (_handle_malfunction_off_map only checks movement_action_given), so it is
-                # deliberately excluded here - including it would hand the distribute phase a candidate
-                # that never gets committed, an optimistic mismatch with no compensating benefit.
-                or (state == TrainState.MALFUNCTION_OFF_MAP and earliest_departure_reached
-                    and movement_action_given)
-            ):
-                candidate_entry_point = initial_entry_point
-                candidate_next_entry_point = candidate_entry_point_independent
-            # (3b.5) on-map cell transition
-            elif is_on_map and is_cell_exit and candidate_entry_point_independent is not None and state == TrainState.MOVING:
-                # design: actions applied at cell entry -- attempt the already-decided target
-                # (guaranteed on-map by is_on_map above); this step's action instead decides the
-                # look-ahead beyond it (candidate_entry_point_independent, computed above in (2)).
-                candidate_entry_point = agent.next_entry_point
-                candidate_next_entry_point = candidate_entry_point_independent
-            # (3b.2bis/3b.4/3b.6) unchanged - start-moving-from-stop, off-map-stay, and cell-stay
-            # (mid-cell / attempted-but-denied) all set the identical "keep current" candidate - a
-            # pure identity copy of already-valid current/next_entry_point, so it can't violate the
-            # off/on-map invariant that already held.
-            else:
-                candidate_entry_point = agent.current_entry_point
-                candidate_next_entry_point = agent.next_entry_point
-
-            assert (candidate_entry_point, candidate_next_entry_point) == (_verify_candidate_entry_point, _verify_candidate_next_entry_point), \
-                f"_candidate_entry_points diverged from inline (3b): inline={(candidate_entry_point, candidate_next_entry_point)} " \
-                f"_candidate_entry_points={(_verify_candidate_entry_point, _verify_candidate_next_entry_point)} agent={i_agent} state={state} " \
-                f"in_malfunction={in_malfunction} action={action} action_valid={action_valid}"
+            candidate_speed = self._candidate_speed(
+                pre_speed=pre_speed,
+                pre_offset=pre_offset,
+                action=action,
+                pre_current_entry_point=agent.current_entry_point,
+                pre_done=pre_done,
+                candidate_entry_point=candidate_entry_point,
+                in_malfunction=in_malfunction,
+                candidate_entry_point_independent=candidate_entry_point_independent,
+                agent_targets=agent.targets,
+                agent_max_speed=agent_max_speed,
+            )
 
             if self.check_step_pre_post_conditions:
                 self._check_off_on_map_invariant(candidate_entry_point, candidate_next_entry_point)
@@ -1141,21 +1069,22 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
         accepted" derivation (assertions there become a return statement here).
 
         N.B. known gap, to be revisited: dropped the original assertions' `agent.target_entry_point`
-        cross-checks and the "stay off map" branch's `agent.speed_counter.distance is None` cross-check
-        (both unrelated to the speed value itself, the latter already covered by
-        _check_state_off_on_map_invariant) - callers should not rely on this method for those.
+        cross-checks (unrelated to the speed value itself) - callers should not rely on this method for
+        that distinction.
+
+        design: mirrors _candidate_entry_points - every branch below always returns the real
+        collect-phase placeholder value, matching step()'s own (3a) convention of never skipping
+        computation for a done/malfunctioning/off-map/invalid-action agent (see the loop's own N.B.
+        comment). The real post-step agent.speed_counter.speed is None instead of this value exactly
+        when off map or removed at target - callers must guard that separately (see
+        _check_post_speed_distance_speedup_invariants's own elif branches), not rely on this method's
+        return value for the None case.
         """
         # done or target reached
         if pre_done or candidate_entry_point in agent_targets:
-            # handle_done_state() clears position and nulls speed_counter (speed/distance both None) on
-            # the exact step the agent reaches DONE and gets removed.
-            if self.remove_agents_at_target:
-                return None
             return Fraction(0)
         # malfunction
         if in_malfunction:
-            if pre_current_entry_point is None:
-                return None
             return Fraction(0)
         # map entry - candidate_entry_point is exactly predictive of a real map entry here, same as
         # _candidate_distance's own "map entry" branch.
@@ -1163,8 +1092,9 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
             return _cap_speed(agent_max_speed, self.acceleration_delta)
         # stay off map
         if pre_current_entry_point is None:
-            return None
-        # invalid action at cell transition
+            return Fraction(0)
+        # invalid action at cell exit - see _candidate_distance's own docstring for why only this one
+        # (not _candidate_distance) needs the explicit is_cell_exit gate.
         is_cell_exit = pre_offset is None or (pre_offset + pre_speed >= SEGMENT_LENGTH)
         if candidate_entry_point_independent is None and is_cell_exit:
             return Fraction(0)
@@ -1252,18 +1182,26 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
                     elapsed_steps=self._elapsed_steps,
                     candidate_entry_point_independent=candidate_entry_point_independent,
                 )
-                assert agent.speed_counter.speed == self._candidate_speed(
-                    pre_speed=pre_speed,
-                    pre_offset=pre_step.pre_offsets[h],
-                    action=action,
-                    pre_current_entry_point=pre_step.pre_current_entry_points[h],
-                    pre_done=pre_step.pre_dones[h],
-                    candidate_entry_point=candidate_entry_point,
-                    in_malfunction=pre_step.pre_in_malfunctions[h],
-                    candidate_entry_point_independent=candidate_entry_point_independent,
-                    agent_targets=agent.targets,
-                    agent_max_speed=agent.speed_counter.max_speed,
-                )
+                # _candidate_speed never returns None (see its own docstring) - the real post-step speed
+                # is None instead exactly when removed at target or still/again off map, mirroring
+                # _check_post_position_update_invariants's own remove_agents_at_target guard.
+                if self.remove_agents_at_target and (pre_step.pre_dones[h] or candidate_entry_point in agent.targets):
+                    assert agent.speed_counter.speed is None
+                elif candidate_entry_point is None:
+                    assert agent.speed_counter.speed is None
+                else:
+                    assert agent.speed_counter.speed == self._candidate_speed(
+                        pre_speed=pre_speed,
+                        pre_offset=pre_step.pre_offsets[h],
+                        action=action,
+                        pre_current_entry_point=pre_step.pre_current_entry_points[h],
+                        pre_done=pre_step.pre_dones[h],
+                        candidate_entry_point=candidate_entry_point,
+                        in_malfunction=pre_step.pre_in_malfunctions[h],
+                        candidate_entry_point_independent=candidate_entry_point_independent,
+                        agent_targets=agent.targets,
+                        agent_max_speed=agent.speed_counter.max_speed,
+                    )
 
     def _infrastructure_representation(self, entry_point: EntryPointT) -> str:
         raise NotImplementedError()

--- a/flatland/envs/rail_env.py
+++ b/flatland/envs/rail_env.py
@@ -532,6 +532,21 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
                 candidate_speed = agent.speed_counter.speed
             candidate_speed = _cap_speed(agent_max_speed, candidate_speed)
 
+            # verification: _candidate_entry_points (used by _check_post_position_invariants) should
+            # reproduce exactly the same (candidate_entry_point, candidate_next_entry_point) as the
+            # inline (3b) derivation below, given the same pre-step values.
+            # _verify_candidate_entry_point, _verify_candidate_next_entry_point = self._candidate_entry_points(
+            #     action=action,
+            #     agent=agent,
+            #     pre_current_entry_point=agent.current_entry_point,
+            #     pre_next_entry_point=agent.next_entry_point,
+            #     pre_speed=agent.speed_counter.speed,
+            #     pre_offset=agent.speed_counter.distance,
+            #     pre_done=agent.target_entry_point is not None,
+            #     pre_in_malfunction=in_malfunction,
+            #     elapsed_steps=self._elapsed_steps,
+            # )
+
             # (3b) POSITION UPDATE - mirrors _check_post_position_invariants's "candidates accepted"
             # derivation: done/malfunction/map-entry/on-map-transition/stay.
             # (3b.1) done
@@ -577,6 +592,11 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
             else:
                 candidate_entry_point = agent.current_entry_point
                 candidate_next_entry_point = agent.next_entry_point
+
+            # assert (candidate_entry_point, candidate_next_entry_point) == (_verify_candidate_entry_point, _verify_candidate_next_entry_point), \
+            #     f"_candidate_entry_points diverged from inline (3b): inline={(candidate_entry_point, candidate_next_entry_point)} " \
+            #     f"_candidate_entry_points={(_verify_candidate_entry_point, _verify_candidate_next_entry_point)} agent={i_agent} state={state} " \
+            #     f"in_malfunction={in_malfunction} action={action} action_valid={action_valid}"
 
             if self.check_step_pre_post_conditions:
                 self._check_off_on_map_invariant(candidate_entry_point, candidate_next_entry_point)
@@ -810,15 +830,16 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
         """
         The expected (current, next) entry point pair for this step, given action + pre-step values
         (`elapsed_steps` included as one, i.e. `self._elapsed_steps` after its own (0) increment, same
-        as loop 1 sees it) -
+        as loop 1 sees it; `pre_done` is `agent.target_entry_point is not None`, NOT `self.dones` - see
+        the "already done" branch below) -
         verbatim-adapted from _check_post_position_invariants's own "candidates accepted in distribute
         phase" derivation (assertions there become return statements here), so both step()'s own (3b)
         POSITION UPDATE and the post-step check call this one, identically shaped, implementation.
 
-        N.B. known gap, to be revisited: does not yet special-case done / remove_agents_at_target
-        the way the original assertions did (dropped the `agent.current_entry_point ==
-        agent.target_entry_point` cross-check, which doesn't fit an (current, next) return shape) -
-        callers should not yet rely on this method alone for the done/target-removal distinction.
+        N.B. known gap, to be revisited: dropped the original assertions' `agent.current_entry_point ==
+        agent.target_entry_point` cross-check (which specific target alternative was reached), since it
+        doesn't fit an (current, next) return shape - callers should not rely on this method for that
+        distinction.
         """
         is_on_map = pre_next_entry_point is not None
         is_cell_exit = pre_speed is not None and pre_speed > 0 and pre_offset + pre_speed >= SEGMENT_LENGTH
@@ -853,9 +874,8 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
             candidate_next_entry_point = pre_next_entry_point
 
         # done
+        # N.B. Covers both remove_agents_at_target cases.
         if pre_done:
-            if self.remove_agents_at_target:
-                return None, None
             return pre_current_entry_point, pre_next_entry_point
         # in malfunction
         if pre_in_malfunction:
@@ -945,7 +965,7 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
             pre_speeds={agent.handle: agent.speed_counter.speed for agent in self.agents},
             pre_current_entry_points={agent.handle: agent.current_entry_point for agent in self.agents},
             pre_next_entry_points={agent.handle: agent.next_entry_point for agent in self.agents},
-            pre_dones={agent.handle: self.dones[agent.handle] for agent in self.agents},
+            pre_dones={agent.handle: agent.target_entry_point is not None for agent in self.agents},
             pre_in_malfunctions={agent.handle: agent.malfunction_handler.in_malfunction for agent in self.agents},
             pre_offsets={agent.handle: agent.speed_counter.distance for agent in self.agents},
         )

--- a/flatland/envs/rail_env.py
+++ b/flatland/envs/rail_env.py
@@ -421,8 +421,11 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
                 agent.current_entry_point = None
                 agent.next_entry_point = None
                 # design: distance is None when off map -- passing speed=None sets distance back
-                # to None exactly when the agent's position leaves the map.
-                agent.speed_counter.step(speed=None, crossing_completed=False)
+                # to None exactly when the agent's position leaves the map. Overrides whatever (10b)
+                # set this step (candidate_speed's own "done or target reached" branch returns
+                # Fraction(0), not None - see its docstring), which is fine since (10b) always runs
+                # strictly before this.
+                agent.speed_counter.set(None, None)
 
     def step(self, action_dict: Dict[int, RailEnvActions]):
         """
@@ -499,11 +502,12 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
             is_cell_exit = agent.speed_counter.is_cell_exit()
             action_valid = not is_cell_exit or candidate_entry_point_independent is not None
 
-            # (3a) SPEED UPDATE / (3b) POSITION UPDATE - delegated to the shared, pre-step-only
-            # candidate_ methods (also used by the post-step checks) instead of duplicating the branch
-            # logic inline here - see _candidate_entry_points/_candidate_speed's own docstrings for the
-            # branch-by-branch derivation. (3b) is computed first since (3a) needs its candidate_entry_point
-            # (the "done or target reached" branch).
+            # (3a) SPEED UPDATE / (3b) POSITION UPDATE / (3c) CANDIDATE DISTANCE - delegated to the
+            # shared, pre-step-only candidate_ methods (also used by the post-step checks) instead of
+            # duplicating the branch logic inline here - see _candidate_entry_points/_candidate_speed/
+            # _candidate_distance's own docstrings for the branch-by-branch derivation. (3b) is computed
+            # first since (3a)/(3c) both need its candidate_entry_point (the "done or target reached"
+            # branch).
             agent_max_speed = agent.speed_counter.max_speed
             pre_speed = agent.speed_counter.speed
             pre_offset = agent.speed_counter.distance
@@ -531,6 +535,18 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
                 candidate_entry_point_independent=candidate_entry_point_independent,
                 agent_targets=agent.targets,
                 agent_max_speed=agent_max_speed,
+            )
+            # (3c) CANDIDATE DISTANCE - computed once here for the distribute phase's (10b) to read,
+            # mirroring (3a)'s candidate_speed (previously only the post-step checks called
+            # _candidate_distance; (10b) re-derived an equivalent distance itself via SpeedCounter.step()).
+            candidate_distance = self._candidate_distance(
+                pre_speed=pre_speed,
+                pre_offset=pre_offset,
+                pre_done=pre_done,
+                candidate_entry_point=candidate_entry_point,
+                in_malfunction=in_malfunction,
+                candidate_entry_point_independent=candidate_entry_point_independent,
+                agent_targets=agent.targets,
             )
 
             if self.check_step_pre_post_conditions:
@@ -581,6 +597,7 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
             self.temp_transition_data[i_agent].candidate_entry_point = candidate_entry_point
             self.temp_transition_data[i_agent].candidate_next_entry_point = candidate_next_entry_point
             self.temp_transition_data[i_agent].candidate_speed = candidate_speed
+            self.temp_transition_data[i_agent].candidate_distance = candidate_distance
 
             self.resource_check.add_agent(i_agent, current_resource, new_resource)
 
@@ -640,65 +657,36 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
                 if not pre_done:
                     agent.state_machine.update_if_reached(candidate_entry_point, agent.targets)
 
-            # (10b) SPEED_COUNTER UPDATE (SPEED AND DISTANCE)
-            if agent.state == TrainState.MOVING and agent_transition_data.speed == 0:
-                # design (D1): pre-step speed 0 -> distance held unchanged this step
-                # (SpeedCounter.step() with crossing_completed=False and old self._speed==0 is a no-op
-                # on distance); speed ramps from rest via this step's candidate_speed
-                # (acceleration_delta). The following step, now genuinely pre-speed>0, is the one that
-                # actually completes the crossing (see (3b.5)/(10a) above).
-                agent.speed_counter.step(speed=agent_transition_data.candidate_speed, crossing_completed=False)
-            elif agent.state == TrainState.MOVING:
-                crossing_completed = (agent.old_entry_point != candidate_entry_point) and resource_check
-                # N.B. map entry (previous state READY_TO_DEPART/MALFUNCTION_OFF_MAP) also flows through
-                # here: candidate_speed is already acceleration_delta (see (3a.3)), and speed_counter.step()
-                # bootstraps distance to 0 for an off-map -> on-map transition regardless of crossing_completed.
-                speed = agent_transition_data.candidate_speed
-                # design: reaching or remaining in MOVING requires movement_allowed (see (9), state_machine's
-                # _handle_moving/_handle_stopped/_handle_ready_to_depart/_handle_malfunction_off_map/
-                # _handle_malfunction all gate a transition into MOVING on movement_action_given and
-                # movement_allowed) - so action_valid and resource_check are always True here; distance
-                # advances by the pre-step speed and, if the crossing genuinely completed
-                # (agent.old_entry_point != candidate_entry_point), wraps into the new cell
-                # (distance % SEGMENT_LENGTH) - otherwise it's a normal within-cell advance.
-                agent.speed_counter.step(speed=speed, crossing_completed=crossing_completed)
-            elif agent.state == TrainState.STOPPED and agent.state_machine.previous_state == TrainState.MOVING:
-                crossing_completed = (agent.old_entry_point != candidate_entry_point) and resource_check
-                speed = Fraction(0)
-                if not agent_transition_data.state_transition_signal.action_valid or not resource_check:
-                    # MOVING -> STOPPED via invalid action at the cell boundary, or resource_check
-                    # denying the crossing to another agent: distance still advances by the pre-step
-                    # speed (SpeedCounter.step() -> _distance_update() adds pre-step speed
-                    # unconditionally) but is clamped at the cell boundary (min(pre_distance +
-                    # pre_speed, SEGMENT_LENGTH)) instead of wrapping into the new cell - the agent
-                    # travels up to the boundary this step, it just isn't credited with crossing it.
-                    # This banking is intentional, not a (D1) violation, in both cases: pre_speed is
-                    # always > 0 here (a MOVING agent's pre-step speed can never be 0), so the advance
-                    # is real. What (D1) rules out is a *later*, pre-speed-0 STOPPED->MOVING step
-                    # consuming this banked distance for a free crossing - prevented by (10a)/(10b)'s
-                    # pre-speed-0 deferral above.
-                    agent.speed_counter.step(speed=speed, crossing_completed=crossing_completed)
+            # (10b) SPEED_COUNTER UPDATE (SPEED AND DISTANCE) - candidate_speed/candidate_distance
+            # already computed in the collect phase ((3a)/(3c)); mirrors
+            # _check_post_speed_distance_speedup_invariants's own "discarded vs. accepted" shape (a
+            # single set() call here instead of the assertions there) - both branches gate purely on
+            # resource_check, nothing more granular, and neither needs a crossing_completed flag
+            # (set() derives is_cell_entry internally, from old vs. new distance alone).
+            if not resource_check:
+                # candidates discarded -> speed 0 (None if the agent never made it onto the map this
+                # step - agent.old_entry_point is this step's stable pre-step snapshot, untouched by
+                # (10a) above) and distance capped at the pre-step speed, not credited with the crossing
+                # (SpeedCounter.distance/.speed still hold their pre-step values here - (10a) never
+                # touches speed_counter, and this is (10b)'s own first write to it this step).
+                new_speed = None if agent.old_entry_point is None else Fraction(0)
+                new_distance = SpeedCounter.distance_without_crossing(
+                    agent.speed_counter.distance, agent.speed_counter.speed)
+                agent.speed_counter.set(new_speed, new_distance)
+            else:
+                # candidates accepted - distance is exactly candidate_distance in every case (already
+                # None for "removed at target"/"stayed off map", see _candidate_distance's own
+                # docstring); speed needs the same None guard _check_post_speed_distance_speedup_invariants
+                # itself uses, since _candidate_speed never returns None (see its own docstring) even
+                # though the real post-step speed must be.
+                new_distance = agent_transition_data.candidate_distance
+                if self.remove_agents_at_target and (pre_done or candidate_entry_point in agent.targets):
+                    new_speed = None
+                elif candidate_entry_point is None:
+                    new_speed = None
                 else:
-                    # MOVING -> STOPPED via an explicit STOP_MOVING action that braked candidate_speed to
-                    # exactly 0 this step, action valid and resource_check granted: distance advances by
-                    # the pre-step speed and, if the crossing genuinely completed, wraps into the new cell
-                    # (distance % SEGMENT_LENGTH) - the agent can still complete an already-in-flight cell
-                    # crossing on the very step it comes to a stop.
-                    agent.speed_counter.step(speed=speed, crossing_completed=crossing_completed)
-            elif agent.state.is_on_map_state():
-                # TODO harmonize condition with overleaf - force stop or malfunction
-                agent.speed_counter.stop()
-            elif agent.state.is_off_map_state():
-                # design: speed and distance are None while off map
-                agent.speed_counter.step(speed=None, crossing_completed=False)
-            elif not self.remove_agents_at_target:
-                # design: DONE but not removed is neither on-map nor off-map (see
-                # TrainState.is_on_map_state()/is_off_map_state()) - position stays put, so freeze
-                # speed at 0 instead of setting distance to None (agent.speed_counter.step(None, ...)
-                # is reserved for when the position itself leaves the map, see handle_done_state()).
-                assert agent.state == TrainState.DONE
-                agent.speed_counter.step(speed=Fraction(0), crossing_completed=False)
-            # and calls agent.speed_counter.step(speed=None, ...) itself.
+                    new_speed = agent_transition_data.candidate_speed
+                agent.speed_counter.set(new_speed, new_distance)
 
             # (11) HANDLE DONE STATE ACTIONS, OPTIONALLY REMOVE AGENTS
             self.handle_done_state(agent, candidate_entry_point)

--- a/flatland/envs/rail_env.py
+++ b/flatland/envs/rail_env.py
@@ -747,20 +747,9 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
                                 elapsed_steps: int,
                                 candidate_entry_point_independent: Optional[EntryPointT]) -> Tuple[Optional[EntryPointT], Optional[EntryPointT]]:
         """
-        The expected (current, next) entry point pair for this step, given action + pre-step values
-        (`elapsed_steps` included as one, i.e. `self._elapsed_steps` after its own (0) increment, same
-        as the collect phase sees it; `pre_done` is `agent.target_entry_point is not None`, NOT `self.dones`
-        - see the "already done" branch below; `candidate_entry_point_independent` is
-        pre_step_snapshot.pre_candidate_entry_point_independents[h], precomputed there so
-        self.rail.apply_action_independent() runs once per agent per step, not once per caller) -
-        verbatim-adapted from _check_post_position_invariants's own "candidates accepted in distribute
-        phase" derivation (assertions there become return statements here), so both step()'s own (3b)
-        POSITION UPDATE and the post-step check call this one, identically shaped, implementation.
-
-        N.B. known gap, to be revisited: dropped the original assertions' `agent.current_entry_point ==
-        agent.target_entry_point` cross-check (which specific target alternative was reached), since it
-        doesn't fit an (current, next) return shape - callers should not rely on this method for that
-        distinction.
+        The (optimistic) candidate entry points of collect phase
+        (actions invalid in the grid if cell transition is imminent lead to staying on the cell)
+        to be accepted/rejected by resource check in distribute phase.
         """
         is_on_map = pre_next_entry_point is not None
         is_cell_exit = pre_speed is not None and pre_speed > 0 and pre_offset + pre_speed >= SEGMENT_LENGTH
@@ -776,19 +765,6 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
             ready_to_depart = (agent.earliest_departure <= elapsed_steps)  # no +1: is it READY_TO_DEPART now
         map_entry = (not is_on_map and candidate_entry_point_independent is not None
                      and movement_action_given and ready_to_depart)
-        if map_entry:
-            # (3b.3) map entry
-            candidate_entry_point = agent.initial_entry_point
-            candidate_next_entry_point = candidate_entry_point_independent
-        elif is_on_map and is_cell_exit:
-            # (3b.5) on-map cell transition - candidate_next_entry_point stays None here exactly
-            # when the action was invalid at the boundary (denied by (3b.6)); guarded for below.
-            candidate_entry_point = pre_next_entry_point
-            candidate_next_entry_point = candidate_entry_point_independent
-        else:
-            # (3b.1/3b.2/3b.2bis/3b.4/3b.6) unchanged
-            candidate_entry_point = pre_current_entry_point
-            candidate_next_entry_point = pre_next_entry_point
 
         # done
         # N.B. Covers both remove_agents_at_target cases.
@@ -798,18 +774,18 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
         if pre_in_malfunction:
             return pre_current_entry_point, pre_next_entry_point
         # map entry
-        if pre_current_entry_point is None and candidate_entry_point is not None:
-            return candidate_entry_point, candidate_next_entry_point
+        if map_entry:
+            return agent.initial_entry_point, candidate_entry_point_independent
         # target reached - real entering-target candidate (matches the collect phase's own
         # resource-reservation value, needed there for collision detection); when
         # remove_agents_at_target, the actual clearing to None only happens afterward, in the
         # distribute phase (handle_done_state) - not this method's job (see
         # _check_post_position_invariants's own guard for that).
-        if candidate_entry_point in agent.targets and (pre_speed > 0 and pre_offset + pre_speed >= SEGMENT_LENGTH):
-            return candidate_entry_point, candidate_next_entry_point
+        if is_on_map and is_cell_exit and pre_next_entry_point in agent.targets:
+            return pre_next_entry_point, candidate_entry_point_independent
         # on-map cell transition
-        if candidate_next_entry_point is not None and (pre_speed > 0 and pre_offset + pre_speed >= SEGMENT_LENGTH):
-            return candidate_entry_point, candidate_next_entry_point
+        if is_on_map and is_cell_exit and candidate_entry_point_independent is not None:
+            return pre_next_entry_point, candidate_entry_point_independent
         # stay
         return pre_current_entry_point, pre_next_entry_point
 
@@ -991,22 +967,11 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
                             pre_done: bool, candidate_entry_point: Optional[EntryPointT],
                             in_malfunction: bool, candidate_entry_point_independent: Optional[EntryPointT],
                             agent_targets: Set[EntryPointT]) -> Optional[Fraction]:
+        # TODO revise design: code is unconditional in invalid action!
         """
-        The expected post-step speed_counter.distance for an agent whose candidate was accepted in the
-        distribute phase (self.temp_transition_data[h].resource_check True) - verbatim-adapted from
-        _check_post_speed_distance_speedup_invariants's own "distance update invariant"/"candidates
-        accepted" derivation (assertions there become a return statement here).
-
-        N.B. known gap, to be revisited: dropped the original assertions' `agent.target_entry_point is
-        not None`/`agent.target_entry_point in agent.targets` cross-checks (unrelated to the distance
-        value itself) - callers should not rely on this method for that distinction.
-
-        Unlike _candidate_speed, the "invalid action" branch below needs no is_cell_exit gate: mid-cell
-        (pre_offset + pre_speed < SEGMENT_LENGTH), distance_without_crossing and distance_after_crossing
-        are the exact same formula (min()/modulo both no-op below SEGMENT_LENGTH), and when pre_speed == 0
-        distance_without_crossing(pre_offset, 0) == pre_offset, matching the (D1) branch below it too - so
-        candidate_entry_point_independent is None (pure transition-map invalidity, no cell-exit
-        conflation) is already the exact right condition regardless of position within the cell.
+        The (optimistic) candidate distance of collect phase
+        (actions invalid in the grid if cell transition is imminent lead to pre-step speed added truncated by segment length)
+        to be accepted/rejected by resource check in distribute phase.
         """
         # done
         if pre_done:
@@ -1049,22 +1014,9 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
                          candidate_entry_point_independent: Optional[EntryPointT], agent_targets: Set[EntryPointT],
                          agent_max_speed: Fraction) -> Optional[Fraction]:
         """
-        The expected post-step speed_counter.speed for an agent whose candidate was accepted in the
-        distribute phase (self.temp_transition_data[h].resource_check True) - verbatim-adapted from
-        _check_post_speed_distance_speedup_invariants's own "speed update invariant"/"candidates
-        accepted" derivation (assertions there become a return statement here).
-
-        N.B. known gap, to be revisited: dropped the original assertions' `agent.target_entry_point`
-        cross-checks (unrelated to the speed value itself) - callers should not rely on this method for
-        that distinction.
-
-        design: mirrors _candidate_entry_points - every branch below always returns the real
-        collect-phase placeholder value, matching step()'s own (3a) convention of never skipping
-        computation for a done/malfunctioning/off-map/invalid-action agent (see the loop's own N.B.
-        comment). The real post-step agent.speed_counter.speed is None instead of this value exactly
-        when off map or removed at target - callers must guard that separately (see
-        _check_post_speed_distance_speedup_invariants's own elif branches), not rely on this method's
-        return value for the None case.
+        The (optimistic) candidate speed of collect phase
+        (actions invalid in the grid if cell transition is imminent lead to speed 0)
+        to be accepted/rejected by resource check in distribute phase.
         """
         # done or target reached
         if pre_done or candidate_entry_point in agent_targets:

--- a/flatland/envs/rail_env.py
+++ b/flatland/envs/rail_env.py
@@ -551,10 +551,13 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
             elif action_valid and (
                 (state == TrainState.READY_TO_DEPART and movement_action_given)
                 # design (issue #280): MALFUNCTION_OFF_MAP intentionally does not go via READY_TO_DEPART -
-                # STOP_MOVING and MOVE_* both add to map directly if possible, same as MOVING's own
-                # straight-to-MOVING shortcut in _handle_malfunction_off_map.
+                # a movement action adds it to the map directly if possible, same as MOVING's own
+                # straight-to-MOVING shortcut in _handle_malfunction_off_map. A STOP_MOVING action never
+                # promotes it (_handle_malfunction_off_map only checks movement_action_given), so it is
+                # deliberately excluded here - including it would hand loop 2 a candidate that never gets
+                # committed, an optimistic mismatch with no compensating benefit.
                 or (state == TrainState.MALFUNCTION_OFF_MAP and earliest_departure_reached
-                    and (movement_action_given or stop_action_given))
+                    and movement_action_given)
             ):
                 candidate_entry_point = initial_entry_point
                 candidate_next_entry_point = candidate_entry_point_independent

--- a/flatland/envs/rail_env.py
+++ b/flatland/envs/rail_env.py
@@ -457,10 +457,10 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
 
             # N.B. every candidate_ variable in this loop (candidate_speed, candidate_entry_point,
             # candidate_entry_point_independent, candidate_next_entry_point, ...) reflects
-            # the unilateral update of the collect phase (loop 1) - computed from the action alone,
+            # the unilateral update of the collect phase - computed from the action alone,
             # including for an invalid action, which itself just yields a
             # zeroed/unchanged candidate (e.g. candidate_speed = 0) rather than skipping computation
-            # entirely. Distribute phase (loop 2) checks whether the resource check actually granted it.
+            # entirely. The distribute phase checks whether the resource check actually granted it.
 
             # Invariant: both None off-map, both set and different on-map).
 
@@ -535,17 +535,17 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
             # verification: _candidate_entry_points (used by _check_post_position_invariants) should
             # reproduce exactly the same (candidate_entry_point, candidate_next_entry_point) as the
             # inline (3b) derivation below, given the same pre-step values.
-            # _verify_candidate_entry_point, _verify_candidate_next_entry_point = self._candidate_entry_points(
-            #     action=action,
-            #     agent=agent,
-            #     pre_current_entry_point=agent.current_entry_point,
-            #     pre_next_entry_point=agent.next_entry_point,
-            #     pre_speed=agent.speed_counter.speed,
-            #     pre_offset=agent.speed_counter.distance,
-            #     pre_done=agent.target_entry_point is not None,
-            #     pre_in_malfunction=in_malfunction,
-            #     elapsed_steps=self._elapsed_steps,
-            # )
+            _verify_candidate_entry_point, _verify_candidate_next_entry_point = self._candidate_entry_points(
+                action=action,
+                agent=agent,
+                pre_current_entry_point=agent.current_entry_point,
+                pre_next_entry_point=agent.next_entry_point,
+                pre_speed=agent.speed_counter.speed,
+                pre_offset=agent.speed_counter.distance,
+                pre_done=agent.target_entry_point is not None,
+                pre_in_malfunction=in_malfunction,
+                elapsed_steps=self._elapsed_steps,
+            )
 
             # (3b) POSITION UPDATE - mirrors _check_post_position_invariants's "candidates accepted"
             # derivation: done/malfunction/map-entry/on-map-transition/stay.
@@ -571,8 +571,8 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
                 # a movement action adds it to the map directly if possible, same as MOVING's own
                 # straight-to-MOVING shortcut in _handle_malfunction_off_map. A STOP_MOVING action never
                 # promotes it (_handle_malfunction_off_map only checks movement_action_given), so it is
-                # deliberately excluded here - including it would hand loop 2 a candidate that never gets
-                # committed, an optimistic mismatch with no compensating benefit.
+                # deliberately excluded here - including it would hand the distribute phase a candidate
+                # that never gets committed, an optimistic mismatch with no compensating benefit.
                 or (state == TrainState.MALFUNCTION_OFF_MAP and earliest_departure_reached
                     and movement_action_given)
             ):
@@ -593,10 +593,10 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
                 candidate_entry_point = agent.current_entry_point
                 candidate_next_entry_point = agent.next_entry_point
 
-            # assert (candidate_entry_point, candidate_next_entry_point) == (_verify_candidate_entry_point, _verify_candidate_next_entry_point), \
-            #     f"_candidate_entry_points diverged from inline (3b): inline={(candidate_entry_point, candidate_next_entry_point)} " \
-            #     f"_candidate_entry_points={(_verify_candidate_entry_point, _verify_candidate_next_entry_point)} agent={i_agent} state={state} " \
-            #     f"in_malfunction={in_malfunction} action={action} action_valid={action_valid}"
+            assert (candidate_entry_point, candidate_next_entry_point) == (_verify_candidate_entry_point, _verify_candidate_next_entry_point), \
+                f"_candidate_entry_points diverged from inline (3b): inline={(candidate_entry_point, candidate_next_entry_point)} " \
+                f"_candidate_entry_points={(_verify_candidate_entry_point, _verify_candidate_next_entry_point)} agent={i_agent} state={state} " \
+                f"in_malfunction={in_malfunction} action={action} action_valid={action_valid}"
 
             if self.check_step_pre_post_conditions:
                 self._check_off_on_map_invariant(candidate_entry_point, candidate_next_entry_point)
@@ -639,7 +639,7 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
             self.temp_transition_data[i_agent].speed = agent.speed_counter.speed
 
             # design: actions applied at cell entry -- carry this step's attempted target and
-            # look-ahead candidate via per-step scratch data; loop 2 decides whether to promote
+            # look-ahead candidate via per-step scratch data; the distribute phase decides whether to promote
             # the candidate into agent.next_entry_point once the attempt's outcome (motion check)
             # is known. agent.next_entry_point itself is left untouched here so it still holds the
             # value being contested until that outcome is known.
@@ -830,7 +830,7 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
         """
         The expected (current, next) entry point pair for this step, given action + pre-step values
         (`elapsed_steps` included as one, i.e. `self._elapsed_steps` after its own (0) increment, same
-        as loop 1 sees it; `pre_done` is `agent.target_entry_point is not None`, NOT `self.dones` - see
+        as the collect phase sees it; `pre_done` is `agent.target_entry_point is not None`, NOT `self.dones` - see
         the "already done" branch below) -
         verbatim-adapted from _check_post_position_invariants's own "candidates accepted in distribute
         phase" derivation (assertions there become return statements here), so both step()'s own (3b)
@@ -883,10 +883,12 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
         # map entry
         if pre_current_entry_point is None and candidate_entry_point is not None:
             return candidate_entry_point, candidate_next_entry_point
-        # target reached
+        # target reached - real entering-target candidate (matches the collect phase's own
+        # resource-reservation value, needed there for collision detection); when
+        # remove_agents_at_target, the actual clearing to None only happens afterward, in the
+        # distribute phase (handle_done_state) - not this method's job (see
+        # _check_post_position_invariants's own guard for that).
         if candidate_entry_point in agent.targets and (pre_speed > 0 and pre_offset + pre_speed >= SEGMENT_LENGTH):
-            if self.remove_agents_at_target:
-                return None, None
             return candidate_entry_point, candidate_next_entry_point
         # on-map cell transition
         if candidate_next_entry_point is not None and (pre_speed > 0 and pre_offset + pre_speed >= SEGMENT_LENGTH):
@@ -958,7 +960,7 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
         Capture per-agent speed/entry-point/done/malfunction state for the post-step checks
         (`_check_post_speed_distance_invariants`/`_check_post_position_invariants`) to verify the
         post-step update against. Called after (0a)/(0b) so pre_in_malfunctions reflects this step's
-        own malfunction counter update/roll - the same value loop 1's own `in_malfunction` read sees -
+        own malfunction counter update/roll - the same value the collect phase's own `in_malfunction` read sees -
         rather than the previous step's already-stale ending malfunction status.
         """
         return PreStepSnapshot(
@@ -1012,24 +1014,28 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
         """
         for h in pre_step.pre_speeds.keys():
             agent = self.agents[h]
+            action = RailEnvActions.from_value(action_dict.get(h, RailEnvActions.DO_NOTHING))
+            candidate_entry_point, candidate_next_entry_point = self._candidate_entry_points(
+                action=action,
+                agent=agent,
+                pre_current_entry_point=pre_step.pre_current_entry_points[h],
+                pre_next_entry_point=pre_step.pre_next_entry_points[h],
+                pre_speed=pre_step.pre_speeds[h],
+                pre_offset=pre_step.pre_offsets[h],
+                pre_done=pre_step.pre_dones[h],
+                pre_in_malfunction=pre_step.pre_in_malfunctions[h],
+                elapsed_steps=self._elapsed_steps,
+            )
             # candidates discarded in distribute phase -> previous configuration
             if not self.temp_transition_data[h].resource_check:
                 assert agent.current_entry_point == pre_step.pre_current_entry_points[h]
                 assert agent.next_entry_point == pre_step.pre_next_entry_points[h]
+            # target reached and removed
+            elif self.remove_agents_at_target and (pre_step.pre_dones[h] or candidate_entry_point in agent.targets):
+                assert agent.current_entry_point is None
+                assert agent.next_entry_point is None
             # candidates accepted in distribute phase
             else:
-                action = RailEnvActions.from_value(action_dict.get(h, RailEnvActions.DO_NOTHING))
-                candidate_entry_point, candidate_next_entry_point = self._candidate_entry_points(
-                    action=action,
-                    agent=agent,
-                    pre_current_entry_point=pre_step.pre_current_entry_points[h],
-                    pre_next_entry_point=pre_step.pre_next_entry_points[h],
-                    pre_speed=pre_step.pre_speeds[h],
-                    pre_offset=pre_step.pre_offsets[h],
-                    pre_done=pre_step.pre_dones[h],
-                    pre_in_malfunction=pre_step.pre_in_malfunctions[h],
-                    elapsed_steps=self._elapsed_steps,
-                )
                 assert agent.current_entry_point == candidate_entry_point
                 assert agent.next_entry_point == candidate_next_entry_point
 

--- a/flatland/envs/rail_env.py
+++ b/flatland/envs/rail_env.py
@@ -660,18 +660,20 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
             # (10b) SPEED_COUNTER UPDATE (SPEED AND DISTANCE) - candidate_speed/candidate_distance
             # already computed in the collect phase ((3a)/(3c)); mirrors
             # _check_post_speed_distance_speedup_invariants's own "discarded vs. accepted" shape (a
-            # single set() call here instead of the assertions there) - both branches gate purely on
-            # resource_check, nothing more granular, and neither needs a crossing_completed flag
-            # (set() derives is_cell_entry internally, from old vs. new distance alone).
-            if not resource_check:
-                # candidates discarded -> speed 0 (None if the agent never made it onto the map this
-                # step - agent.old_entry_point is this step's stable pre-step snapshot, untouched by
-                # (10a) above) and distance capped at the pre-step speed, not credited with the crossing
-                # (SpeedCounter.distance/.speed still hold their pre-step values here - (10a) never
-                # touches speed_counter, and this is (10b)'s own first write to it this step).
-                new_speed = None if agent.old_entry_point is None else Fraction(0)
-                new_distance = SpeedCounter.distance_without_crossing(
-                    agent.speed_counter.distance, agent.speed_counter.speed)
+            # single set() call here instead of the assertions there).
+            if not resource_check and agent.old_entry_point is None:
+                # off map pre-step (agent.old_entry_point is this step's stable pre-step snapshot,
+                # untouched by (10a) above), denied map-entry attempt - speed_counter is already
+                # (None, None) here (the off-map invariant), and distance_without_crossing(None, None)
+                # is None too, so this is already exactly right: a true no-op.
+                pass
+            elif not resource_check:
+                # on-map, candidate discarded -> speed forced to 0 and distance capped at the pre-step
+                # speed, not credited with the (denied) crossing (SpeedCounter.distance/.speed still
+                # hold their pre-step values here - (10a) never touches speed_counter, and this is
+                # (10b)'s own first write to it this step).
+                new_speed = Fraction(0)
+                new_distance = SpeedCounter.distance_without_crossing(agent.speed_counter.distance, agent.speed_counter.speed)
                 agent.speed_counter.set(new_speed, new_distance)
             else:
                 # candidates accepted - distance is exactly candidate_distance in every case (already

--- a/flatland/envs/rail_env.py
+++ b/flatland/envs/rail_env.py
@@ -6,7 +6,7 @@ import random
 import warnings
 from fractions import Fraction
 from functools import lru_cache
-from typing import List, Optional, Dict, Tuple, Any, Generic, TypeVar, NamedTuple
+from typing import List, Optional, Dict, Tuple, Any, Generic, TypeVar, NamedTuple, Set
 
 import numpy as np
 
@@ -1039,6 +1039,105 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
                 assert agent.current_entry_point == candidate_entry_point
                 assert agent.next_entry_point == candidate_next_entry_point
 
+    def _candidate_distance(self, pre_speed: Optional[Fraction], pre_offset: Optional[Fraction],
+                            pre_done: bool, candidate_entry_point: Optional[EntryPointT],
+                            in_malfunction: bool, action_valid: bool,
+                            agent_targets: Set[EntryPointT]) -> Optional[Fraction]:
+        """
+        The expected post-step speed_counter.distance for an agent whose candidate was accepted in the
+        distribute phase (self.temp_transition_data[h].resource_check True) - verbatim-adapted from
+        _check_post_speed_distance_speedup_invariants's own "distance update invariant"/"candidates
+        accepted" derivation (assertions there become a return statement here).
+
+        N.B. known gap, to be revisited: dropped the original assertions' `agent.target_entry_point is
+        not None`/`agent.target_entry_point in agent.targets` cross-checks (unrelated to the distance
+        value itself) - callers should not rely on this method for that distinction.
+        """
+        # done
+        if pre_done:
+            return SpeedCounter.distance_without_crossing(pre_offset, pre_speed)
+        # target reached
+        if candidate_entry_point in agent_targets:
+            if self.remove_agents_at_target:
+                return None
+            return SpeedCounter.distance_without_crossing(pre_offset, pre_speed)
+        # off map (stayed off map) / map entry - candidate_entry_point is exactly predictive of a real
+        # map entry here (the optimistic MALFUNCTION_OFF_MAP+STOP_MOVING mismatch was closed by
+        # excluding stop_action_given from (3b.3)'s condition).
+        if pre_offset is None and candidate_entry_point is None:
+            return None
+        if pre_offset is None and candidate_entry_point is not None:
+            return Fraction(0)
+        # malfunction
+        if in_malfunction:
+            return pre_offset
+        # invalid action
+        if not action_valid:
+            # design: an invalid action denies the crossing attempt at the cell boundary, same
+            # consequence as a resource_check denial (see the caller's top-level "candidates discarded"
+            # branch, and (10b)'s matching MOVING->STOPPED branch in step()) - distance banks up to the
+            # boundary, it just isn't credited with crossing it. pre_speed is always > 0 here (a MOVING
+            # agent's pre-step speed can never be 0).
+            return SpeedCounter.distance_without_crossing(pre_offset, pre_speed)
+        # stopped, or stopped -> moving (or malfunction recovering)
+        # (D1): pre-step speed 0 must never advance distance this step, whether the agent stays STOPPED
+        # (a plain no-op) or is promoted to MOVING - (10a)/(10b)'s pre-speed-0 deferral in step() defers
+        # any crossing to the following (genuinely positive-pre-speed) step.
+        if pre_speed == 0:
+            return pre_offset
+        return SpeedCounter.distance_after_crossing(pre_offset, pre_speed)
+
+    def _candidate_speed(self, pre_speed: Optional[Fraction], action: RailEnvActions,
+                         pre_current_entry_point: Optional[EntryPointT], pre_done: bool,
+                         candidate_entry_point: Optional[EntryPointT], in_malfunction: bool,
+                         action_valid: bool, agent_targets: Set[EntryPointT],
+                         agent_max_speed: Fraction) -> Optional[Fraction]:
+        """
+        The expected post-step speed_counter.speed for an agent whose candidate was accepted in the
+        distribute phase (self.temp_transition_data[h].resource_check True) - verbatim-adapted from
+        _check_post_speed_distance_speedup_invariants's own "speed update invariant"/"candidates
+        accepted" derivation (assertions there become a return statement here).
+
+        N.B. known gap, to be revisited: dropped the original assertions' `agent.target_entry_point`
+        cross-checks and the "stay off map" branch's `agent.speed_counter.distance is None` cross-check
+        (both unrelated to the speed value itself, the latter already covered by
+        _check_state_off_on_map_invariant) - callers should not rely on this method for those.
+        """
+        # done or target reached
+        if pre_done or candidate_entry_point in agent_targets:
+            # handle_done_state() clears position and nulls speed_counter (speed/distance both None) on
+            # the exact step the agent reaches DONE and gets removed.
+            if self.remove_agents_at_target:
+                return None
+            return Fraction(0)
+        # malfunction
+        if in_malfunction:
+            if pre_current_entry_point is None:
+                return None
+            return Fraction(0)
+        # map entry - candidate_entry_point is exactly predictive of a real map entry here, same as
+        # _candidate_distance's own "map entry" branch.
+        if pre_current_entry_point is None and candidate_entry_point is not None:
+            return _cap_speed(agent_max_speed, self.acceleration_delta)
+        # stay off map
+        if pre_current_entry_point is None:
+            return None
+        # invalid action
+        if not action_valid:
+            return Fraction(0)
+        # acceleration or start moving
+        if action == RailEnvActions.MOVE_FORWARD or (pre_speed == 0 and RailEnvActions.is_moving_action(action)):
+            # pre_speed is None while WAITING (not yet departing this step) -
+            # speed_after_acceleration(None, ...) == None matches that case too.
+            return SpeedCounter.speed_after_acceleration(pre_speed, agent_max_speed, self.acceleration_delta)
+        # braking
+        if action == RailEnvActions.STOP_MOVING:
+            # pre_speed is None for WAITING/READY_TO_DEPART/MALFUNCTION_OFF_MAP -
+            # speed_after_braking(None, ...) == None matches that case too.
+            return SpeedCounter.speed_after_braking(pre_speed, self.braking_delta)
+        # default
+        return pre_speed
+
     def _check_post_speed_distance_speedup_invariants(self, action_dict: Dict[int, RailEnvActions],
                                                       pre_step: PreStepSnapshot) -> None:
         """
@@ -1059,51 +1158,15 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
 
             # candidates accepted in distribute phase
             else:
-                action_valid = self.temp_transition_data[h].state_transition_signal.action_valid
-                # done
-                if pre_step.pre_dones[h]:
-                    assert agent.target_entry_point is not None
-                    assert agent.target_entry_point in agent.targets
-                    assert agent.speed_counter.distance == SpeedCounter.distance_without_crossing(
-                        pre_step.pre_offsets[h], pre_speed)
-                # target reached
-                elif self.temp_transition_data[h].candidate_entry_point in agent.targets:
-                    assert agent.target_entry_point is not None
-                    assert agent.target_entry_point in agent.targets
-                    if self.remove_agents_at_target:
-                        assert agent.speed_counter.distance is None
-                    else:
-                        assert agent.speed_counter.distance == SpeedCounter.distance_without_crossing(
-                            pre_step.pre_offsets[h], pre_speed)
-                # off map (stayed off map) / map entry - self.temp_transition_data[h].candidate_entry_point
-                # is exactly predictive of a real map entry here (the optimistic MALFUNCTION_OFF_MAP+
-                # STOP_MOVING mismatch was closed by excluding stop_action_given from (3b.3)'s condition).
-                elif pre_step.pre_offsets[h] is None and self.temp_transition_data[h].candidate_entry_point is None:
-                    assert agent.speed_counter.distance is None
-                elif pre_step.pre_offsets[h] is None and self.temp_transition_data[h].candidate_entry_point is not None:
-                    assert agent.speed_counter.distance == 0
-                # malfunction
-                elif agent.malfunction_handler.in_malfunction:
-                    assert agent.speed_counter.distance == pre_step.pre_offsets[h]
-                # invalid action
-                elif not action_valid:
-                    # design: an invalid action denies the crossing attempt at the cell boundary, same
-                    # consequence as a resource_check denial (see the top-level "candidates discarded"
-                    # branch above, and (10b)'s matching MOVING->STOPPED branch in step()) - distance
-                    # banks up to the boundary, it just isn't credited with crossing it. pre_speed is
-                    # always > 0 here (a MOVING agent's pre-step speed can never be 0).
-                    assert agent.speed_counter.distance == SpeedCounter.distance_without_crossing(
-                        pre_step.pre_offsets[h], pre_speed)
-                # stopped, or stopped -> moving (or malfunction recovering)
-                # (D1): pre-step speed 0 must never advance distance this step, whether the agent
-                # stays STOPPED (a plain no-op) or is promoted to MOVING - (10a)/(10b)'s pre-speed-0
-                # deferral in step() defers any crossing to the following (genuinely positive-pre-speed)
-                # step.
-                elif pre_speed == 0:
-                    assert agent.speed_counter.distance == pre_step.pre_offsets[h]
-                else:
-                    assert agent.speed_counter.distance == SpeedCounter.distance_after_crossing(
-                        pre_step.pre_offsets[h], pre_speed)
+                assert agent.speed_counter.distance == self._candidate_distance(
+                    pre_speed=pre_speed,
+                    pre_offset=pre_step.pre_offsets[h],
+                    pre_done=pre_step.pre_dones[h],
+                    candidate_entry_point=self.temp_transition_data[h].candidate_entry_point,
+                    in_malfunction=agent.malfunction_handler.in_malfunction,
+                    action_valid=self.temp_transition_data[h].state_transition_signal.action_valid,
+                    agent_targets=agent.targets,
+                )
 
         # speed update invariant
         for h, pre_speed in pre_step.pre_speeds.items():
@@ -1119,49 +1182,17 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
                     assert agent.speed_counter.speed == 0
             # candidates accepted in distribute phase
             else:
-                action_valid = self.temp_transition_data[h].state_transition_signal.action_valid
-                # done or target reached
-                if pre_step.pre_dones[h] or self.temp_transition_data[h].candidate_entry_point in agent.targets:
-                    assert agent.target_entry_point is not None
-                    assert agent.target_entry_point in agent.targets
-                    if self.remove_agents_at_target:
-                        # handle_done_state() clears position and nulls speed_counter (speed/distance
-                        # both None) on the exact step the agent reaches DONE and gets removed.
-                        assert agent.speed_counter.speed is None
-                    else:
-                        assert agent.speed_counter.speed == Fraction(0)
-                # malfunction
-                elif agent.malfunction_handler.in_malfunction:
-                    if pre_step.pre_current_entry_points[h] is None:
-                        assert agent.speed_counter.speed is None
-                    else:
-                        assert agent.speed_counter.speed == 0
-                # map entry - self.temp_transition_data[h].candidate_entry_point is exactly predictive of
-                # a real map entry here, same as the distance-update loop's "map entry" branch above.
-                elif pre_step.pre_current_entry_points[h] is None and self.temp_transition_data[h].candidate_entry_point is not None:
-                    assert agent.speed_counter.speed == _cap_speed(agent.speed_counter.max_speed,
-                                                                    self.acceleration_delta)
-                # stay off map
-                elif pre_step.pre_current_entry_points[h] is None:
-                    assert agent.speed_counter.speed is None
-                    assert agent.speed_counter.distance is None
-                # invalid action
-                elif not action_valid:
-                    assert agent.speed_counter.speed == 0
-                # acceleration or start moving
-                elif action == RailEnvActions.MOVE_FORWARD or (pre_speed == 0 and RailEnvActions.is_moving_action(action)):
-                    # pre_speed is None while WAITING (not yet departing this step) -
-                    # speed_after_acceleration(None, ...) == None matches that case too.
-                    assert agent.speed_counter.speed == SpeedCounter.speed_after_acceleration(
-                        pre_speed, agent.speed_counter.max_speed, self.acceleration_delta)
-                # braking
-                elif action == RailEnvActions.STOP_MOVING:
-                    # pre_speed is None for WAITING/READY_TO_DEPART/MALFUNCTION_OFF_MAP -
-                    # speed_after_braking(None, ...) == None matches that case too.
-                    assert agent.speed_counter.speed == SpeedCounter.speed_after_braking(pre_speed, self.braking_delta)
-                # default
-                else:
-                    assert agent.speed_counter.speed == pre_speed
+                assert agent.speed_counter.speed == self._candidate_speed(
+                    pre_speed=pre_speed,
+                    action=action,
+                    pre_current_entry_point=pre_step.pre_current_entry_points[h],
+                    pre_done=pre_step.pre_dones[h],
+                    candidate_entry_point=self.temp_transition_data[h].candidate_entry_point,
+                    in_malfunction=agent.malfunction_handler.in_malfunction,
+                    action_valid=self.temp_transition_data[h].state_transition_signal.action_valid,
+                    agent_targets=agent.targets,
+                    agent_max_speed=agent.speed_counter.max_speed,
+                )
 
     def _infrastructure_representation(self, entry_point: EntryPointT) -> str:
         raise NotImplementedError()

--- a/flatland/envs/rail_env.py
+++ b/flatland/envs/rail_env.py
@@ -49,6 +49,7 @@ class PreStepSnapshot(NamedTuple):
     pre_dones: Dict[int, bool]
     pre_in_malfunctions: Dict[int, bool]
     pre_offsets: Dict[int, Optional[Fraction]]
+    pre_candidate_entry_point_independents: Dict[int, Optional[EntryPointT]]
 
 
 class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPointT]):
@@ -445,7 +446,10 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
         # (0b) GENERATE NEW MALFUNCTIONS AND OTHER RANDOM EFFECTS
         self.effects_generator.on_episode_step_start(self)
 
-        pre_step_snapshot = self._capture_pre_step_snapshot() if self.check_step_pre_post_conditions else None
+        # N.B. captured unconditionally, not gated behind check_step_pre_post_conditions like the checks
+        # that otherwise consume it - the collect phase's own (2) CANDIDATE ENTRY POINT block below relies
+        # on pre_candidate_entry_point_independents regardless of whether checks are enabled.
+        pre_step_snapshot = self._capture_pre_step_snapshot(action_dict)
 
         for agent in self.agents:
             i_agent = agent.handle
@@ -483,12 +487,11 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
 
             # (2) CANDIDATE ENTRY POINT: action validity - need both by speed update (3a) and position update (3b) below
             is_on_map = agent.next_entry_point is not None
-            # whether the action leads to a valid transition
-            if is_on_map:
-                candidate_entry_point_independent = self.rail.apply_action_independent(action, agent.next_entry_point)
-            else:
-                # TODO this is wrong: if done, we should not try to reservee the initial edge!
-                candidate_entry_point_independent = self.rail.apply_action_independent(action, initial_entry_point)
+            # whether the action leads to a valid transition - precomputed in pre_step_snapshot so
+            # self.rail.apply_action_independent() runs exactly once per agent per step (also read by
+            # _candidate_entry_points/_candidate_speed/_candidate_distance below, via the post-step checks)
+            # TODO this is wrong: if done, we should not try to reservee the initial edge!
+            candidate_entry_point_independent = pre_step_snapshot.pre_candidate_entry_point_independents[i_agent]
 
             # mid cell or valid transition (only invalid actions are non-L/R on symmetric switches)
             is_cell_exit = agent.speed_counter.is_cell_exit()
@@ -545,6 +548,7 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
                 pre_done=agent.target_entry_point is not None,
                 pre_in_malfunction=in_malfunction,
                 elapsed_steps=self._elapsed_steps,
+                candidate_entry_point_independent=candidate_entry_point_independent,
             )
 
             # (3b) POSITION UPDATE - mirrors _check_post_position_invariants's "candidates accepted"
@@ -819,32 +823,6 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
     def _is_speed_zero(self, candidate_speed: Fraction) -> bool:
         return candidate_speed == 0.0
 
-    def _action_valid(self, action: RailEnvActions, agent: EnvAgent,
-                      pre_next_entry_point: Optional[EntryPointT],
-                      pre_speed: Optional[Fraction], pre_offset: Optional[Fraction]) -> bool:
-        """
-        Whether `action` leads to a valid transition, derived from pre-step values/action alone -
-        verbatim-adapted from the same is_cell_exit/candidate_entry_point_independent/action_valid
-        derivation as step()'s own (2) CANDIDATE ENTRY POINT block and _candidate_entry_points' internal
-        computation (kept separate from the latter since _candidate_entry_points doesn't expose
-        candidate_entry_point_independent, and needs its own copy for the map-entry/on-map-transition
-        candidates regardless).
-        """
-        is_on_map = pre_next_entry_point is not None
-        if is_on_map:
-            candidate_entry_point_independent = self.rail.apply_action_independent(action, pre_next_entry_point)
-        else:
-            candidate_entry_point_independent = self.rail.apply_action_independent(action, agent.initial_entry_point)
-        # SpeedCounter.is_cell_exit() contract: True off map (self._distance is None), else
-        # distance + speed >= SEGMENT_LENGTH - deliberately NOT gated on speed > 0 (a STOPPED agent
-        # banked exactly at the boundary, pre_speed == 0, still counts as at cell exit). Unlike
-        # _candidate_entry_points' own is_cell_exit reconstruction - which folds in a pre_speed > 0 guard
-        # as a state-free proxy for state == MOVING, since its is_cell_exit is only ever used ANDed with
-        # is_on_map in the (3b.5) branch - action_valid is used off-map too and needs the real,
-        # state-independent geometric definition, not that proxy.
-        is_cell_exit = pre_offset is None or (pre_offset + pre_speed >= SEGMENT_LENGTH)
-        return not is_cell_exit or candidate_entry_point_independent is not None
-
     def _candidate_entry_points(self, action: RailEnvActions, agent: EnvAgent,
                                 pre_current_entry_point: Optional[EntryPointT],
                                 pre_next_entry_point: Optional[EntryPointT],
@@ -852,12 +830,15 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
                                 pre_offset: Optional[Fraction],
                                 pre_done: bool,
                                 pre_in_malfunction: bool,
-                                elapsed_steps: int) -> Tuple[Optional[EntryPointT], Optional[EntryPointT]]:
+                                elapsed_steps: int,
+                                candidate_entry_point_independent: Optional[EntryPointT]) -> Tuple[Optional[EntryPointT], Optional[EntryPointT]]:
         """
         The expected (current, next) entry point pair for this step, given action + pre-step values
         (`elapsed_steps` included as one, i.e. `self._elapsed_steps` after its own (0) increment, same
-        as the collect phase sees it; `pre_done` is `agent.target_entry_point is not None`, NOT `self.dones` - see
-        the "already done" branch below) -
+        as the collect phase sees it; `pre_done` is `agent.target_entry_point is not None`, NOT `self.dones`
+        - see the "already done" branch below; `candidate_entry_point_independent` is
+        pre_step_snapshot.pre_candidate_entry_point_independents[h], precomputed there so
+        self.rail.apply_action_independent() runs once per agent per step, not once per caller) -
         verbatim-adapted from _check_post_position_invariants's own "candidates accepted in distribute
         phase" derivation (assertions there become return statements here), so both step()'s own (3b)
         POSITION UPDATE and the post-step check call this one, identically shaped, implementation.
@@ -869,10 +850,6 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
         """
         is_on_map = pre_next_entry_point is not None
         is_cell_exit = pre_speed is not None and pre_speed > 0 and pre_offset + pre_speed >= SEGMENT_LENGTH
-        if is_on_map:
-            candidate_entry_point_independent = self.rail.apply_action_independent(action, pre_next_entry_point)
-        else:
-            candidate_entry_point_independent = self.rail.apply_action_independent(action, agent.initial_entry_point)
 
         # (3b.3) map entry: derived purely from pre-step values/action, deliberately not from state.
         # ready_to_depart reproduces "is state already READY_TO_DEPART this step" without reading state -
@@ -981,14 +958,43 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
 
         self._verify_mutually_exclusive_resource_allocation()
 
-    def _capture_pre_step_snapshot(self) -> PreStepSnapshot:
+    def _capture_pre_step_snapshot(self, action_dict: Dict[int, RailEnvActions]) -> PreStepSnapshot:
         """
-        Capture per-agent speed/entry-point/done/malfunction state for the post-step checks
+        Capture per-agent speed/entry-point/done/malfunction state for the collect phase's own (2)
+        CANDIDATE ENTRY POINT block and the post-step checks
         (`_check_post_speed_distance_invariants`/`_check_post_position_invariants`) to verify the
         post-step update against. Called after (0a)/(0b) so pre_in_malfunctions reflects this step's
         own malfunction counter update/roll - the same value the collect phase's own `in_malfunction` read sees -
         rather than the previous step's already-stale ending malfunction status.
+
+        pre_candidate_entry_point_independents is computed here (rather than by each of its several
+        callers - step()'s own (2), _candidate_entry_points, _candidate_speed, _candidate_distance) so
+        self.rail.apply_action_independent() runs exactly once per agent per step, not once per caller.
+
+        N.B. ugly but deliberate: pre_candidate_entry_point_independents is filled in unconditionally
+        (step()'s own (2) block needs it regardless of check_step_pre_post_conditions), but the other six
+        fields are only ever read by the post-step checks below - so when check_step_pre_post_conditions
+        is False, they're left empty rather than paying for six wasted per-agent dict builds every step
+        (see e.g. examples/flatland_performance_profiling.py's get_rail_env(), which disables checks
+        specifically to profile step()'s own cost).
         """
+        pre_candidate_entry_point_independents = {
+            agent.handle: self.rail.apply_action_independent(
+                RailEnvActions.from_value(action_dict.get(agent.handle, RailEnvActions.DO_NOTHING)),
+                agent.next_entry_point if agent.next_entry_point is not None else agent.initial_entry_point
+            )
+            for agent in self.agents
+        }
+        if not self.check_step_pre_post_conditions:
+            return PreStepSnapshot(
+                pre_speeds={},
+                pre_current_entry_points={},
+                pre_next_entry_points={},
+                pre_dones={},
+                pre_in_malfunctions={},
+                pre_offsets={},
+                pre_candidate_entry_point_independents=pre_candidate_entry_point_independents,
+            )
         return PreStepSnapshot(
             pre_speeds={agent.handle: agent.speed_counter.speed for agent in self.agents},
             pre_current_entry_points={agent.handle: agent.current_entry_point for agent in self.agents},
@@ -996,6 +1002,7 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
             pre_dones={agent.handle: agent.target_entry_point is not None for agent in self.agents},
             pre_in_malfunctions={agent.handle: agent.malfunction_handler.in_malfunction for agent in self.agents},
             pre_offsets={agent.handle: agent.speed_counter.distance for agent in self.agents},
+            pre_candidate_entry_point_independents=pre_candidate_entry_point_independents,
         )
 
     def _check_off_on_map_invariant(self, current_entry_point: EntryPointT, next_entry_point: EntryPointT):
@@ -1051,6 +1058,7 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
                 pre_done=pre_step.pre_dones[h],
                 pre_in_malfunction=pre_step.pre_in_malfunctions[h],
                 elapsed_steps=self._elapsed_steps,
+                candidate_entry_point_independent=pre_step.pre_candidate_entry_point_independents[h],
             )
             # candidates discarded in distribute phase -> previous configuration
             if not self.temp_transition_data[h].resource_check:
@@ -1067,7 +1075,7 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
 
     def _candidate_distance(self, pre_speed: Optional[Fraction], pre_offset: Optional[Fraction],
                             pre_done: bool, candidate_entry_point: Optional[EntryPointT],
-                            in_malfunction: bool, action_valid: bool,
+                            in_malfunction: bool, candidate_entry_point_independent: Optional[EntryPointT],
                             agent_targets: Set[EntryPointT]) -> Optional[Fraction]:
         """
         The expected post-step speed_counter.distance for an agent whose candidate was accepted in the
@@ -1078,6 +1086,13 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
         N.B. known gap, to be revisited: dropped the original assertions' `agent.target_entry_point is
         not None`/`agent.target_entry_point in agent.targets` cross-checks (unrelated to the distance
         value itself) - callers should not rely on this method for that distinction.
+
+        Unlike _candidate_speed, the "invalid action" branch below needs no is_cell_exit gate: mid-cell
+        (pre_offset + pre_speed < SEGMENT_LENGTH), distance_without_crossing and distance_after_crossing
+        are the exact same formula (min()/modulo both no-op below SEGMENT_LENGTH), and when pre_speed == 0
+        distance_without_crossing(pre_offset, 0) == pre_offset, matching the (D1) branch below it too - so
+        candidate_entry_point_independent is None (pure transition-map invalidity, no cell-exit
+        conflation) is already the exact right condition regardless of position within the cell.
         """
         # done
         if pre_done:
@@ -1098,7 +1113,7 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
         if in_malfunction:
             return pre_offset
         # invalid action
-        if not action_valid:
+        if candidate_entry_point_independent is None:
             # design: an invalid action denies the crossing attempt at the cell boundary, same
             # consequence as a resource_check denial (see the caller's top-level "candidates discarded"
             # branch, and (10b)'s matching MOVING->STOPPED branch in step()) - distance banks up to the
@@ -1113,10 +1128,11 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
             return pre_offset
         return SpeedCounter.distance_after_crossing(pre_offset, pre_speed)
 
-    def _candidate_speed(self, pre_speed: Optional[Fraction], action: RailEnvActions,
+    def _candidate_speed(self, pre_speed: Optional[Fraction], pre_offset: Optional[Fraction],
+                         action: RailEnvActions,
                          pre_current_entry_point: Optional[EntryPointT], pre_done: bool,
                          candidate_entry_point: Optional[EntryPointT], in_malfunction: bool,
-                         action_valid: bool, agent_targets: Set[EntryPointT],
+                         candidate_entry_point_independent: Optional[EntryPointT], agent_targets: Set[EntryPointT],
                          agent_max_speed: Fraction) -> Optional[Fraction]:
         """
         The expected post-step speed_counter.speed for an agent whose candidate was accepted in the
@@ -1148,8 +1164,9 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
         # stay off map
         if pre_current_entry_point is None:
             return None
-        # invalid action
-        if not action_valid:
+        # invalid action at cell transition
+        is_cell_exit = pre_offset is None or (pre_offset + pre_speed >= SEGMENT_LENGTH)
+        if candidate_entry_point_independent is None and is_cell_exit:
             return Fraction(0)
         # acceleration or start moving
         if action == RailEnvActions.MOVE_FORWARD or (pre_speed == 0 and RailEnvActions.is_moving_action(action)):
@@ -1185,6 +1202,7 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
             # candidates accepted in distribute phase
             else:
                 action = RailEnvActions.from_value(action_dict.get(h, RailEnvActions.DO_NOTHING))
+                candidate_entry_point_independent = pre_step.pre_candidate_entry_point_independents[h]
                 candidate_entry_point, _ = self._candidate_entry_points(
                     action=action,
                     agent=agent,
@@ -1195,6 +1213,7 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
                     pre_done=pre_step.pre_dones[h],
                     pre_in_malfunction=pre_step.pre_in_malfunctions[h],
                     elapsed_steps=self._elapsed_steps,
+                    candidate_entry_point_independent=candidate_entry_point_independent,
                 )
                 assert agent.speed_counter.distance == self._candidate_distance(
                     pre_speed=pre_speed,
@@ -1202,13 +1221,7 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
                     pre_done=pre_step.pre_dones[h],
                     candidate_entry_point=candidate_entry_point,
                     in_malfunction=pre_step.pre_in_malfunctions[h],
-                    action_valid=self._action_valid(
-                        action=action,
-                        agent=agent,
-                        pre_next_entry_point=pre_step.pre_next_entry_points[h],
-                        pre_speed=pre_speed,
-                        pre_offset=pre_step.pre_offsets[h],
-                    ),
+                    candidate_entry_point_independent=candidate_entry_point_independent,
                     agent_targets=agent.targets,
                 )
 
@@ -1226,6 +1239,7 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
                     assert agent.speed_counter.speed == 0
             # candidates accepted in distribute phase
             else:
+                candidate_entry_point_independent = pre_step.pre_candidate_entry_point_independents[h]
                 candidate_entry_point, _ = self._candidate_entry_points(
                     action=action,
                     agent=agent,
@@ -1236,21 +1250,17 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
                     pre_done=pre_step.pre_dones[h],
                     pre_in_malfunction=pre_step.pre_in_malfunctions[h],
                     elapsed_steps=self._elapsed_steps,
+                    candidate_entry_point_independent=candidate_entry_point_independent,
                 )
                 assert agent.speed_counter.speed == self._candidate_speed(
                     pre_speed=pre_speed,
+                    pre_offset=pre_step.pre_offsets[h],
                     action=action,
                     pre_current_entry_point=pre_step.pre_current_entry_points[h],
                     pre_done=pre_step.pre_dones[h],
                     candidate_entry_point=candidate_entry_point,
                     in_malfunction=pre_step.pre_in_malfunctions[h],
-                    action_valid=self._action_valid(
-                        action=action,
-                        agent=agent,
-                        pre_next_entry_point=pre_step.pre_next_entry_points[h],
-                        pre_speed=pre_speed,
-                        pre_offset=pre_step.pre_offsets[h],
-                    ),
+                    candidate_entry_point_independent=candidate_entry_point_independent,
                     agent_targets=agent.targets,
                     agent_max_speed=agent.speed_counter.max_speed,
                 )

--- a/flatland/envs/rail_env.py
+++ b/flatland/envs/rail_env.py
@@ -819,6 +819,32 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
     def _is_speed_zero(self, candidate_speed: Fraction) -> bool:
         return candidate_speed == 0.0
 
+    def _action_valid(self, action: RailEnvActions, agent: EnvAgent,
+                      pre_next_entry_point: Optional[EntryPointT],
+                      pre_speed: Optional[Fraction], pre_offset: Optional[Fraction]) -> bool:
+        """
+        Whether `action` leads to a valid transition, derived from pre-step values/action alone -
+        verbatim-adapted from the same is_cell_exit/candidate_entry_point_independent/action_valid
+        derivation as step()'s own (2) CANDIDATE ENTRY POINT block and _candidate_entry_points' internal
+        computation (kept separate from the latter since _candidate_entry_points doesn't expose
+        candidate_entry_point_independent, and needs its own copy for the map-entry/on-map-transition
+        candidates regardless).
+        """
+        is_on_map = pre_next_entry_point is not None
+        if is_on_map:
+            candidate_entry_point_independent = self.rail.apply_action_independent(action, pre_next_entry_point)
+        else:
+            candidate_entry_point_independent = self.rail.apply_action_independent(action, agent.initial_entry_point)
+        # SpeedCounter.is_cell_exit() contract: True off map (self._distance is None), else
+        # distance + speed >= SEGMENT_LENGTH - deliberately NOT gated on speed > 0 (a STOPPED agent
+        # banked exactly at the boundary, pre_speed == 0, still counts as at cell exit). Unlike
+        # _candidate_entry_points' own is_cell_exit reconstruction - which folds in a pre_speed > 0 guard
+        # as a state-free proxy for state == MOVING, since its is_cell_exit is only ever used ANDed with
+        # is_on_map in the (3b.5) branch - action_valid is used off-map too and needs the real,
+        # state-independent geometric definition, not that proxy.
+        is_cell_exit = pre_offset is None or (pre_offset + pre_speed >= SEGMENT_LENGTH)
+        return not is_cell_exit or candidate_entry_point_independent is not None
+
     def _candidate_entry_points(self, action: RailEnvActions, agent: EnvAgent,
                                 pre_current_entry_point: Optional[EntryPointT],
                                 pre_next_entry_point: Optional[EntryPointT],
@@ -1158,13 +1184,31 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
 
             # candidates accepted in distribute phase
             else:
+                action = RailEnvActions.from_value(action_dict.get(h, RailEnvActions.DO_NOTHING))
+                candidate_entry_point, _ = self._candidate_entry_points(
+                    action=action,
+                    agent=agent,
+                    pre_current_entry_point=pre_step.pre_current_entry_points[h],
+                    pre_next_entry_point=pre_step.pre_next_entry_points[h],
+                    pre_speed=pre_speed,
+                    pre_offset=pre_step.pre_offsets[h],
+                    pre_done=pre_step.pre_dones[h],
+                    pre_in_malfunction=pre_step.pre_in_malfunctions[h],
+                    elapsed_steps=self._elapsed_steps,
+                )
                 assert agent.speed_counter.distance == self._candidate_distance(
                     pre_speed=pre_speed,
                     pre_offset=pre_step.pre_offsets[h],
                     pre_done=pre_step.pre_dones[h],
-                    candidate_entry_point=self.temp_transition_data[h].candidate_entry_point,
-                    in_malfunction=agent.malfunction_handler.in_malfunction,
-                    action_valid=self.temp_transition_data[h].state_transition_signal.action_valid,
+                    candidate_entry_point=candidate_entry_point,
+                    in_malfunction=pre_step.pre_in_malfunctions[h],
+                    action_valid=self._action_valid(
+                        action=action,
+                        agent=agent,
+                        pre_next_entry_point=pre_step.pre_next_entry_points[h],
+                        pre_speed=pre_speed,
+                        pre_offset=pre_step.pre_offsets[h],
+                    ),
                     agent_targets=agent.targets,
                 )
 
@@ -1182,14 +1226,31 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
                     assert agent.speed_counter.speed == 0
             # candidates accepted in distribute phase
             else:
+                candidate_entry_point, _ = self._candidate_entry_points(
+                    action=action,
+                    agent=agent,
+                    pre_current_entry_point=pre_step.pre_current_entry_points[h],
+                    pre_next_entry_point=pre_step.pre_next_entry_points[h],
+                    pre_speed=pre_speed,
+                    pre_offset=pre_step.pre_offsets[h],
+                    pre_done=pre_step.pre_dones[h],
+                    pre_in_malfunction=pre_step.pre_in_malfunctions[h],
+                    elapsed_steps=self._elapsed_steps,
+                )
                 assert agent.speed_counter.speed == self._candidate_speed(
                     pre_speed=pre_speed,
                     action=action,
                     pre_current_entry_point=pre_step.pre_current_entry_points[h],
                     pre_done=pre_step.pre_dones[h],
-                    candidate_entry_point=self.temp_transition_data[h].candidate_entry_point,
-                    in_malfunction=agent.malfunction_handler.in_malfunction,
-                    action_valid=self.temp_transition_data[h].state_transition_signal.action_valid,
+                    candidate_entry_point=candidate_entry_point,
+                    in_malfunction=pre_step.pre_in_malfunctions[h],
+                    action_valid=self._action_valid(
+                        action=action,
+                        agent=agent,
+                        pre_next_entry_point=pre_step.pre_next_entry_points[h],
+                        pre_speed=pre_speed,
+                        pre_offset=pre_step.pre_offsets[h],
+                    ),
                     agent_targets=agent.targets,
                     agent_max_speed=agent.speed_counter.max_speed,
                 )

--- a/flatland/envs/rail_env.py
+++ b/flatland/envs/rail_env.py
@@ -430,8 +430,8 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
         if self.dones["__all__"]:
             raise Exception("Episode is done, cannot call step()")
 
-        pre_step_snapshot = self._check_pre_step_invariants_and_capture_snapshot() \
-            if self.check_step_pre_post_conditions else None
+        if self.check_step_pre_post_conditions:
+            self._check_pre_post_invariants()
 
         self.clear_rewards_dict()
 
@@ -444,6 +444,8 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
 
         # (0b) GENERATE NEW MALFUNCTIONS AND OTHER RANDOM EFFECTS
         self.effects_generator.on_episode_step_start(self)
+
+        pre_step_snapshot = self._capture_pre_step_snapshot() if self.check_step_pre_post_conditions else None
 
         for agent in self.agents:
             i_agent = agent.handle
@@ -530,21 +532,6 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
                 candidate_speed = agent.speed_counter.speed
             candidate_speed = _cap_speed(agent_max_speed, candidate_speed)
 
-            # verification: _candidate_entry_points (used by _check_post_position_invariants) should
-            # reproduce exactly the same (candidate_entry_point, candidate_next_entry_point) as the
-            # inline (3b) derivation below, given the same pre-step values - temporary cross-check
-            # while (3b.3)'s map-entry condition (only knowable from genuinely pre-step data, not from
-            # self.temp_transition_data which isn't populated yet at this point in loop 1) is reworked.
-            # _verify_candidate_entry_point, _verify_candidate_next_entry_point = self._candidate_entry_points(
-            #     action=action,
-            #     agent=agent,
-            #     pre_current_entry_point=agent.current_entry_point,
-            #     pre_next_entry_point=agent.next_entry_point,
-            #     pre_speed=agent.speed_counter.speed,
-            #     pre_offset=agent.speed_counter.distance,
-            #     pre_done=self.dones[i_agent],
-            # )
-
             # (3b) POSITION UPDATE - mirrors _check_post_position_invariants's "candidates accepted"
             # derivation: done/malfunction/map-entry/on-map-transition/stay.
             # (3b.1) done
@@ -590,11 +577,6 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
             else:
                 candidate_entry_point = agent.current_entry_point
                 candidate_next_entry_point = agent.next_entry_point
-
-            # assert (candidate_entry_point, candidate_next_entry_point) == (_verify_candidate_entry_point, _verify_candidate_next_entry_point), \
-            #     f"_candidate_entry_points diverged from inline (3b): inline={(candidate_entry_point, candidate_next_entry_point)} " \
-            #     f"_candidate_entry_points={(_verify_candidate_entry_point, _verify_candidate_next_entry_point)} agent={i_agent} state={state} " \
-            #     f"in_malfunction={in_malfunction} action={action} action_valid={action_valid}"
 
             if self.check_step_pre_post_conditions:
                 self._check_off_on_map_invariant(candidate_entry_point, candidate_next_entry_point)
@@ -795,10 +777,10 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
         self.effects_generator.on_episode_step_end(self, action_dict=action_dict)
 
         if self.check_step_pre_post_conditions:
-            self._check_malfunction_state_invariant()
-            self._verify_mutually_exclusive_resource_allocation()
-            self._check_post_speed_distance_invariants(action_dict, pre_step_snapshot)
-            self._check_post_position_invariants(action_dict, pre_step_snapshot)
+            self._check_pre_post_invariants()
+            self._check_malfunction_state_invariant() # only holds after env.step()!
+            self._check_post_speed_distance_speedup_invariants(action_dict, pre_step_snapshot)
+            self._check_post_position_update_invariants(action_dict, pre_step_snapshot)
 
         return self._get_observations(), self.rewards_dict, self.dones, self.get_info_dict()
 
@@ -822,9 +804,13 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
                                 pre_next_entry_point: Optional[EntryPointT],
                                 pre_speed: Optional[Fraction],
                                 pre_offset: Optional[Fraction],
-                                pre_done: bool) -> Tuple[Optional[EntryPointT], Optional[EntryPointT]]:
+                                pre_done: bool,
+                                pre_in_malfunction: bool,
+                                elapsed_steps: int) -> Tuple[Optional[EntryPointT], Optional[EntryPointT]]:
         """
-        The expected (current, next) entry point pair for this step, given action + pre-step values -
+        The expected (current, next) entry point pair for this step, given action + pre-step values
+        (`elapsed_steps` included as one, i.e. `self._elapsed_steps` after its own (0) increment, same
+        as loop 1 sees it) -
         verbatim-adapted from _check_post_position_invariants's own "candidates accepted in distribute
         phase" derivation (assertions there become return statements here), so both step()'s own (3b)
         POSITION UPDATE and the post-step check call this one, identically shaped, implementation.
@@ -841,11 +827,18 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
         else:
             candidate_entry_point_independent = self.rail.apply_action_independent(action, agent.initial_entry_point)
 
-        # loop 1's own (3b.3) candidate is exactly predictive of a real map entry here: the
-        # optimistic MALFUNCTION_OFF_MAP+STOP_MOVING mismatch that used to require a post-hoc
-        # agent.current_entry_point read instead was closed by excluding stop_action_given from
-        # (3b.3)'s condition (see step()'s own comment there).
-        if not is_on_map and self.temp_transition_data[agent.handle].candidate_entry_point is not None:
+        # (3b.3) map entry: derived purely from pre-step values/action, deliberately not from state.
+        # ready_to_depart reproduces "is state already READY_TO_DEPART this step" without reading state -
+        # NOT the same as state_transition_signal.earliest_departure_reached (elapsed_steps + 1), which is
+        # deliberately signalled one step early to drive next step's WAITING->READY_TO_DEPART transition.
+        movement_action_given = RailEnvActions.is_moving_action(action)
+        if elapsed_steps == 1:
+            ready_to_depart = (agent.earliest_departure == 0)  # no "step 0" exists, so this is the base case
+        else:
+            ready_to_depart = (agent.earliest_departure <= elapsed_steps)  # no +1: is it READY_TO_DEPART now
+        map_entry = (not is_on_map and candidate_entry_point_independent is not None
+                     and movement_action_given and ready_to_depart)
+        if map_entry:
             # (3b.3) map entry
             candidate_entry_point = agent.initial_entry_point
             candidate_next_entry_point = candidate_entry_point_independent
@@ -865,7 +858,7 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
                 return None, None
             return pre_current_entry_point, pre_next_entry_point
         # in malfunction
-        if agent.malfunction_handler.in_malfunction:
+        if pre_in_malfunction:
             return pre_current_entry_point, pre_next_entry_point
         # map entry
         if pre_current_entry_point is None and candidate_entry_point is not None:
@@ -915,11 +908,11 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
                         msgs += msg
             assert len(resources) == len(set(resources)), msgs
 
-    def _check_pre_step_invariants_and_capture_snapshot(self) -> PreStepSnapshot:
+    def _check_pre_post_invariants(self) -> None:
         """
-        Verify the current_entry_point/next_entry_point invariant holds before `step()` runs, and
-        capture per-agent speed/entry-point/done state for `_check_post_speed_invariants()` to later
-        verify the post-step speed update against.
+        Verify the current_entry_point/next_entry_point invariant holds before `step()` runs (i.e.
+        the configuration left behind by the previous step, before this step's own (0a)/(0b) malfunction
+        processing runs).
         """
         for agent in self.agents:
             # invariant: current_entry_point/next_entry_point are either both None (off-map) or
@@ -938,6 +931,16 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
             self._check_state_off_on_map_invariant(current_entry_point, agent.speed_counter.speed,
                                                    agent.speed_counter.distance, agent.state, agent.target_entry_point)
 
+        self._verify_mutually_exclusive_resource_allocation()
+
+    def _capture_pre_step_snapshot(self) -> PreStepSnapshot:
+        """
+        Capture per-agent speed/entry-point/done/malfunction state for the post-step checks
+        (`_check_post_speed_distance_invariants`/`_check_post_position_invariants`) to verify the
+        post-step update against. Called after (0a)/(0b) so pre_in_malfunctions reflects this step's
+        own malfunction counter update/roll - the same value loop 1's own `in_malfunction` read sees -
+        rather than the previous step's already-stale ending malfunction status.
+        """
         return PreStepSnapshot(
             pre_speeds={agent.handle: agent.speed_counter.speed for agent in self.agents},
             pre_current_entry_points={agent.handle: agent.current_entry_point for agent in self.agents},
@@ -969,7 +972,7 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
         meaningful paired with a real (not candidate) configuration - a *candidate* configuration (not
         yet committed) paired with the agent's *pre-step* speed_counter/state would compare two
         different points in time, so this is called only from
-        `_check_pre_step_invariants_and_capture_snapshot`, never from step()'s (3b) POSITION UPDATE
+        `_check_pre_step_invariants`, never from step()'s (3b) POSITION UPDATE
         (which calls only `_check_off_on_map_invariant`).
         """
         assert (current_entry_point is None) == (speed is None) == (distance is None)
@@ -981,8 +984,8 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
         else:
             assert (current_entry_point is None) == state.is_off_map_state()
 
-    def _check_post_position_invariants(self, action_dict: Dict[int, RailEnvActions],
-                                        pre_step: PreStepSnapshot) -> None:
+    def _check_post_position_update_invariants(self, action_dict: Dict[int, RailEnvActions],
+                                               pre_step: PreStepSnapshot) -> None:
         """
         Verify, for every agent, that this step's position update matches the expected transition given the
         pre-step snapshot captured.
@@ -1004,12 +1007,14 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
                     pre_speed=pre_step.pre_speeds[h],
                     pre_offset=pre_step.pre_offsets[h],
                     pre_done=pre_step.pre_dones[h],
+                    pre_in_malfunction=pre_step.pre_in_malfunctions[h],
+                    elapsed_steps=self._elapsed_steps,
                 )
                 assert agent.current_entry_point == candidate_entry_point
                 assert agent.next_entry_point == candidate_next_entry_point
 
-    def _check_post_speed_distance_invariants(self, action_dict: Dict[int, RailEnvActions],
-                                              pre_step: PreStepSnapshot) -> None:
+    def _check_post_speed_distance_speedup_invariants(self, action_dict: Dict[int, RailEnvActions],
+                                                      pre_step: PreStepSnapshot) -> None:
         """
         Verify, for every agent, that this step's speed update matches the expected transition given the
         pre-step snapshot.

--- a/flatland/envs/rail_env.py
+++ b/flatland/envs/rail_env.py
@@ -966,7 +966,6 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
                             pre_done: bool, candidate_entry_point: Optional[EntryPointT],
                             in_malfunction: bool, candidate_entry_point_independent: Optional[EntryPointT],
                             agent_targets: Set[EntryPointT]) -> Optional[Fraction]:
-        # TODO revise design: code is unconditional in invalid action!
         """
         The (optimistic) candidate distance of collect phase
         (actions invalid in the grid if cell transition is imminent lead to pre-step speed added truncated by segment length)
@@ -990,8 +989,9 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
         # malfunction
         if in_malfunction:
             return pre_offset
-        # invalid action
-        if candidate_entry_point_independent is None:
+        # invalid action at cell exit
+        is_cell_exit = pre_offset + pre_speed >= SEGMENT_LENGTH
+        if candidate_entry_point_independent is None and is_cell_exit:
             # design: an invalid action denies the crossing attempt at the cell boundary, same
             # consequence as a resource_check denial (see the caller's top-level "candidates discarded"
             # branch, and (10b)'s matching MOVING->STOPPED branch in step()) - distance banks up to the

--- a/flatland/envs/rail_env.py
+++ b/flatland/envs/rail_env.py
@@ -922,7 +922,11 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
                 else:
                     candidate_entry_point_independent = self.rail.apply_action_independent(action, agent.initial_entry_point)
 
-                if not is_on_map and agent.current_entry_point is not None:
+                # loop 1's own (3b.3) candidate is exactly predictive of a real map entry here: the
+                # optimistic MALFUNCTION_OFF_MAP+STOP_MOVING mismatch that used to require a post-hoc
+                # agent.current_entry_point read instead was closed by excluding stop_action_given from
+                # (3b.3)'s condition (see step()'s own comment there).
+                if not is_on_map and self.temp_transition_data[h].candidate_entry_point is not None:
                     # (3b.3) map entry
                     candidate_entry_point = agent.initial_entry_point
                     candidate_next_entry_point = candidate_entry_point_independent
@@ -1014,16 +1018,12 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
                     else:
                         assert agent.speed_counter.distance == SpeedCounter.distance_without_crossing(
                             pre_step.pre_offsets[h], pre_speed)
-                # off map (stayed off map) / map entry - genuinely post-hoc: whether map entry actually
-                # happened isn't decided by resource_check/in_malfunction alone, it also needs the state
-                # machine to have promoted to MOVING (e.g. a MALFUNCTION_OFF_MAP/READY_TO_DEPART agent
-                # given STOP_MOVING can get an optimistic non-None candidate_entry_point from loop 1's
-                # (3b.3) yet never be promoted - see issue #280) - so this can't be dedup'd against
-                # self.temp_transition_data[h].candidate_entry_point the way the discarded/malfunction
-                # branches above/below are.
-                elif pre_step.pre_offsets[h] is None and agent.current_entry_point is None:
+                # off map (stayed off map) / map entry - self.temp_transition_data[h].candidate_entry_point
+                # is exactly predictive of a real map entry here (the optimistic MALFUNCTION_OFF_MAP+
+                # STOP_MOVING mismatch was closed by excluding stop_action_given from (3b.3)'s condition).
+                elif pre_step.pre_offsets[h] is None and self.temp_transition_data[h].candidate_entry_point is None:
                     assert agent.speed_counter.distance is None
-                elif pre_step.pre_offsets[h] is None and agent.current_entry_point is not None:
+                elif pre_step.pre_offsets[h] is None and self.temp_transition_data[h].candidate_entry_point is not None:
                     assert agent.speed_counter.distance == 0
                 # malfunction
                 elif agent.malfunction_handler.in_malfunction:
@@ -1079,11 +1079,9 @@ class AbstractRailEnv(Environment, Generic[TransitionMapT, ResourceMapT, EntryPo
                         assert agent.speed_counter.speed is None
                     else:
                         assert agent.speed_counter.speed == 0
-                # map entry - genuinely post-hoc, same reason as the distance-update loop's "map entry"
-                # branch above: can't be dedup'd against self.temp_transition_data[h].candidate_entry_point,
-                # since that candidate can be optimistically non-None (loop 1's (3b.3)) without the state
-                # machine ever actually promoting to MOVING this step (see issue #280).
-                elif pre_step.pre_current_entry_points[h] is None and agent.current_entry_point is not None:
+                # map entry - self.temp_transition_data[h].candidate_entry_point is exactly predictive of
+                # a real map entry here, same as the distance-update loop's "map entry" branch above.
+                elif pre_step.pre_current_entry_points[h] is None and self.temp_transition_data[h].candidate_entry_point is not None:
                     assert agent.speed_counter.speed == _cap_speed(agent.speed_counter.max_speed,
                                                                     self.acceleration_delta)
                 # stay off map

--- a/flatland/envs/step_utils/env_utils.py
+++ b/flatland/envs/step_utils/env_utils.py
@@ -14,5 +14,4 @@ class AgentTransitionData:
     candidate_entry_point: Tuple[Tuple[int, int], int] = None
     candidate_next_entry_point: Tuple[Tuple[int, int], int] = None
     candidate_distance: Optional[Fraction] = None
-    action_valid: bool = False
     resource_check: bool = False

--- a/flatland/envs/step_utils/env_utils.py
+++ b/flatland/envs/step_utils/env_utils.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from fractions import Fraction
-from typing import Tuple
+from typing import Optional, Tuple
 
 from flatland.envs.step_utils.states import StateTransitionSignals
 
@@ -13,5 +13,6 @@ class AgentTransitionData:
     state_transition_signal: StateTransitionSignals
     candidate_entry_point: Tuple[Tuple[int, int], int] = None
     candidate_next_entry_point: Tuple[Tuple[int, int], int] = None
+    candidate_distance: Optional[Fraction] = None
     action_valid: bool = False
     resource_check: bool = False

--- a/flatland/envs/step_utils/speed_counter.py
+++ b/flatland/envs/step_utils/speed_counter.py
@@ -1,7 +1,7 @@
 from decimal import Decimal
 from fractions import Fraction
 from functools import lru_cache
-from typing import Optional, Tuple
+from typing import Optional
 
 import numpy as np
 
@@ -67,27 +67,14 @@ def cached_cell_exit(max_speed: Fraction, speed: Fraction, distance: Fraction) -
     return _cached_cell_exit(distance, speed)
 
 
-@lru_cache()
-def _distance_update(distance: Fraction, speed: Fraction,
-                     crossing_completed: bool = True) -> Tuple[Fraction, bool]:
-    if crossing_completed:
-        # check assumption
-        assert distance + speed >= SEGMENT_LENGTH
-        new_distance = SpeedCounter.distance_after_crossing(distance, speed)
-        return new_distance, new_distance < speed
-
-    # move at most segment end
-    return SpeedCounter.distance_without_crossing(distance, speed), False
-
-
 class SpeedCounter:
     """
     Tracks an agent's speed and within-cell distance as Fractions of SEGMENT_LENGTH. speed/distance are
-    None while off map (see step()) and become concrete Fractions once the agent enters the map.
+    None while off map (see set()) and become concrete Fractions once the agent enters the map.
 
     Four static, lru_cache'd formulas compute the expected post-step speed/distance from explicit
-    pre-step inputs - used internally (e.g. _distance_update()) as well as by RailEnv.step() to compute
-    candidate speed/distance, and again by its post-step invariant checks
+    pre-step inputs - used by RailEnv.step() to compute candidate speed/distance (which set() is then
+    called with directly), and again by its post-step invariant checks
     (_check_post_speed_distance_invariants) to verify the actual post-step values match. They are static
     rather than instance methods since they compute a *candidate* value from explicit pre-step inputs,
     not the counter's own (post-step) state; acceleration_delta/braking_delta are env-level parameters,
@@ -113,34 +100,41 @@ class SpeedCounter:
         self._distance: Optional[Fraction] = None
         self._is_cell_entry = False
 
-    def step(self, speed: Optional[Fraction], crossing_completed: bool) -> None:
+    def set(self, speed: Optional[Fraction], distance: Optional[Fraction]) -> None:
         """
-        Step the speed counter:
-        - the distance traveled this step is computed from the pre-step speed.
-        - the speed is updated to the new speed (modulo capping by max speed).
+        Directly set speed/distance to an already-computed value - e.g. RailEnv.step()'s own
+        candidate_speed/candidate_distance (accepted), or the discarded-candidate formulas
+        (distance_without_crossing/Fraction(0)) when the candidate was rejected. Unlike the old step(),
+        this does not itself derive distance from a crossing decision - the caller has already made
+        that decision; set() only tracks the resulting state and derives is_cell_entry from it.
 
         Parameters
         ----------
         speed : Optional[Fraction]
-            The new speed, effective from the next step, or None while off map (leaving the map,
-            or staying off map).
-        crossing_completed : bool
-            Whether the transition into the next cell actually completed.
+            The new speed, or None while off map (leaving the map, or staying off map).
+        distance : Optional[Fraction]
+            The new within-cell distance, or None while off map. Both speed and distance are None
+            together, or both concrete Fractions together - never mixed (see the class docstring).
         """
-        if speed is None:
-            # design: speed and distance are None when off map
-            self._distance = None
-            self._speed = None
-            self._is_cell_entry = False
-            return
-        if self._distance is None:
-            # design: distance is None when off map -- entering the map: bootstrap distance to 0
-            # instead of advancing from a pre-step speed that does not reflect being on the map yet.
-            self._distance = Fraction(0)
-            self._is_cell_entry = True
-        else:
-            self._distance, self._is_cell_entry = _distance_update(self._distance, self._speed, crossing_completed)
-        self._speed = _cap_speed(self._max_speed, _pseudo_fractional(speed))
+        # design: is_cell_entry is "just entered a new cell" - true exactly when distance dropped
+        # relative to its previous value (a wrap into a new cell), or the agent just bootstrapped onto
+        # the map (previous distance None, new distance concrete). distance never decreases within the
+        # same cell (both distance_after_crossing's modulo and distance_without_crossing's cap only ever
+        # hold or grow it), so "new < old" is unambiguously a crossing, not mid-cell noise. Unlike the
+        # old step()'s new_distance < speed (which reduces to old_distance < SEGMENT_LENGTH under
+        # crossing_completed, wrongly False for an agent banked exactly at the boundary that resumes and
+        # genuinely crosses), this needs no separate crossing_completed flag at all.
+        self._is_cell_entry = (
+            (self._distance is None and distance is not None)
+            or (self._distance is not None and distance is not None and distance < self._distance)
+        )
+        self._distance = distance
+        # design: speed and distance are None together while off map - force speed None whenever
+        # distance is None, regardless of what was passed, so a caller's off-map placeholder speed
+        # (e.g. _candidate_speed's own "stay off map" branch, which always returns Fraction(0) rather
+        # than None - see its docstring) can never leave the two inconsistent.
+        self._speed = (_cap_speed(self._max_speed, _pseudo_fractional(speed))
+                       if (speed is not None and distance is not None) else None)
 
     def stop(self) -> None:
         """
@@ -291,7 +285,7 @@ class SpeedCounter:
                  is_cell_entry: {self.is_cell_entry}"
 
     def reset(self):
-        self.step(None, False)
+        self.set(None, None)
 
     @property
     def is_cell_entry(self):

--- a/tests/test_flatland_envs_observations.py
+++ b/tests/test_flatland_envs_observations.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from fractions import Fraction
 from typing import Callable
 
 import numpy as np
@@ -134,7 +135,7 @@ def test_reward_function_conflict(rendering=False):
     for a in env.agents:
         # design: distance is None when off map -- the agent is placed directly on the map here,
         # bypassing the state machine's own departure step, so bootstrap distance to 0 explicitly.
-        a.speed_counter.step(speed=a.speed_counter.max_speed, crossing_completed=False)
+        a.speed_counter.set(speed=a.speed_counter.max_speed, distance=Fraction(0))
         transition = env.rail.apply_action_independent(RailEnvActions.MOVE_FORWARD, a.current_entry_point)
         assert transition is not None
         a.next_entry_point = _sanitize_entry_point(transition)
@@ -229,7 +230,7 @@ def test_reward_function_waiting(rendering=False):
     for a in env.agents:
         # design: distance is None when off map -- the agent is placed directly on the map here,
         # bypassing the state machine's own departure step, so bootstrap distance to 0 explicitly.
-        a.speed_counter.step(speed=a.speed_counter.max_speed, crossing_completed=False)
+        a.speed_counter.set(speed=a.speed_counter.max_speed, distance=Fraction(0))
         transition = env.rail.apply_action_independent(RailEnvActions.MOVE_FORWARD, a.current_entry_point)
         assert transition is not None
         a.next_entry_point = _sanitize_entry_point(transition)

--- a/tests/test_flatland_envs_rail_env.py
+++ b/tests/test_flatland_envs_rail_env.py
@@ -736,6 +736,150 @@ def test_symmetric_switch_move_forward_action():
     assert agent.speed_counter.distance == Fraction(1, 2)
 
 
+def _assert_speed_distance_match_candidates(env, agent, action_dict):
+    """Capture `agent`'s pre-step values, step `env` with `action_dict`, then assert the real post-step
+    agent.speed_counter.speed/.distance exactly match env._candidate_speed()/env._candidate_distance()
+    (or, when resource_check denies the candidate, the discarded-candidate fallback formulas) computed
+    from those captured pre-step values - the same cross-check RailEnv.step()'s own
+    _check_post_speed_distance_speedup_invariants performs internally after every step, done here
+    explicitly against the candidate_ methods themselves. Returns the real resource_check outcome for
+    `agent` this step, for the caller's own assertions on top.
+    """
+    action = RailEnvActions.from_value(action_dict.get(agent.handle, RailEnvActions.DO_NOTHING))
+    pre_speed = agent.speed_counter.speed
+    pre_offset = agent.speed_counter.distance
+    pre_done = agent.target_entry_point is not None
+    in_malfunction = agent.malfunction_handler.in_malfunction
+    pre_current_entry_point = agent.current_entry_point
+    pre_next_entry_point = agent.next_entry_point
+
+    candidate_entry_point_independent = env.rail.apply_action_independent(
+        action, pre_next_entry_point if pre_next_entry_point is not None else agent.initial_entry_point)
+    candidate_entry_point, candidate_next_entry_point = env._candidate_entry_points(
+        action=action, agent=agent, pre_current_entry_point=pre_current_entry_point,
+        pre_next_entry_point=pre_next_entry_point, pre_speed=pre_speed, pre_offset=pre_offset,
+        pre_done=pre_done, pre_in_malfunction=in_malfunction, elapsed_steps=env._elapsed_steps + 1,
+        candidate_entry_point_independent=candidate_entry_point_independent,
+    )
+
+    env.step(action_dict)
+
+    resource_check = env.temp_transition_data[agent.handle].resource_check
+    if not resource_check:
+        expected_speed = None if pre_current_entry_point is None else Fraction(0)
+        expected_distance = SpeedCounter.distance_without_crossing(pre_offset, pre_speed)
+    else:
+        expected_distance = env._candidate_distance(
+            pre_speed=pre_speed, pre_offset=pre_offset, pre_done=pre_done,
+            candidate_entry_point=candidate_entry_point, in_malfunction=in_malfunction,
+            candidate_entry_point_independent=candidate_entry_point_independent, agent_targets=agent.targets,
+        )
+        if env.remove_agents_at_target and (pre_done or candidate_entry_point in agent.targets):
+            expected_speed = None
+        elif candidate_entry_point is None:
+            expected_speed = None
+        else:
+            expected_speed = env._candidate_speed(
+                pre_speed=pre_speed, pre_offset=pre_offset, action=action,
+                pre_current_entry_point=pre_current_entry_point, pre_done=pre_done,
+                candidate_entry_point=candidate_entry_point, in_malfunction=in_malfunction,
+                candidate_entry_point_independent=candidate_entry_point_independent,
+                agent_targets=agent.targets, agent_max_speed=agent.speed_counter.max_speed,
+            )
+    assert agent.speed_counter.speed == expected_speed, (agent.speed_counter.speed, expected_speed)
+    assert agent.speed_counter.distance == expected_distance, (agent.speed_counter.distance, expected_distance)
+    return resource_check
+
+
+def test_candidate_speed_and_distance_match_genuine_crossing():
+    """Single MOVING agent on L=(3,8) of make_simple_rail's row-3 corridor, at max_speed=1, halfway
+    across L (distance 0.5) - MOVE_FORWARD completes the crossing into R this step (no other agent to
+    contest it, resource_check trivially granted): the real post-step speed/distance exactly match
+    env._candidate_speed()/env._candidate_distance() computed from the pre-step values captured just
+    before the step.
+    """
+    rail, rail_map, optionals = make_simple_rail()
+    env = RailEnv(width=rail_map.shape[1], height=rail_map.shape[0],
+                  rail_generator=rail_from_grid_transition_map(rail, optionals),
+                  line_generator=sparse_line_generator(), number_of_agents=1, random_seed=1)
+    env.reset()
+    env.acceleration_delta = Fraction(1)
+    agent = env.agents[0]
+    L = ((3, 8), Grid4TransitionsEnum.WEST)
+    agent.current_entry_point = L
+    agent._set_state(TrainState.MOVING)
+    agent.next_entry_point = _sanitize_entry_point(env.rail.apply_action_independent(RailEnvActions.MOVE_FORWARD, L))
+    agent.speed_counter = SpeedCounter(max_speed=Fraction(1), speed=Fraction(1))
+    agent.speed_counter.set(speed=Fraction(1), distance=Fraction(1, 2))
+
+    resource_check = _assert_speed_distance_match_candidates(env, agent, {0: RailEnvActions.MOVE_FORWARD})
+    assert resource_check
+    assert agent.current_entry_point != L  # the crossing genuinely completed
+
+
+def test_candidate_speed_and_distance_match_invalid_action_denial_at_cell_exit():
+    """An invalid STOP_MOVING at a symmetric switch (no straight-through option, see
+    test_symmetric_switch_stop_action) denies the crossing at the cell boundary - the real post-step
+    speed/distance exactly match env._candidate_speed()/env._candidate_distance() computed from the
+    pre-step values captured just before the step: speed forced to 0, distance banked at the boundary,
+    not credited with the (denied) crossing.
+    """
+    env, _, _ = env_generator_legacy(seed=43, n_agents=1)
+    assert env.rail.get_full_transitions(15, 15) == RailEnvTransitionsEnum.symmetric_switch_from_west
+
+    agent = env.agents[0]
+    agent.current_entry_point = ((15, 14), 1)
+    agent._set_state(TrainState.MOVING)
+    agent.next_entry_point = _sanitize_entry_point(
+        env.rail.apply_action_independent(RailEnvActions.MOVE_FORWARD, agent.current_entry_point))
+    agent.speed_counter = SpeedCounter(max_speed=Fraction(1, 2), speed=Fraction(1, 2))
+    agent.speed_counter.set(speed=Fraction(1, 2), distance=Fraction(1))  # banked exactly at the boundary
+
+    resource_check = _assert_speed_distance_match_candidates(env, agent, {agent.handle: RailEnvActions.STOP_MOVING})
+    # denial here is via the invalid action, not a resource conflict - self-loop, trivially granted
+    assert resource_check
+    assert agent.current_entry_point == ((15, 14), 1)  # crossing denied - position unchanged
+    assert agent.speed_counter.speed == Fraction(0)
+    assert agent.speed_counter.distance == Fraction(1)
+
+
+def test_candidate_speed_and_distance_match_resource_check_denial():
+    """Agent A on L=(3,8) of make_simple_rail's row-3 corridor, agent B parked at rest on the
+    neighboring cell R=(3,7) directly ahead of A - A tries to cross into R this step and is denied
+    (resource_check False, B still there): the real post-step speed/distance exactly match the
+    discarded-candidate fallback formulas (speed forced to 0, distance banked at the boundary) computed
+    from the pre-step values captured just before the step.
+    """
+    rail, rail_map, optionals = make_simple_rail()
+    env = RailEnv(width=rail_map.shape[1], height=rail_map.shape[0],
+                  rail_generator=rail_from_grid_transition_map(rail, optionals),
+                  line_generator=sparse_line_generator(), number_of_agents=2, random_seed=1)
+    env.reset()
+    env.acceleration_delta = Fraction(1)
+    agent_a, agent_b = env.agents[0], env.agents[1]
+    L = ((3, 8), Grid4TransitionsEnum.WEST)
+    R = ((3, 7), Grid4TransitionsEnum.WEST)
+
+    agent_a.current_entry_point = L
+    agent_a._set_state(TrainState.MOVING)
+    agent_a.next_entry_point = _sanitize_entry_point(env.rail.apply_action_independent(RailEnvActions.MOVE_FORWARD, L))
+    agent_a.speed_counter = SpeedCounter(max_speed=Fraction(1), speed=Fraction(1))
+    agent_a.speed_counter.set(speed=Fraction(1), distance=Fraction(1, 2))
+
+    agent_b.current_entry_point = R
+    agent_b._set_state(TrainState.STOPPED)
+    agent_b.next_entry_point = _sanitize_entry_point(env.rail.apply_action_independent(RailEnvActions.MOVE_FORWARD, R))
+    agent_b.speed_counter = SpeedCounter(max_speed=Fraction(1), speed=Fraction(0))
+    agent_b.speed_counter.set(speed=Fraction(0), distance=Fraction(1, 2))
+
+    resource_check = _assert_speed_distance_match_candidates(
+        env, agent_a, {0: RailEnvActions.MOVE_FORWARD, 1: RailEnvActions.DO_NOTHING})
+    assert not resource_check
+    assert agent_a.current_entry_point == L  # denied - position unchanged
+    assert agent_a.speed_counter.speed == Fraction(0)
+    assert agent_a.speed_counter.distance == Fraction(1)
+
+
 def test_blocked_agent_cannot_redirect_via_later_action():
     """
     Document a real behavioural consequence of "actions applied at cell entry": once an agent's
@@ -1779,7 +1923,7 @@ def test_agent_cruising_at_constant_speed_banks_distance_to_boundary_then_stops(
     agent_a._set_state(TrainState.MOVING)
     agent_a.next_entry_point = _sanitize_entry_point(env.rail.apply_action_independent(RailEnvActions.MOVE_FORWARD, L))
     agent_a.speed_counter = SpeedCounter(max_speed=speed, speed=speed)
-    agent_a.speed_counter.step(speed=speed, crossing_completed=False)  # bootstrap onto the map at distance 0
+    agent_a.speed_counter.set(speed=speed, distance=Fraction(0))  # bootstrap onto the map at distance 0
     agent_a.speed_counter._distance = Fraction(1, 2)
 
     # place B directly on R, at rest - a stopped, blocking neighbor.
@@ -1787,7 +1931,7 @@ def test_agent_cruising_at_constant_speed_banks_distance_to_boundary_then_stops(
     agent_b._set_state(TrainState.STOPPED)
     agent_b.next_entry_point = _sanitize_entry_point(env.rail.apply_action_independent(RailEnvActions.MOVE_FORWARD, R))
     agent_b.speed_counter = SpeedCounter(max_speed=Fraction(1), speed=Fraction(0))
-    agent_b.speed_counter.step(speed=Fraction(0), crossing_completed=False)
+    agent_b.speed_counter.set(speed=Fraction(0), distance=Fraction(0))
     agent_b.speed_counter._distance = Fraction(1, 2)
 
     for step in range(1, steps_to_boundary):
@@ -1860,7 +2004,7 @@ def test_platoon_of_four_agents_starts_and_advances_together_without_force_stops
         next_transition = env.rail.apply_action_independent(RailEnvActions.MOVE_FORWARD, cell)
         agent.next_entry_point = _sanitize_entry_point(next_transition)
         agent.speed_counter = SpeedCounter(max_speed=Fraction(1, 2), speed=Fraction(0))
-        agent.speed_counter.step(speed=Fraction(0), crossing_completed=False)
+        agent.speed_counter.set(speed=Fraction(0), distance=Fraction(0))
         agent.speed_counter._distance = Fraction(1)
 
     forward = {i: RailEnvActions.MOVE_FORWARD for i in range(4)}
@@ -1951,7 +2095,7 @@ def test_platoon_of_four_agents_starting_mid_cell_moves_in_lockstep_without_forc
         next_transition = env.rail.apply_action_independent(RailEnvActions.MOVE_FORWARD, cell)
         agent.next_entry_point = _sanitize_entry_point(next_transition)
         agent.speed_counter = SpeedCounter(max_speed=Fraction(1, 2), speed=Fraction(0))
-        agent.speed_counter.step(speed=Fraction(0), crossing_completed=False)
+        agent.speed_counter.set(speed=Fraction(0), distance=Fraction(0))
         agent.speed_counter._distance = distance
 
     forward = {i: RailEnvActions.MOVE_FORWARD for i in range(4)}
@@ -2035,7 +2179,7 @@ def test_platoon_all_stop_together_once_leader_stops_and_stays_stopped(
         next_transition = env.rail.apply_action_independent(RailEnvActions.MOVE_FORWARD, cell)
         agent.next_entry_point = _sanitize_entry_point(next_transition)
         agent.speed_counter = SpeedCounter(max_speed=max_speed, speed=max_speed)
-        agent.speed_counter.step(speed=max_speed, crossing_completed=False)  # bootstrap onto the map at distance 0
+        agent.speed_counter.set(speed=max_speed, distance=Fraction(0))  # bootstrap onto the map at distance 0
 
     forward = {i: RailEnvActions.MOVE_FORWARD for i in range(4)}
     hold_leader = {0: RailEnvActions.MOVE_FORWARD, 1: RailEnvActions.MOVE_FORWARD,
@@ -2148,7 +2292,7 @@ def test_two_agents_different_in_cell_distance_converge_to_lockstep(max_speed, s
         next_transition = env.rail.apply_action_independent(RailEnvActions.MOVE_FORWARD, cell)
         agent.next_entry_point = _sanitize_entry_point(next_transition)
         agent.speed_counter = SpeedCounter(max_speed=max_speed, speed=max_speed)
-        agent.speed_counter.step(speed=max_speed, crossing_completed=False)
+        agent.speed_counter.set(speed=max_speed, distance=Fraction(0))
         agent.speed_counter._distance = distance
 
     forward = {0: RailEnvActions.MOVE_FORWARD, 1: RailEnvActions.MOVE_FORWARD}

--- a/tests/test_flatland_envs_rail_env.py
+++ b/tests/test_flatland_envs_rail_env.py
@@ -29,6 +29,7 @@ from flatland.envs.step_utils.states import TrainState
 from flatland.trajectories.policy_runner import PolicyRunner
 from flatland.utils.rendertools import RenderTool
 from flatland.utils.simple_rail import make_simple_rail
+from tests.test_flatland_rail_agent_status import _make_straight_rail, _place_agent_on_map
 from tests.trajectories.test_policy_runner import RandomPolicy
 
 """Tests for `flatland` package."""
@@ -878,6 +879,72 @@ def test_candidate_speed_and_distance_match_resource_check_denial():
     assert agent_a.current_entry_point == L  # denied - position unchanged
     assert agent_a.speed_counter.speed == Fraction(0)
     assert agent_a.speed_counter.distance == Fraction(1)
+
+
+def test_pre_done_candidate_entry_point_independent_is_stale_not_a_live_reservation():
+    """
+    Documents that a removed agent never actually holds its initial cell as a reservation another agent
+    can be blocked by.
+
+    Rail: `_make_straight_rail(3)`'s 3-cell corridor A=(0,0) - B=(0,1) - C=(0,2). Agent 0's target is B;
+    B is also agent 1's own initial cell (agent 1's line runs B -> C).
+
+    - Setup: agent 0 bootstrapped directly onto A, MOVING at max_speed=1 with distance already at the
+      cell boundary (crosses into B in one step). Agent 1 stays off map, READY_TO_DEPART with
+      earliest_departure=0 and initial_entry_point B.
+    - Step 0: both agents contest resource B in the same step - agent 0 crossing A->B, agent 1 departing
+      directly onto B - so agent 0 genuinely occupies B (agent 1's own initial cell) as this step is
+      resolved. MotionCheck's same-target tie-break favors the lower handle: agent 0 wins, reaches its
+      target B, and (remove_agents_at_target) is immediately DONE with current_entry_point already None
+      by the end of this step. Agent 1 loses the conflict - motion_check.stopped names it as blocked,
+      it stays off map, still READY_TO_DEPART, and (collision_factor set > 0 here specifically to make
+      this checkable) draws no collision/invalid-action penalty for the denial.
+    - Step 1: agent 1 retries the identical departure action - granted this time with no denial, even
+      though the pre-step snapshot still computes a transition from agent 0's (now DONE) initial cell A:
+      that lookup is never consulted for a DONE agent's own resource, so it leaves B genuinely free -
+      agent 1 ends up on exactly its own initial cell.
+    """
+    rail, optionals = _make_straight_rail(3)
+    env = RailEnv(width=3, height=1, rail_generator=rail_from_grid_transition_map(rail, optionals),
+                  line_generator=sparse_line_generator(), number_of_agents=2,
+                  obs_builder_object=GlobalObsForRailEnv(),
+                  rewards=BaseDefaultRewards(collision_factor=1.0))
+    env.reset()
+    env._max_episode_steps = 1000
+    _place_agent_on_map(env, 0, (0, 0), Grid4TransitionsEnum.WEST, (0, 1), TrainState.MOVING,
+                        Fraction(1), Fraction(1), RailEnvActions.MOVE_FORWARD)
+    agent0, agent1 = env.agents[0], env.agents[1]
+
+    agent1.initial_entry_point = ((0, 1), Grid4TransitionsEnum.EAST)
+    agent1.targets = {((0, 2), d) for d in Grid4TransitionsEnum}
+    agent1.earliest_departure = 0
+    agent1._set_state(TrainState.READY_TO_DEPART)
+
+    # agent 0 is about to cross into B - agent 1's own initial cell - this very step
+    assert agent0.next_entry_point[0] == agent1.initial_entry_point[0]
+
+    _, rewards_dict, _, _ = env.step({0: RailEnvActions.MOVE_FORWARD, 1: RailEnvActions.MOVE_FORWARD})
+    # agent 0 genuinely occupied B (agent 1's initial cell) while this conflicting step was resolved,
+    # even though it is DONE and removed (current_entry_point back to None) by the time step() returns
+    assert env.temp_transition_data[agent0.handle].candidate_entry_point[0] == agent1.initial_entry_point[0]
+    assert agent0.state == TrainState.DONE
+    assert agent0.current_entry_point is None  # removed - B genuinely free now
+    assert agent1.state == TrainState.READY_TO_DEPART  # denied - lower-handle agent 0 won the conflict
+    assert agent1.current_entry_point is None
+    assert agent1.handle in env.resource_check.stopped  # motion_check itself names agent 1 as blocked
+    assert agent0.handle not in env.resource_check.stopped  # agent 0 was not blocked - it won the conflict
+    # denial by a resource conflict is not penalized as a collision/invalid action for agent 1, despite
+    # collision_factor > 0 - BaseDefaultRewards.step_reward only penalizes a MOVING->STOPPED transition,
+    # and agent 1 never left READY_TO_DEPART
+    assert rewards_dict[agent1.handle][DefaultPenalties.COLLISION.value] == 0
+    assert rewards_dict[agent1.handle][DefaultPenalties.INVALID_ACTION.value] == 0
+
+    env.step({1: RailEnvActions.MOVE_FORWARD})
+    assert agent1.current_entry_point == agent1.initial_entry_point  # entered unhindered, on its own initial cell
+    assert agent1.state == TrainState.MOVING
+    assert agent0.state == TrainState.DONE  # still done - stays terminal
+    assert agent0.current_entry_point is None
+    assert agent0.next_entry_point is None
 
 
 def test_blocked_agent_cannot_redirect_via_later_action():

--- a/tests/test_flatland_malfunction.py
+++ b/tests/test_flatland_malfunction.py
@@ -85,7 +85,7 @@ def test_malfunction_process():
         env_agent.state = TrainState.MOVING
         # design: distance is None when off map -- the agent is placed directly on the map here,
         # bypassing the state machine's own departure step, so bootstrap distance to 0 explicitly.
-        env_agent.speed_counter.step(speed=env_agent.speed_counter.max_speed, crossing_completed=False)
+        env_agent.speed_counter.set(speed=env_agent.speed_counter.max_speed, distance=Fraction(0))
         # design: actions applied at cell entry -- keep the current_entry_point/next_entry_point
         # invariant (both set and different while on-map) even for this direct test-harness setup.
         transition = env.rail.apply_action_independent(RailEnvActions.MOVE_FORWARD, env_agent.current_entry_point)
@@ -490,7 +490,7 @@ def test_stop_moving_crossing_completion_consistent_with_do_nothing():
         agent._set_state(TrainState.MOVING)
         # design: distance is None when off map -- the agent is placed directly on the map here,
         # bypassing the state machine's own departure step, so bootstrap distance to 0 explicitly.
-        agent.speed_counter.step(speed=agent.speed_counter.max_speed, crossing_completed=False)
+        agent.speed_counter.set(speed=agent.speed_counter.max_speed, distance=Fraction(0))
         # design: actions applied at cell entry
         transition = env.rail.apply_action_independent(RailEnvActions.MOVE_FORWARD, agent.current_entry_point)
         assert transition is not None
@@ -530,7 +530,7 @@ def test_stop_moving_wraps_overshoot_beyond_boundary():
     """
     Further consequence of the fix in test_stop_moving_crossing_completion_consistent_with_do_nothing:
     once STOP_MOVING completes an in-flight crossing like any other action, overshoot past the cell
-    boundary is preserved (wrapped via `SpeedCounter._distance_update`'s `distance % SEGMENT_LENGTH`),
+    boundary is preserved (wrapped via `SpeedCounter.distance_after_crossing`'s `distance % SEGMENT_LENGTH`),
     not discarded - `distance + pre_speed` reaching `3/2` lands the agent `1/2` into the new cell, not
     capped at exactly the boundary.
     """
@@ -552,7 +552,7 @@ def test_stop_moving_wraps_overshoot_beyond_boundary():
     agent.speed_counter = SpeedCounter(speed=Fraction(1, 2), max_speed=Fraction(1, 1))
     # design: distance is None when off map -- the agent is placed directly on the map here,
     # bypassing the state machine's own departure step, so bootstrap distance to 0 explicitly.
-    agent.speed_counter.step(speed=agent.speed_counter.speed, crossing_completed=False)
+    agent.speed_counter.set(speed=agent.speed_counter.speed, distance=Fraction(0))
 
     env.step({0: RailEnvActions.MOVE_FORWARD})
     pre_speed = agent.speed_counter.speed
@@ -757,7 +757,7 @@ def test_last_malfunction_step():
         env_agent.state = TrainState.MOVING
         # design: distance is None when off map -- the agent is placed directly on the map here,
         # bypassing the state machine's own departure step, so bootstrap distance to 0 explicitly.
-        env_agent.speed_counter.step(speed=env_agent.speed_counter.max_speed, crossing_completed=False)
+        env_agent.speed_counter.set(speed=env_agent.speed_counter.max_speed, distance=Fraction(0))
         # design: actions applied at cell entry -- keep the current_entry_point/next_entry_point
         # invariant (both set and different while on-map) even for this direct test-harness setup.
         transition = env.rail.apply_action_independent(RailEnvActions.MOVE_FORWARD, env_agent.current_entry_point)

--- a/tests/test_flatland_rail_agent_status.py
+++ b/tests/test_flatland_rail_agent_status.py
@@ -250,11 +250,10 @@ def _make_straight_rail(n_cells: int):
     exercise SpeedCounter.distance_without_crossing's "target reached, remove_agents_at_target=False"
     case via an actual RailEnv rather than by calling the formula directly - this matters because the
     formula alone doesn't explain *why* it applies here: by the time RailEnv.step()'s (10b) runs,
-    agent.state is already DONE (see (10a)'s update_if_reached(), called before (10b)), so the crossing
-    never goes through (10b)'s ordinary `elif agent.state == TrainState.MOVING:` branch (the one that
-    would wrap distance via distance_after_crossing) - it falls through to the DONE-but-not-removed
-    fallback branch instead, which calls speed_counter.step(speed=0, crossing_completed=False),
-    i.e. distance_without_crossing.
+    agent.state is already DONE (see (10a)'s update_if_reached(), called before (10b)), so
+    _candidate_distance's own "pre_done" branch is the one that applies (not its ordinary "genuine
+    crossing" branch, which would wrap distance via distance_after_crossing) - it calls
+    distance_without_crossing directly.
     """
     transitions = RailEnvTransitions()
     cells = transitions.transition_list
@@ -285,7 +284,7 @@ def _place_agent_on_map(env, handle, position, direction, target, state, max_spe
     agent.targets = {(target, d) for d in Grid4TransitionsEnum}
     agent._set_state(state)
     agent.speed_counter = SpeedCounter(max_speed=max_speed, speed=speed)
-    agent.speed_counter.step(speed=speed, crossing_completed=False)  # bootstrap distance to 0 on-map
+    agent.speed_counter.set(speed=speed, distance=Fraction(0))  # bootstrap distance to 0 on-map
     next_entry_point = env.rail.apply_action_independent(first_action, agent.current_entry_point)
     assert next_entry_point is not None
     agent.next_entry_point = _sanitize_entry_point(next_entry_point)

--- a/tests/test_multi_speed.py
+++ b/tests/test_multi_speed.py
@@ -1,3 +1,5 @@
+from fractions import Fraction
+
 import numpy as np
 
 from flatland.core.grid.grid4 import Grid4TransitionsEnum
@@ -93,7 +95,7 @@ def test_multi_speed_init():
         # design: distance is None when off map -- the agent is already on the map here, so mark
         # the fresh speed_counter as having just entered (distance 0), not off-map (None).
         sc = env.agents[i_agent].speed_counter
-        sc.step(speed=sc.speed, crossing_completed=False)
+        sc.set(speed=sc.speed, distance=Fraction(0))
         old_pos.append(_position(env.agents[i_agent]))
         print(_position(env.agents[i_agent]))
     # Run episode

--- a/tests/test_over_under_passes.py
+++ b/tests/test_over_under_passes.py
@@ -1,4 +1,5 @@
 import time
+from fractions import Fraction
 
 from flatland.core.grid.grid4 import Grid4TransitionsEnum
 from flatland.envs.agent_utils import _sanitize_entry_point
@@ -40,7 +41,7 @@ def test_diamond_crossing_without_over_and_underpasses(rendering: bool = False):
     agent_0._set_state(TrainState.MOVING)
     # design: distance is None when off map -- the agent is placed directly on the map here,
     # bypassing the state machine's own departure step, so bootstrap distance to 0 explicitly.
-    agent_0.speed_counter.step(speed=agent_0.speed_counter.max_speed, crossing_completed=False)
+    agent_0.speed_counter.set(speed=agent_0.speed_counter.max_speed, distance=Fraction(0))
     # design: actions applied at cell entry -- keep the current_entry_point/next_entry_point
     # invariant (both set and different while on-map) even for this direct test-harness setup.
     agent_0.next_entry_point = _sanitize_entry_point(env.rail.apply_action_independent(RailEnvActions.MOVE_FORWARD, agent_0.current_entry_point))
@@ -55,7 +56,7 @@ def test_diamond_crossing_without_over_and_underpasses(rendering: bool = False):
     agent_1._set_state(TrainState.MOVING)
     # design: distance is None when off map -- the agent is placed directly on the map here,
     # bypassing the state machine's own departure step, so bootstrap distance to 0 explicitly.
-    agent_1.speed_counter.step(speed=agent_1.speed_counter.max_speed, crossing_completed=False)
+    agent_1.speed_counter.set(speed=agent_1.speed_counter.max_speed, distance=Fraction(0))
     # design: actions applied at cell entry -- keep the current_entry_point/next_entry_point
     # invariant (both set and different while on-map) even for this direct test-harness setup.
     agent_1.next_entry_point = _sanitize_entry_point(env.rail.apply_action_independent(RailEnvActions.MOVE_FORWARD, agent_1.current_entry_point))
@@ -129,7 +130,7 @@ def test_diamond_crossing_with_over_and_underpasses(rendering: bool = False):
     agent_0._set_state(TrainState.MOVING)
     # design: distance is None when off map -- the agent is placed directly on the map here,
     # bypassing the state machine's own departure step, so bootstrap distance to 0 explicitly.
-    agent_0.speed_counter.step(speed=agent_0.speed_counter.max_speed, crossing_completed=False)
+    agent_0.speed_counter.set(speed=agent_0.speed_counter.max_speed, distance=Fraction(0))
     # design: actions applied at cell entry -- keep the current_entry_point/next_entry_point
     # invariant (both set and different while on-map) even for this direct test-harness setup.
     agent_0.next_entry_point = _sanitize_entry_point(env.rail.apply_action_independent(RailEnvActions.MOVE_FORWARD, agent_0.current_entry_point))
@@ -144,7 +145,7 @@ def test_diamond_crossing_with_over_and_underpasses(rendering: bool = False):
     agent_1._set_state(TrainState.MOVING)
     # design: distance is None when off map -- the agent is placed directly on the map here,
     # bypassing the state machine's own departure step, so bootstrap distance to 0 explicitly.
-    agent_1.speed_counter.step(speed=agent_1.speed_counter.max_speed, crossing_completed=False)
+    agent_1.speed_counter.set(speed=agent_1.speed_counter.max_speed, distance=Fraction(0))
     # design: actions applied at cell entry -- keep the current_entry_point/next_entry_point
     # invariant (both set and different while on-map) even for this direct test-harness setup.
     agent_1.next_entry_point = _sanitize_entry_point(env.rail.apply_action_independent(RailEnvActions.MOVE_FORWARD, agent_1.current_entry_point))
@@ -215,7 +216,7 @@ def test_diamond_crossing_with_over_and_underpasses_head_on(rendering: bool = Fa
     agent_0._set_state(TrainState.MOVING)
     # design: distance is None when off map -- the agent is placed directly on the map here,
     # bypassing the state machine's own departure step, so bootstrap distance to 0 explicitly.
-    agent_0.speed_counter.step(speed=agent_0.speed_counter.max_speed, crossing_completed=False)
+    agent_0.speed_counter.set(speed=agent_0.speed_counter.max_speed, distance=Fraction(0))
     # design: actions applied at cell entry -- keep the current_entry_point/next_entry_point
     # invariant (both set and different while on-map) even for this direct test-harness setup.
     agent_0.next_entry_point = _sanitize_entry_point(env.rail.apply_action_independent(RailEnvActions.MOVE_FORWARD, agent_0.current_entry_point))
@@ -230,7 +231,7 @@ def test_diamond_crossing_with_over_and_underpasses_head_on(rendering: bool = Fa
     agent_1._set_state(TrainState.MOVING)
     # design: distance is None when off map -- the agent is placed directly on the map here,
     # bypassing the state machine's own departure step, so bootstrap distance to 0 explicitly.
-    agent_1.speed_counter.step(speed=agent_1.speed_counter.max_speed, crossing_completed=False)
+    agent_1.speed_counter.set(speed=agent_1.speed_counter.max_speed, distance=Fraction(0))
     # design: actions applied at cell entry -- keep the current_entry_point/next_entry_point
     # invariant (both set and different while on-map) even for this direct test-harness setup.
     agent_1.next_entry_point = _sanitize_entry_point(env.rail.apply_action_independent(RailEnvActions.MOVE_FORWARD, agent_1.current_entry_point))

--- a/tests/test_rewards.py
+++ b/tests/test_rewards.py
@@ -408,23 +408,26 @@ def test_energy_efficiency_smoothniss_in_morl():
                      latest_arrival=14,
                      arrival_time=12)
 
-    agent.speed_counter.step(_pseudo_fractional(0), False)
+    # distance is irrelevant to this test (only speed feeds the energy-efficiency-smoothness reward
+    # below) - held at a fixed placeholder throughout rather than tracking set()'s real distance
+    # progression.
+    agent.speed_counter.set(_pseudo_fractional(0), Fraction(0))
     agent.state_machine.set_state(TrainState.WAITING)
     assert rewards.step_reward(agent, agent_transition_data=None, distance_map=None, elapsed_steps=-1) == (0, 0, 0)
 
-    agent.speed_counter.step(_pseudo_fractional(1), False)
+    agent.speed_counter.set(_pseudo_fractional(1), Fraction(0))
     agent.state_machine.set_state(TrainState.MOVING)
     assert rewards.step_reward(agent, agent_transition_data=None, distance_map=None, elapsed_steps=-1) == (0, -1, -1)
 
-    agent.speed_counter.step(_pseudo_fractional(0.6), False)
+    agent.speed_counter.set(_pseudo_fractional(0.6), Fraction(0))
     agent.state_machine.set_state(TrainState.MOVING)
     assert np.allclose(rewards.step_reward(agent, agent_transition_data=None, distance_map=None, elapsed_steps=-1), (0, -0.36, -0.16))
 
-    agent.speed_counter.step(_pseudo_fractional(0.6), False)
+    agent.speed_counter.set(_pseudo_fractional(0.6), Fraction(0))
     agent.state_machine.set_state(TrainState.MALFUNCTION)
     assert np.allclose(rewards.step_reward(agent, agent_transition_data=None, distance_map=None, elapsed_steps=-1), (0, 0, -0.36))
 
-    agent.speed_counter.step(_pseudo_fractional(0.3), False)
+    agent.speed_counter.set(_pseudo_fractional(0.3), Fraction(0))
     agent.state_machine.set_state(TrainState.MOVING)
     assert np.allclose(rewards.step_reward(agent, agent_transition_data=None, distance_map=None, elapsed_steps=-1), (0, -0.09, -0.09))
 

--- a/tests/test_speed_counter.py
+++ b/tests/test_speed_counter.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 
 from flatland.envs.step_utils.speed_counter import SpeedCounter, _pseudo_fractional, _cap_speed, \
-    cached_cell_exit, _cached_cell_exit, _distance_update
+    cached_cell_exit, _cached_cell_exit
 
 
 # design: distance update with pre-step speed.
@@ -18,31 +18,31 @@ def test_step_counter_speed025():
     assert sc.distance is None
     assert np.isclose(float(sc.speed), 0.25)
 
-    sc.step(sc.speed, False)
+    sc.set(sc.speed, Fraction(0))
     assert sc.is_cell_entry == True  # bootstrap onto the map: just entered its first cell
     assert sc.is_cell_exit() == False
     assert sc.distance == 0
     assert np.isclose(float(sc.speed), 0.25)
 
-    sc.step(sc.speed, False)
+    sc.set(sc.speed, Fraction(1, 4))
     assert sc.is_cell_entry == False  # mid-cell advance (0 -> 0.25): still the same cell
     assert sc.is_cell_exit() == False
     assert sc.distance == 0.25
     assert np.isclose(float(sc.speed), 0.25)
 
-    sc.step(sc.speed, False)
+    sc.set(sc.speed, Fraction(1, 2))
     assert sc.is_cell_entry == False  # mid-cell advance (0.25 -> 0.5): still the same cell
     assert sc.is_cell_exit() == False
     assert sc.distance == 0.5
     assert np.isclose(float(sc.speed), 0.25)
 
-    sc.step(sc.speed, False)
+    sc.set(sc.speed, Fraction(3, 4))
     assert sc.is_cell_entry == False  # mid-cell advance (0.5 -> 0.75): still the same cell, now at is_cell_exit()
     assert sc.is_cell_exit() == True
     assert sc.distance == 0.75
     assert np.isclose(float(sc.speed), 0.25)
 
-    sc.step(sc.speed, True)
+    sc.set(sc.speed, Fraction(0))
     assert sc.is_cell_entry == True  # wraps into the next cell (0.75 -> 0): genuine crossing
     assert sc.is_cell_exit() == False
     assert sc.distance == 0
@@ -58,19 +58,19 @@ def test_step_counter_speed05():
     assert sc.distance is None
     assert np.isclose(float(sc.speed), 0.5)
 
-    sc.step(sc.speed, False)
+    sc.set(sc.speed, Fraction(0))
     assert sc.is_cell_entry == True  # bootstrap onto the map: just entered its first cell
     assert sc.is_cell_exit() == False
     assert sc.distance == 0
     assert np.isclose(float(sc.speed), 0.5)
 
-    sc.step(sc.speed, False)
+    sc.set(sc.speed, Fraction(1, 2))
     assert sc.is_cell_entry == False  # mid-cell advance (0 -> 0.5): still the same cell, now at is_cell_exit()
     assert sc.is_cell_exit() == True
     assert sc.distance == 0.5
     assert np.isclose(float(sc.speed), 0.5)
 
-    sc.step(sc.speed, True)
+    sc.set(sc.speed, Fraction(0))
     assert sc.is_cell_entry == True  # wraps into the next cell (0.5 -> 0): genuine crossing
     assert sc.is_cell_exit() == False
     assert sc.distance == 0.0
@@ -86,31 +86,31 @@ def test_step_counter_speed025_05():
     assert sc.distance is None
     assert np.isclose(float(sc.speed), 0.25)
 
-    sc.step(sc.speed, False)
+    sc.set(sc.speed, Fraction(0))
     assert sc.is_cell_entry == True  # bootstrap onto the map: just entered its first cell
     assert sc.is_cell_exit() == False
     assert sc.distance == 0
     assert np.isclose(float(sc.speed), 0.25)
 
-    sc.step(sc.speed, False)
+    sc.set(sc.speed, Fraction(1, 4))
     assert sc.is_cell_entry == False  # mid-cell advance (0 -> 0.25): still the same cell
     assert sc.is_cell_exit() == False
     assert sc.distance == 0.25
     assert np.isclose(float(sc.speed), 0.25)
 
-    sc.step(0.5, False)
+    sc.set(0.5, Fraction(1, 2))
     assert sc.is_cell_entry == False  # mid-cell advance with a new (higher) speed (0.25 -> 0.5): still the same cell
     assert sc.is_cell_exit() == True
     assert sc.distance == 0.5
     assert np.isclose(float(sc.speed), 0.5)
 
-    sc.step(sc.speed, True)
+    sc.set(sc.speed, Fraction(0))
     assert sc.is_cell_entry == True  # wraps into the next cell (0.5 -> 0): genuine crossing
     assert sc.is_cell_exit() == False
     assert sc.distance == 0
     assert np.isclose(float(sc.speed), 0.5)
 
-    sc.step(0.25, False)
+    sc.set(0.25, Fraction(1, 2))
     assert sc.is_cell_entry == False  # mid-cell advance with a new (lower) speed (0 -> 0.5): still the same cell
     assert sc.is_cell_exit() == False
     assert sc.distance == 0.5
@@ -126,37 +126,37 @@ def test_step_counter_speed025_03():
     assert sc.distance is None
     assert np.isclose(float(sc.speed), 0.25)
 
-    sc.step(sc.speed, False)
+    sc.set(sc.speed, Fraction(0))
     assert sc.is_cell_entry == True  # bootstrap onto the map: just entered its first cell
     assert sc.is_cell_exit() == False
     assert sc.distance == 0
     assert np.isclose(float(sc.speed), 0.25)
 
-    sc.step(sc.speed, False)
+    sc.set(sc.speed, Fraction(1, 4))
     assert sc.is_cell_entry == False  # mid-cell advance (0 -> 0.25): still the same cell
     assert sc.is_cell_exit() == False
     assert sc.distance == 0.25
     assert np.isclose(float(sc.speed), 0.25)
 
-    sc.step(Fraction(1, 2), False)
+    sc.set(Fraction(1, 2), Fraction(1, 2))
     assert sc.is_cell_entry == False  # mid-cell advance with a new (capped-to-max_speed) speed (0.25 -> 0.5): still the same cell
     assert sc.is_cell_exit() == False
     assert np.isclose(float(sc.distance), 0.5)
     assert np.isclose(float(sc.speed), 0.3)
 
-    sc.step(sc.speed, False)
+    sc.set(sc.speed, Fraction(4, 5))
     assert sc.is_cell_entry == False  # mid-cell advance (0.5 -> 0.8): still the same cell, now at is_cell_exit()
     assert sc.is_cell_exit() == True
     assert np.isclose(float(sc.distance), 0.8)
     assert np.isclose(float(sc.speed), 0.3)
 
-    sc.step(sc.speed, True)
+    sc.set(sc.speed, Fraction(1, 10))
     assert sc.is_cell_entry == True  # wraps into the next cell (0.8 -> 0.1): genuine crossing
     assert sc.is_cell_exit() == False
     assert np.isclose(float(sc.distance), 0.1)
     assert np.isclose(float(sc.speed), 0.3)
 
-    sc.step(-0.5, False)
+    sc.set(-0.5, Fraction(2, 5))
     # invalidate cell_entry despite speed 0
     assert sc.is_cell_entry == False  # braking to a stop mid-cell (0.1 -> 0.4, capped at speed=0): still the same cell
     assert sc.is_cell_exit() == False
@@ -174,12 +174,12 @@ def test_clone_speed_counter_fractional_speed():
     """Test that a SpeedCounter stays consistent when restored from a pickled state."""
     sc = SpeedCounter(speed=1 / 5, max_speed=1 / 3)
     assert pickle.loads(pickle.dumps(sc)) == sc
-    sc.step(sc.speed, False)
+    sc.set(sc.speed, Fraction(0))
     # design: distance is None when off map
     assert sc.is_cell_entry  # bootstrap onto the map: just entered its first cell
     assert sc.distance == 0
     assert pickle.loads(pickle.dumps(sc)) == sc
-    sc.step(1 / 10, False)
+    sc.set(1 / 10, Fraction(1, 5))
     assert not sc.is_cell_entry  # mid-cell advance (0 -> 0.2): still the same cell
     # design: distance update with pre-step speed.
     assert np.isclose(float(sc.distance), 0.2)
@@ -289,40 +289,13 @@ def test_cached_cell_exit_caps_speed_at_max_speed():
     assert cached_cell_exit(Fraction(3, 10), Fraction(9, 10), Fraction(1, 2)) == False
 
 
-def test_cached_distance_update_crossing_completed_single_wrap():
-    distance, is_cell_entry = _distance_update(Fraction(3, 4), Fraction(1, 2), True)
-    assert distance == Fraction(1, 4)
-    assert is_cell_entry == True
-
-
-def test_cached_distance_update_crossing_completed_multiple_wraps():
-    # exercises modulo - not reachable via normal SpeedCounter.step() usage
-    # (distance is always kept < SEGMENT_LENGTH and speed capped at <= max_speed <= 1 between calls), but
-    # the raw function must still handle it correctly if ever called with an out-of-range starting distance.
-    distance, is_cell_entry = _distance_update(Fraction(3, 2), Fraction(1), True)
-    assert distance == Fraction(1, 2)
-    assert is_cell_entry == True
-
-
-def test_cached_distance_update_crossing_not_completed_under_boundary():
-    distance, is_cell_entry = _distance_update(Fraction(1, 4), Fraction(1, 4), False)
-    assert distance == Fraction(1, 2)
-    assert is_cell_entry == False
-
-
-def test_cached_distance_update_crossing_not_completed_capped_at_boundary():
-    distance, is_cell_entry = _distance_update(Fraction(3, 4), Fraction(1, 2), False)
-    assert distance == Fraction(1, 1)
-    assert is_cell_entry == False
-
-
 def test_step_crossing_not_completed_caps_at_boundary():
     """A MOVING agent whose transition into the next cell is blocked by a resource conflict this step:
     distance must be capped at the cell boundary, not wrapped into the next cell as if it had moved."""
     sc = SpeedCounter(max_speed=0.5, speed=0.5)
-    sc.step(sc.speed, False)  # design: distance is None when off map
-    sc.step(sc.speed, False)  # distance -> 1/2 (from the pre-step speed 1/2); speed stays 1/2 for the next call
-    sc.step(speed=0.5, crossing_completed=False)
+    sc.set(sc.speed, Fraction(0))  # design: distance is None when off map
+    sc.set(sc.speed, Fraction(1, 2))  # distance -> 1/2 (from the pre-step speed 1/2); speed stays 1/2 for the next call
+    sc.set(speed=0.5, distance=Fraction(1, 1))
     assert sc.distance == Fraction(1, 1)
     assert not sc.is_cell_entry  # denied at the boundary (1/2 -> 1, capped): still the same cell, not the next one
     assert sc.speed == Fraction(1, 2)
@@ -330,8 +303,8 @@ def test_step_crossing_not_completed_caps_at_boundary():
 
 def test_step_crossing_not_completed_under_boundary_behaves_like_normal_step():
     sc = SpeedCounter(max_speed=0.25, speed=0.25)
-    sc.step(sc.speed, False)  # design: distance is None when off map
-    sc.step(speed=0.25, crossing_completed=False)
+    sc.set(sc.speed, Fraction(0))  # design: distance is None when off map
+    sc.set(speed=0.25, distance=Fraction(1, 4))
     assert sc.distance == Fraction(1, 4)
     assert not sc.is_cell_entry  # mid-cell advance (0 -> 1/4), nowhere near the boundary: still the same cell
 
@@ -340,56 +313,36 @@ def test_stop_freezes_speed_without_touching_distance():
     """design: distance update with pre-step speed - stop() must leave already-accumulated in-cell
     distance untouched (e.g. a malfunction interrupting a MOVING agent mid-cell)."""
     sc = SpeedCounter(max_speed=0.5, speed=0.5)
-    sc.step(sc.speed, False)  # design: distance is None when off map
-    sc.step(sc.speed, False)  # distance -> 1/2
+    sc.set(sc.speed, Fraction(0))  # design: distance is None when off map
+    sc.set(sc.speed, Fraction(1, 2))  # distance -> 1/2
     sc.stop()
     assert sc.speed == Fraction(0)
     assert sc.distance == Fraction(1, 2)
     assert not sc.is_cell_entry  # force-stopped mid-cell, position frozen in place: still the same cell
 
 
-def test_stop_vs_step_speed_zero_regression():
-    """The pre-fix equivalent step(speed=0) (crossing_completed defaults True) wrongly wraps the same
-    in-cell progress to 0 and flags a false cell entry, since it still runs distance through
-    cached_distance_update using the old (pre-step) speed. This is exactly the bug stop() fixes."""
-    sc = SpeedCounter(max_speed=0.5, speed=0.5)
-    sc.step(sc.speed, False)  # design: distance is None when off map
-    sc.step(sc.speed, False)  # distance -> 1/2
-    sc.step(Fraction(0), True)
-    assert sc.distance == Fraction(0)
-    assert sc.is_cell_entry  # the bug: reports a crossing that never physically happened (this is what stop() avoids)
-
-
-@pytest.mark.xfail(strict=True, reason=(
-    "SpeedCounter.step()'s is_cell_entry is derived as new_distance < speed (not new_distance < old "
-    "distance), which reduces to old_distance < SEGMENT_LENGTH whenever crossing_completed - true except "
-    "at this one boundary: an agent 'banked' with distance exactly == SEGMENT_LENGTH (denied/braked to a "
-    "stop right at the cell boundary) that later resumes and genuinely completes its crossing gets "
-    "new_distance == speed exactly, so is_cell_entry evaluates False even though the agent's cell "
-    "genuinely just changed. Comparing against the OLD distance instead of speed gives the correct True "
-    "here (see the planned SpeedCounter.set() replacement)."
-))
-def test_step_is_cell_entry_wrong_for_genuine_crossing_from_banked_boundary():
+def test_set_is_cell_entry_true_for_genuine_crossing_from_banked_boundary():
     """A MOVING agent bootstraps at speed=1 onto the map, is denied/braked to a stop exactly at the next
     cell boundary (banking distance == SEGMENT_LENGTH), is later promoted back to MOVING while still
     banked (distance unchanged), then genuinely completes its crossing into the next cell. is_cell_entry
-    should report True for that last step - the agent's cell really did just change - but today's formula
-    reports False."""
+    correctly reports True for that last step - set() derives it from old vs. new distance, not from
+    new_distance < speed (the old step()'s formula, which wrongly reported False at exactly this boundary
+    - see Phase 0's xfail test this replaces)."""
     sc = SpeedCounter(max_speed=1.0, speed=1.0)
-    sc.step(sc.speed, False)  # bootstrap onto the map: distance -> 0, speed -> 1
-    sc.step(speed=0, crossing_completed=False)  # denied/braked exactly at the boundary: distance -> 1 (banked), speed -> 0
+    sc.set(sc.speed, Fraction(0))  # bootstrap onto the map: distance -> 0, speed -> 1
+    sc.set(speed=0, distance=Fraction(1))  # denied/braked exactly at the boundary: distance -> 1 (banked), speed -> 0
     assert sc.distance == Fraction(1)
-    sc.step(speed=0.5, crossing_completed=False)  # promoted back to MOVING while still banked: distance stays 1, speed -> 1/2
+    sc.set(speed=0.5, distance=Fraction(1))  # promoted back to MOVING while still banked: distance stays 1, speed -> 1/2
     assert sc.distance == Fraction(1)
-    sc.step(speed=0.5, crossing_completed=True)  # genuine crossing completes from the banked boundary
+    sc.set(speed=0.5, distance=Fraction(1, 2))  # genuine crossing completes from the banked boundary
     assert sc.distance == Fraction(1, 2)
-    assert sc.is_cell_entry  # the train's cell really did just change - today's formula wrongly says False
+    assert sc.is_cell_entry  # the train's cell really did just change
 
 
 def test_reset_clears_distance_speed_and_cell_entry():
     sc = SpeedCounter(speed=0.5, max_speed=1.0)
-    sc.step(sc.speed, False)  # design: distance is None when off map
-    sc.step(sc.speed, False)
+    sc.set(sc.speed, Fraction(0))  # design: distance is None when off map
+    sc.set(sc.speed, Fraction(1, 2))
     assert sc.distance != 0
     assert not sc.is_cell_entry  # mid-cell advance: still the same cell
     sc.reset()
@@ -421,7 +374,7 @@ def test_eq_between_speed_counters_with_different_state():
 
     sc1 = SpeedCounter(max_speed=0.5, speed=0.5)
     sc2 = SpeedCounter(max_speed=0.5, speed=0.5)
-    sc2.step(sc2.speed, False)
+    sc2.set(sc2.speed, Fraction(0))
     assert sc1 != sc2  # differs in distance now
 
 

--- a/tests/test_speed_counter.py
+++ b/tests/test_speed_counter.py
@@ -13,37 +13,37 @@ from flatland.envs.step_utils.speed_counter import SpeedCounter, _pseudo_fractio
 def test_step_counter_speed025():
     sc = SpeedCounter(max_speed=0.25, speed=0.25)
     # design: distance is None when off map
-    assert sc.is_cell_entry == False
+    assert sc.is_cell_entry == False  # off map: no cell entered (yet) at all
     assert sc.is_cell_exit() == True
     assert sc.distance is None
     assert np.isclose(float(sc.speed), 0.25)
 
     sc.step(sc.speed, False)
-    assert sc.is_cell_entry == True
+    assert sc.is_cell_entry == True  # bootstrap onto the map: just entered its first cell
     assert sc.is_cell_exit() == False
     assert sc.distance == 0
     assert np.isclose(float(sc.speed), 0.25)
 
     sc.step(sc.speed, False)
-    assert sc.is_cell_entry == False
+    assert sc.is_cell_entry == False  # mid-cell advance (0 -> 0.25): still the same cell
     assert sc.is_cell_exit() == False
     assert sc.distance == 0.25
     assert np.isclose(float(sc.speed), 0.25)
 
     sc.step(sc.speed, False)
-    assert sc.is_cell_entry == False
+    assert sc.is_cell_entry == False  # mid-cell advance (0.25 -> 0.5): still the same cell
     assert sc.is_cell_exit() == False
     assert sc.distance == 0.5
     assert np.isclose(float(sc.speed), 0.25)
 
     sc.step(sc.speed, False)
-    assert sc.is_cell_entry == False
+    assert sc.is_cell_entry == False  # mid-cell advance (0.5 -> 0.75): still the same cell, now at is_cell_exit()
     assert sc.is_cell_exit() == True
     assert sc.distance == 0.75
     assert np.isclose(float(sc.speed), 0.25)
 
     sc.step(sc.speed, True)
-    assert sc.is_cell_entry == True
+    assert sc.is_cell_entry == True  # wraps into the next cell (0.75 -> 0): genuine crossing
     assert sc.is_cell_exit() == False
     assert sc.distance == 0
     assert np.isclose(float(sc.speed), 0.25)
@@ -53,25 +53,25 @@ def test_step_counter_speed025():
 def test_step_counter_speed05():
     sc = SpeedCounter(max_speed=0.5, speed=0.5)
     # design: distance is None when off map
-    assert sc.is_cell_entry == False
+    assert sc.is_cell_entry == False  # off map: no cell entered (yet) at all
     assert sc.is_cell_exit() == True
     assert sc.distance is None
     assert np.isclose(float(sc.speed), 0.5)
 
     sc.step(sc.speed, False)
-    assert sc.is_cell_entry == True
+    assert sc.is_cell_entry == True  # bootstrap onto the map: just entered its first cell
     assert sc.is_cell_exit() == False
     assert sc.distance == 0
     assert np.isclose(float(sc.speed), 0.5)
 
     sc.step(sc.speed, False)
-    assert sc.is_cell_entry == False
+    assert sc.is_cell_entry == False  # mid-cell advance (0 -> 0.5): still the same cell, now at is_cell_exit()
     assert sc.is_cell_exit() == True
     assert sc.distance == 0.5
     assert np.isclose(float(sc.speed), 0.5)
 
     sc.step(sc.speed, True)
-    assert sc.is_cell_entry == True
+    assert sc.is_cell_entry == True  # wraps into the next cell (0.5 -> 0): genuine crossing
     assert sc.is_cell_exit() == False
     assert sc.distance == 0.0
     assert np.isclose(float(sc.speed), 0.5)
@@ -81,37 +81,37 @@ def test_step_counter_speed05():
 def test_step_counter_speed025_05():
     sc = SpeedCounter(speed=0.25, max_speed=1.0)
     # design: distance is None when off map
-    assert sc.is_cell_entry == False
+    assert sc.is_cell_entry == False  # off map: no cell entered (yet) at all
     assert sc.is_cell_exit() == True
     assert sc.distance is None
     assert np.isclose(float(sc.speed), 0.25)
 
     sc.step(sc.speed, False)
-    assert sc.is_cell_entry == True
+    assert sc.is_cell_entry == True  # bootstrap onto the map: just entered its first cell
     assert sc.is_cell_exit() == False
     assert sc.distance == 0
     assert np.isclose(float(sc.speed), 0.25)
 
     sc.step(sc.speed, False)
-    assert sc.is_cell_entry == False
+    assert sc.is_cell_entry == False  # mid-cell advance (0 -> 0.25): still the same cell
     assert sc.is_cell_exit() == False
     assert sc.distance == 0.25
     assert np.isclose(float(sc.speed), 0.25)
 
     sc.step(0.5, False)
-    assert sc.is_cell_entry == False
+    assert sc.is_cell_entry == False  # mid-cell advance with a new (higher) speed (0.25 -> 0.5): still the same cell
     assert sc.is_cell_exit() == True
     assert sc.distance == 0.5
     assert np.isclose(float(sc.speed), 0.5)
 
     sc.step(sc.speed, True)
-    assert sc.is_cell_entry == True
+    assert sc.is_cell_entry == True  # wraps into the next cell (0.5 -> 0): genuine crossing
     assert sc.is_cell_exit() == False
     assert sc.distance == 0
     assert np.isclose(float(sc.speed), 0.5)
 
     sc.step(0.25, False)
-    assert sc.is_cell_entry == False
+    assert sc.is_cell_entry == False  # mid-cell advance with a new (lower) speed (0 -> 0.5): still the same cell
     assert sc.is_cell_exit() == False
     assert sc.distance == 0.5
     assert np.isclose(float(sc.speed), 0.25)
@@ -121,44 +121,44 @@ def test_step_counter_speed025_05():
 def test_step_counter_speed025_03():
     sc = SpeedCounter(speed=0.25, max_speed=0.3)
     # design: distance is None when off map
-    assert sc.is_cell_entry == False
+    assert sc.is_cell_entry == False  # off map: no cell entered (yet) at all
     assert sc.is_cell_exit() == True
     assert sc.distance is None
     assert np.isclose(float(sc.speed), 0.25)
 
     sc.step(sc.speed, False)
-    assert sc.is_cell_entry == True
+    assert sc.is_cell_entry == True  # bootstrap onto the map: just entered its first cell
     assert sc.is_cell_exit() == False
     assert sc.distance == 0
     assert np.isclose(float(sc.speed), 0.25)
 
     sc.step(sc.speed, False)
-    assert sc.is_cell_entry == False
+    assert sc.is_cell_entry == False  # mid-cell advance (0 -> 0.25): still the same cell
     assert sc.is_cell_exit() == False
     assert sc.distance == 0.25
     assert np.isclose(float(sc.speed), 0.25)
 
     sc.step(Fraction(1, 2), False)
-    assert sc.is_cell_entry == False
+    assert sc.is_cell_entry == False  # mid-cell advance with a new (capped-to-max_speed) speed (0.25 -> 0.5): still the same cell
     assert sc.is_cell_exit() == False
     assert np.isclose(float(sc.distance), 0.5)
     assert np.isclose(float(sc.speed), 0.3)
 
     sc.step(sc.speed, False)
-    assert sc.is_cell_entry == False
+    assert sc.is_cell_entry == False  # mid-cell advance (0.5 -> 0.8): still the same cell, now at is_cell_exit()
     assert sc.is_cell_exit() == True
     assert np.isclose(float(sc.distance), 0.8)
     assert np.isclose(float(sc.speed), 0.3)
 
     sc.step(sc.speed, True)
-    assert sc.is_cell_entry == True
+    assert sc.is_cell_entry == True  # wraps into the next cell (0.8 -> 0.1): genuine crossing
     assert sc.is_cell_exit() == False
     assert np.isclose(float(sc.distance), 0.1)
     assert np.isclose(float(sc.speed), 0.3)
 
     sc.step(-0.5, False)
     # invalidate cell_entry despite speed 0
-    assert sc.is_cell_entry == False
+    assert sc.is_cell_entry == False  # braking to a stop mid-cell (0.1 -> 0.4, capped at speed=0): still the same cell
     assert sc.is_cell_exit() == False
     assert np.isclose(float(sc.distance), 0.4)
     assert np.isclose(float(sc.speed), 0.0)
@@ -176,11 +176,11 @@ def test_clone_speed_counter_fractional_speed():
     assert pickle.loads(pickle.dumps(sc)) == sc
     sc.step(sc.speed, False)
     # design: distance is None when off map
-    assert sc.is_cell_entry
+    assert sc.is_cell_entry  # bootstrap onto the map: just entered its first cell
     assert sc.distance == 0
     assert pickle.loads(pickle.dumps(sc)) == sc
     sc.step(1 / 10, False)
-    assert not sc.is_cell_entry
+    assert not sc.is_cell_entry  # mid-cell advance (0 -> 0.2): still the same cell
     # design: distance update with pre-step speed.
     assert np.isclose(float(sc.distance), 0.2)
     assert pickle.loads(pickle.dumps(sc)) == sc
@@ -324,7 +324,7 @@ def test_step_crossing_not_completed_caps_at_boundary():
     sc.step(sc.speed, False)  # distance -> 1/2 (from the pre-step speed 1/2); speed stays 1/2 for the next call
     sc.step(speed=0.5, crossing_completed=False)
     assert sc.distance == Fraction(1, 1)
-    assert not sc.is_cell_entry
+    assert not sc.is_cell_entry  # denied at the boundary (1/2 -> 1, capped): still the same cell, not the next one
     assert sc.speed == Fraction(1, 2)
 
 
@@ -333,7 +333,7 @@ def test_step_crossing_not_completed_under_boundary_behaves_like_normal_step():
     sc.step(sc.speed, False)  # design: distance is None when off map
     sc.step(speed=0.25, crossing_completed=False)
     assert sc.distance == Fraction(1, 4)
-    assert not sc.is_cell_entry
+    assert not sc.is_cell_entry  # mid-cell advance (0 -> 1/4), nowhere near the boundary: still the same cell
 
 
 def test_stop_freezes_speed_without_touching_distance():
@@ -345,7 +345,7 @@ def test_stop_freezes_speed_without_touching_distance():
     sc.stop()
     assert sc.speed == Fraction(0)
     assert sc.distance == Fraction(1, 2)
-    assert not sc.is_cell_entry
+    assert not sc.is_cell_entry  # force-stopped mid-cell, position frozen in place: still the same cell
 
 
 def test_stop_vs_step_speed_zero_regression():
@@ -357,7 +357,33 @@ def test_stop_vs_step_speed_zero_regression():
     sc.step(sc.speed, False)  # distance -> 1/2
     sc.step(Fraction(0), True)
     assert sc.distance == Fraction(0)
-    assert sc.is_cell_entry
+    assert sc.is_cell_entry  # the bug: reports a crossing that never physically happened (this is what stop() avoids)
+
+
+@pytest.mark.xfail(strict=True, reason=(
+    "SpeedCounter.step()'s is_cell_entry is derived as new_distance < speed (not new_distance < old "
+    "distance), which reduces to old_distance < SEGMENT_LENGTH whenever crossing_completed - true except "
+    "at this one boundary: an agent 'banked' with distance exactly == SEGMENT_LENGTH (denied/braked to a "
+    "stop right at the cell boundary) that later resumes and genuinely completes its crossing gets "
+    "new_distance == speed exactly, so is_cell_entry evaluates False even though the agent's cell "
+    "genuinely just changed. Comparing against the OLD distance instead of speed gives the correct True "
+    "here (see the planned SpeedCounter.set() replacement)."
+))
+def test_step_is_cell_entry_wrong_for_genuine_crossing_from_banked_boundary():
+    """A MOVING agent bootstraps at speed=1 onto the map, is denied/braked to a stop exactly at the next
+    cell boundary (banking distance == SEGMENT_LENGTH), is later promoted back to MOVING while still
+    banked (distance unchanged), then genuinely completes its crossing into the next cell. is_cell_entry
+    should report True for that last step - the agent's cell really did just change - but today's formula
+    reports False."""
+    sc = SpeedCounter(max_speed=1.0, speed=1.0)
+    sc.step(sc.speed, False)  # bootstrap onto the map: distance -> 0, speed -> 1
+    sc.step(speed=0, crossing_completed=False)  # denied/braked exactly at the boundary: distance -> 1 (banked), speed -> 0
+    assert sc.distance == Fraction(1)
+    sc.step(speed=0.5, crossing_completed=False)  # promoted back to MOVING while still banked: distance stays 1, speed -> 1/2
+    assert sc.distance == Fraction(1)
+    sc.step(speed=0.5, crossing_completed=True)  # genuine crossing completes from the banked boundary
+    assert sc.distance == Fraction(1, 2)
+    assert sc.is_cell_entry  # the train's cell really did just change - today's formula wrongly says False
 
 
 def test_reset_clears_distance_speed_and_cell_entry():
@@ -365,12 +391,12 @@ def test_reset_clears_distance_speed_and_cell_entry():
     sc.step(sc.speed, False)  # design: distance is None when off map
     sc.step(sc.speed, False)
     assert sc.distance != 0
-    assert not sc.is_cell_entry
+    assert not sc.is_cell_entry  # mid-cell advance: still the same cell
     sc.reset()
     # design: speed and distance are None when off map - reset() puts the counter back off map
     assert sc.distance is None
     assert sc.speed is None
-    assert not sc.is_cell_entry
+    assert not sc.is_cell_entry  # back off map: no cell entered
     # max_speed is untouched by reset()
     assert sc.max_speed == Fraction(1)
 
@@ -381,7 +407,7 @@ def test_repr_contains_state():
     assert "speed: 1/2" in r
     # design: distance is None when off map
     assert "distance: None" in r
-    assert "is_cell_entry: False" in r
+    assert "is_cell_entry: False" in r  # off map: no cell entered
 
 
 def test_eq_against_non_speed_counter_returns_false():
@@ -426,7 +452,7 @@ def test_setstate_backward_compat_underscore_speed_key():
     assert sc.speed == Fraction(1, 2)
     assert sc.max_speed == Fraction(1, 2)
     assert sc.distance == Fraction(1, 4)
-    assert not sc.is_cell_entry
+    assert not sc.is_cell_entry  # persisted state says: mid-cell, not a fresh cell entry - carried through as-is
 
 
 def test_setstate_backward_compat_counter_key():
@@ -437,14 +463,14 @@ def test_setstate_backward_compat_counter_key():
     assert sc.speed == Fraction(1, 4)
     assert sc.max_speed == Fraction(1, 4)
     assert sc.distance == Fraction(1, 2)
-    assert not sc.is_cell_entry
+    assert not sc.is_cell_entry  # persisted state says: counter=2 cells already traveled, not a fresh entry
 
 
 def test_setstate_backward_compat_counter_key_zero():
     sc = SpeedCounter.__new__(SpeedCounter)
     sc.__setstate__({"speed": Fraction(1, 4), "counter": 0})
     assert sc.distance == Fraction(0)
-    assert sc.is_cell_entry
+    assert sc.is_cell_entry  # persisted state says: counter=0, no cells traveled yet - a fresh entry
 
 
 def test_setstate_missing_is_cell_entry_and_counter_leaves_it_unset():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,5 @@
 """Test Utils."""
+from fractions import Fraction
 from typing import List, Tuple, Optional
 
 import numpy as np
@@ -128,9 +129,9 @@ def run_replay_config(env: RailEnv, test_configs: List[ReplayConfig], rendering:
                     agent._set_state(TrainState.MOVING)
                     # design: distance is None when off map -- this test-harness shortcut places
                     # the agent directly onto the map, bypassing the state machine's own departure
-                    # step (which would otherwise call speed_counter.step() with a non-None speed);
+                    # step (which would otherwise call speed_counter.set() with a non-None speed);
                     # do it explicitly here so distance starts at 0 (on-map) instead of None.
-                    agent.speed_counter.step(speed=agent.speed_counter.speed, crossing_completed=False)
+                    agent.speed_counter.set(speed=agent.speed_counter.speed, distance=Fraction(0))
                     # design: actions applied at cell entry -- keep the current_entry_point/
                     # next_entry_point invariant (both set and different while on-map, see the
                     # invariant documented in RailEnv.step()) even for this test-harness shortcut:


### PR DESCRIPTION
## Changes

### Carried out

| ID | Description | Category | Severity | Commit(s) |
|---|---|---|---|---|
| — | Drop the dead `stop_action_given` map-entry candidate for MALFUNCTION_OFF_MAP - `_handle_malfunction_off_map` only ever promotes to MOVING via `movement_action_given`, so the discarded candidate was optimistic dead weight | refactor | Low | f1daa61d |
| — | Dedupe 3 post-hoc position reads against the collect phase's own `candidate_entry_point`, safe now that map-entry candidates are exactly predictive of the real outcome | refactor | Low | 499c13d7 |
| — | Extract `_candidate_entry_points`, reused by `_check_post_position_invariants` - dedupes the check's own position derivation into a shared method; leaves a shadow verification call commented out, having caught a real divergence in the map-entry branch that still needed fixing | refactor | Medium | 147586f6 |
| — | Fix `_candidate_entry_points`' map_entry branch to a state-free, no-+1 formula derived purely from pre-step values + action + an explicit `elapsed_steps` parameter, closing the last remaining violation of the method's pre-step-only input constraint | fix | Medium | da3e1b74 |
| — | Restore `pre_done` in `_candidate_entry_points`, sourced from `agent.target_entry_point` rather than `self.dones` (which `end_of_episode_update()` force-sets True for every agent once the episode ends, not just the one that reached its own target) | fix | Medium | 6c265c3d |
| — | Make `_candidate_entry_points` return the real target-entry candidate instead of `None, None` when `remove_agents_at_target=True`, moving the "expect None" assertion into `_check_post_position_update_invariants` where the post-removal expectation actually belongs; re-enables the collect-phase-vs-`_candidate_entry_points` verification assertion | refactor | Medium | abc92e7c |
| — | Extract `_candidate_distance`/`_candidate_speed` from the post-step speed/distance check's "candidates accepted" branches, replacing assertions with return statements (same pattern as `_candidate_entry_points`); notes both methods still read live/committed state at their call sites, not yet pre-step-only | refactor | Medium | dee641a3 |
| — | Make `_candidate_distance`/`_candidate_speed` derive from pre-step values only, adding a shared `_action_valid` helper computed from `SpeedCounter.is_cell_exit()`'s real state-independent contract instead of reading committed state at the call site | refactor | Medium | 9a38d722 |
| — | Derive `_candidate_distance`/`_candidate_speed`'s invalid-action check from `candidate_entry_point_independent` directly, dropping the `_action_valid` helper's `is_cell_exit` conflation; compute `candidate_entry_point_independent` once per agent per step in `_capture_pre_step_snapshot` instead of once per caller | refactor | Low | 3d3b4ba1 |
| — | Drop step()'s duplicated inline (3a)/(3b) branches, delegating to `_candidate_speed`/`_candidate_entry_points` directly and removing the now-unnecessary verification assert; requires `_candidate_speed` to never return None (done/target-reached/malfunction/stay-off-map branches now uniformly return `Fraction(0)`) | refactor | Medium | bf7287ac |
| — | Replace step()'s (10a) with `_check_post_position_update_invariants`'s own candidate-acceptance structure, installed as assignments instead of assertions; `handle_done_state()` now takes `candidate_entry_point` explicitly instead of reading it back post-nulling | refactor | Medium | ec51dff2 |
| — | Document `is_cell_entry` semantics and add an `xfail(strict=True)` test reproducing a banked-restart boundary gap in `SpeedCounter.step()`'s formula, ahead of replacing it with `set()` | test | Low | afec03fc |
| — | Drive (10b) SPEED_COUNTER UPDATE from the collect phase's own `candidate_speed`/`candidate_distance` (adding (3c) CANDIDATE DISTANCE), replacing `SpeedCounter.step()` with `set(speed, distance)`; fixes the banked-restart `is_cell_entry` gap documented by the previous commit's xfail test | refactor | High | d92e9d86 |
| — | Split (10b)'s off-map-denied case out as its own no-op branch - `speed_counter` is already `(None, None)` there, so the previous ternary was computing an already-in-place value | refactor | Low | 8799efe7 |
| — | Drop the unused `AgentTransitionData.action_valid` field - never read anywhere; every check goes through `state_transition_signal.action_valid` instead | refactor | Low | e11af124 |
| — | Inline `candidate_entry_point`/`candidate_next_entry_point` in `_candidate_entry_points` instead of precomputing them as separate locals; guard target-reached/on-map-transition checks with `is_on_map` explicitly so the arithmetic conjunct is never evaluated with a None pre_speed/pre_offset; flags a known docstring/code mismatch in `_candidate_distance`'s invalid-action branch with a TODO | refactor | Low | 41c06ec9 |
| — | Add a regression test proving a DONE, removed agent's initial-edge lookup is stale (the resource is genuinely free the very next step, no penalty for a contending agent), dropping the now-disproven "if done, we should not try to reserve the initial edge" TODO | test | Medium | e956d1df |
| — | Gate `_candidate_distance`'s invalid-action branch on `is_cell_exit`, mirroring `_candidate_speed`'s own equivalent gate and matching the method's docstring - clarity/consistency fix, not a behavior change (the formulas already coincide off the cell boundary); resolves the "code is unconditional in invalid action" TODO left by 41c06ec9 | fix | Low | dbdd48dd |

### Remaining

No outstanding follow-up work identified for this PR.

## Related issues

Link to every issue from the issue tracker (if any) you addressed in this PR.

## Checklist

- [ ] Tests are included for relevant behavior changes.
- [ ] Documentation is added in the [flatland-book](https://github.com/flatland-association/flatland-book) repo for relevant behavior changes.
- [ ] If you made important user-facing changes, describe them under the `[Unreleased]` tag in `CHANGELOG.md`.
- [ ] New package dependencies are declared in the `pyproject.toml` file.
  Requirement files have been updated by running `tox -e requirements`.
- [ ] Code works with all supported Python versions (3.10, 3.11, 3.12 and 3.13). Checks run with all supported version and are
  required to run successfully.
- [ ] Code is formatted according to PEP 8 (an IDE like PyCharm can do this for you).
- [ ] Technical guidelines listed in `CONTRIBUTING.md` are followed.